### PR TITLE
adding command line utilities to metatrain

### DIFF
--- a/src/metatrain/cmd_line_utilities/get_num_neighbors.py
+++ b/src/metatrain/cmd_line_utilities/get_num_neighbors.py
@@ -1,0 +1,41 @@
+import ase.io
+import numpy as np
+from multiprocessing import cpu_count
+from pathos.multiprocessing import ProcessingPool as Pool
+from tqdm import tqdm
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("structures_path", help="Path to an xyz file with structures", type = str)
+parser.add_argument("r_cut", help = "cutoff radius", type = float)
+parser.add_argument("--num_strucs_use", help="Number of random structures to use to estimate statics. If not specified, all the provided structures are used", type = str)
+
+args = parser.parse_args()
+
+structures_path = args.structures_path
+
+structures = ase.io.read(structures_path, index = ':')
+
+if args.num_strucs_use is not None:
+    permutation = np.random.permutation(len(structures))
+    structures = [structures[index] for index in permutation[:args.num_strucs_use]]
+
+atom_nums = [len(struc.positions) for struc in structures]
+total_num = np.sum(atom_nums)
+
+
+p = Pool(cpu_count())
+
+
+def get_n_neighbors(structure):
+    i_list, j_list = ase.neighborlist.neighbor_list('ij', structure, args.r_cut)
+    return len(i_list)
+
+
+num_neighbors = p.map(get_n_neighbors, structures)
+total_neighbors = np.sum(num_neighbors)
+
+average_n_neighbors = total_neighbors / total_num
+
+print(f"average number of neighbors within r_cut = {args.r_cut} is {average_n_neighbors}")
+print("total number of atomic environment used to compute statistics is :", total_num)


### PR DESCRIPTION
There are several things to do or to check when it comes to fitting machine learning potentials regardless of the specific employed model.

The most obvious example is checking how many neighbors are on average for various cutoffs in order to meaningfully select the right one. For one very dense system  (=atoms are small), there might be, hypothetically, hundreds of atoms within a typical r_cut of 4A, which implies that all the models will be slow, some much slower than usual, some less but still unreasonably slow. Thus, the proper r_cut should be smaller. On the other hand, for other sparse systems, there might be, hypothetically, just 5 neighbors inside this cutoff, which implies that it should be increased to get reasonable accuracy regardless of the model to use. Thus, for proper selection of the cutoff, one should check statistics on how many neighbors are on average depending on the r_cut. 

It is a simple task, but it is a waste of time for everybody to always reimplement simple checks like this. Instead, invoking already baked and convenient command line utility would be faster. 

Given that metatrain is a hub of multiple models, it is a natural place for such universal utilities required to fit MLIPs regardless of the employed model. So, I propose to start adding such utilities to metatrain. It would be nice to have some dedicated entry point for these.  

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--330.org.readthedocs.build/en/330/

<!-- readthedocs-preview metatrain end -->