### PR TITLE
Treat all warnings as errors during core tests (?)

### DIFF
--- a/.github/workflows/architecture-tests.yml
+++ b/.github/workflows/architecture-tests.yml
@@ -9,12 +9,9 @@ on:
 jobs:
   tests:
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - architecture-name: gap
-          - architecture-name: soap-bpnn
-          - architecture-name: pet
-          - architecture-name: nanopet
+        architecture-name: [gap, nanopet, soap-bpnn, pet]
 
     runs-on: ubuntu-22.04
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,11 +127,3 @@ exclude = [
 ]
 follow_imports = 'skip'
 ignore_missing_imports = true
-
-[tool.pytest.ini_options]
-# ignore" a bunch of internal warnings with Python 3.13 and PyTorch
-filterwarnings = [
-    "ignore:ast.Str is deprecated and will be removed in Python 3.14:DeprecationWarning",
-    "ignore:Attribute s is deprecated and will be removed in Python 3.14:DeprecationWarning",
-    "ignore:ast.NameConstant is deprecated and will be removed in Python 3.14:DeprecationWarning",
-]

--- a/src/metatrain/pet/tests/test_torchscript.py
+++ b/src/metatrain/pet/tests/test_torchscript.py
@@ -1,6 +1,7 @@
 import copy
 
 import torch
+import pytest
 
 from metatrain.pet import PET as WrappedPET
 from metatrain.pet.modules.hypers import Hypers
@@ -41,6 +42,7 @@ def test_torchscript_save_load(tmpdir):
     raw_pet = PET(ARCHITECTURAL_HYPERS, 0.0, len(model.atomic_types))
     model.set_trained_model(raw_pet)
     torch.jit.script(model)
+
     with tmpdir.as_cwd():
         torch.jit.save(torch.jit.script(model), "pet.pt")
         torch.jit.load("pet.pt")

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -575,6 +575,7 @@ def test_train_issue_290(monkeypatch, tmp_path):
 
     structures = ase.io.read("ethanol_reduced_100.xyz", ":")
     more_structures = structures * 15 + [structures[0]]
+
     ase.io.write("ethanol_1501.xyz", more_structures)
 
     # run training with original options

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -3,6 +3,7 @@ import re
 import sys
 import warnings
 
+import pytest
 from metatensor.torch.atomistic import ModelCapabilities, ModelOutput
 
 from metatrain.utils.logging import MetricLogger, get_cli_input, setup_logging
@@ -20,7 +21,7 @@ def assert_log_entry(logtext: str, loglevel: str, message: str) -> None:
         raise AssertionError(f"{message!r} and {loglevel!r} not found in {logtext!r}")
 
 
-def test_warnings_in_log(caplog):
+def test_warnings_in_log():
     """Test that warnings are forwarded to the logger.
 
     Keep this test at the top since it seems otherwise there are some pytest issues...
@@ -28,9 +29,11 @@ def test_warnings_in_log(caplog):
     logger = logging.getLogger()
 
     with setup_logging(logger):
-        warnings.warn("A warning", stacklevel=1)
+        with pytest.warns(Warning) as record:
+            warnings.warn("A warning", stacklevel=1)
 
-    assert "A warning" in caplog.text
+    assert len(record) == 1
+    assert record[0].message.args[0] == "A warning"
 
 
 def test_default_log(caplog, capsys):

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,14 @@ lint_folders =
     "{toxinidir}/src/" \
     "{toxinidir}/tests/" \
     "{toxinidir}/docs/src/"
+warning_options =
+    -W error
+    -W "ignore:ast.Str is deprecated and will be removed in Python 3.14:DeprecationWarning" \
+    -W "ignore:Attribute s is deprecated and will be removed in Python 3.14:DeprecationWarning" \
+    -W "ignore:ast.NameConstant is deprecated and will be removed in Python 3.14:DeprecationWarning" \
+    -W "ignore:second derivatives with respect to positions are not implemented and will not be accumulated during backward() calls:UserWarning" \
+    -W "ignore:second derivatives with respect to cell matrix are not implemented and will not be accumulated during backward() calls:UserWarning" \
+    -W "UserWarning: The TorchScript type system doesn't support instance-level annotations on empty non-base types in `__init__`. Instead, either 1) use a type annotation in the class body, or 2) wrap the type in `torch.jit.Attribute`." \
 
 [testenv:lint]
 description = Run linters and type checks
@@ -63,6 +71,7 @@ commands =
         --cov-append \
         --cov-report= \
         --import-mode=append \
+        {[testenv]warning_options} \
         {posargs}
 
 [testenv:build]
@@ -91,7 +100,7 @@ deps =
 extras = soap-bpnn
 changedir = src/metatrain/soap_bpnn/tests/
 commands =
-    pytest {posargs}
+    pytest {[testenv]warning_options} {posargs}
 
 [testenv:pet-tests]
 description = Run PET tests with pytest
@@ -103,7 +112,7 @@ changedir = src/metatrain/pet/tests/
 commands =
     python -m pip uninstall -y pet_neighbors_convert
     python -m pip install pet-neighbors-convert --no-build-isolation
-    pytest {posargs}
+    pytest {[testenv]warning_options} {posargs}
 
 [testenv:gap-tests]
 description = Run GAP tests with pytest
@@ -113,7 +122,7 @@ deps =
 extras = gap
 changedir = src/metatrain/gap/tests/
 commands =
-    pytest {posargs}
+    pytest {[testenv]warning_options} {posargs}
 
 [testenv:nanopet-tests]
 description = Run NanoPET tests with pytest
@@ -124,7 +133,7 @@ deps =
 extras = nanopet
 changedir = src/metatrain/experimental/nanopet/tests/
 commands =
-    pytest {posargs}
+    pytest {[testenv]warning_options} {posargs}
 
 [testenv:docs]
 description = builds the documentation with sphinx


### PR DESCRIPTION
This treats all warnings as errors during tests, extracted from #315. I don't think it's a good idea to have this for now because it makes it easier for things to break and it will slow down our development

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--323.org.readthedocs.build/en/323/

<!-- readthedocs-preview metatrain end -->