### PR TITLE
Avoid cancellation of other architecture tests if one fails

### DIFF
--- a/.github/workflows/architecture-tests.yml
+++ b/.github/workflows/architecture-tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   tests:
     strategy:
+      fail-fast: false  # prevents cancellation of remaining jobs if one fails
       matrix:
         include:
           - architecture-name: alchemical-model


### PR DESCRIPTION
Prevents all architecture tests from being cancelled if one fails

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--345.org.readthedocs.build/en/345/

<!-- readthedocs-preview metatrain end -->