### PR TITLE
Add write permissions to the docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
~DO NOT MERGE, this contains code to test the fix from a PR.~

This should fix pushing the docs to gh-pages

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--334.org.readthedocs.build/en/334/

<!-- readthedocs-preview metatrain end -->