### PR TITLE
Speed up composition model

### DIFF
--- a/src/metatrain/experimental/alchemical_model/trainer.py
+++ b/src/metatrain/experimental/alchemical_model/trainer.py
@@ -25,7 +25,10 @@ from ...utils.neighbor_lists import (
     get_system_with_neighbor_lists,
 )
 from ...utils.per_atom import average_by_num_atoms
-from ...utils.transfer import systems_and_targets_to_dtype_and_device
+from ...utils.transfer import (
+    systems_and_targets_to_device,
+    systems_and_targets_to_dtype,
+)
 from . import AlchemicalModel
 from .utils.composition import calculate_composition_weights
 from .utils.normalize import (
@@ -94,6 +97,10 @@ class Trainer:
 
         logger.info(f"Training on device {device} with dtype {dtype}")
         model.to(device=device, dtype=dtype)
+        # The additive models of the Alchemical Model are always in float64 (to avoid
+        # numerical errors in the composition weights, which can be very large).
+        for additive_model in model.additive_models:
+            additive_model.to(dtype=torch.float64)
 
         # Calculate and set the composition weights, but only if
         # this is the first training run:
@@ -222,14 +229,14 @@ class Trainer:
                 optimizer.zero_grad()
 
                 systems, targets = batch
-                assert len(systems[0].known_neighbor_lists()) > 0
-                systems, targets = systems_and_targets_to_dtype_and_device(
-                    systems, targets, dtype, device
+                systems, targets = systems_and_targets_to_device(
+                    systems, targets, device
                 )
                 for additive_model in model.additive_models:
                     targets = remove_additive(
                         systems, targets, additive_model, model.dataset_info.targets
                     )
+                systems, targets = systems_and_targets_to_dtype(systems, targets, dtype)
                 predictions = evaluate_model(
                     model,
                     systems,
@@ -261,13 +268,14 @@ class Trainer:
             for batch in val_dataloader:
                 systems, targets = batch
                 assert len(systems[0].known_neighbor_lists()) > 0
-                systems, targets = systems_and_targets_to_dtype_and_device(
-                    systems, targets, dtype, device
+                systems, targets = systems_and_targets_to_device(
+                    systems, targets, device
                 )
                 for additive_model in model.additive_models:
                     targets = remove_additive(
                         systems, targets, additive_model, model.dataset_info.targets
                     )
+                systems, targets = systems_and_targets_to_dtype(systems, targets, dtype)
                 predictions = evaluate_model(
                     model,
                     systems,

--- a/src/metatrain/experimental/soap_bpnn/trainer.py
+++ b/src/metatrain/experimental/soap_bpnn/trainer.py
@@ -23,7 +23,10 @@ from ...utils.neighbor_lists import (
     get_system_with_neighbor_lists,
 )
 from ...utils.per_atom import average_by_num_atoms
-from ...utils.transfer import systems_and_targets_to_dtype_and_device
+from ...utils.transfer import (
+    systems_and_targets_to_device,
+    systems_and_targets_to_dtype,
+)
 from .model import SoapBpnn
 
 
@@ -104,11 +107,10 @@ class Trainer:
 
         # Move the model to the device and dtype:
         model.to(device=device, dtype=dtype)
-        # The additive models of the SOAP-BPNN are always on CPU (to avoid OOM
-        # errors during the linear algebra training) and in float64 (to avoid
+        # The additive models of the SOAP-BPNN are always in float64 (to avoid
         # numerical errors in the composition weights, which can be very large).
         for additive_model in model.additive_models:
-            additive_model.to(device=torch.device("cpu"), dtype=torch.float64)
+            additive_model.to(dtype=torch.float64)
 
         logger.info("Calculating composition weights")
         model.additive_models[0].train_model(  # this is the composition model
@@ -248,13 +250,16 @@ class Trainer:
                 optimizer.zero_grad()
 
                 systems, targets = batch
-                for additive_model in model.additive_models:
+                systems, targets = systems_and_targets_to_device(
+                    systems, targets, device
+                )
+                for additive_model in (
+                    model.module if is_distributed else model
+                ).additive_models:
                     targets = remove_additive(
                         systems, targets, additive_model, train_targets
                     )
-                systems, targets = systems_and_targets_to_dtype_and_device(
-                    systems, targets, dtype, device
-                )
+                systems, targets = systems_and_targets_to_dtype(systems, targets, dtype)
                 predictions = evaluate_model(
                     model,
                     systems,
@@ -289,13 +294,16 @@ class Trainer:
             val_loss = 0.0
             for batch in val_dataloader:
                 systems, targets = batch
-                for additive_model in model.additive_models:
+                systems, targets = systems_and_targets_to_device(
+                    systems, targets, device
+                )
+                for additive_model in (
+                    model.module if is_distributed else model
+                ).additive_models:
                     targets = remove_additive(
                         systems, targets, additive_model, train_targets
                     )
-                systems, targets = systems_and_targets_to_dtype_and_device(
-                    systems, targets, dtype, device
-                )
+                systems, targets = systems_and_targets_to_dtype(systems, targets, dtype)
                 predictions = evaluate_model(
                     model,
                     systems,

--- a/src/metatrain/utils/transfer.py
+++ b/src/metatrain/utils/transfer.py
@@ -6,23 +6,38 @@ from metatensor.torch.atomistic import System
 
 
 @torch.jit.script
-def systems_and_targets_to_dtype_and_device(
+def systems_and_targets_to_device(
     systems: List[System],
     targets: Dict[str, TensorMap],
-    dtype: torch.dtype,
     device: torch.device,
 ):
     """
-    Transfers the systems and targets to the specified dtype and device.
+    Transfers the systems and targets to the specified device.
 
     :param systems: List of systems.
     :param targets: Dictionary of targets.
-    :param dtype: Desired data type.
     :param device: Device to transfer to.
     """
 
-    systems = [system.to(dtype=dtype, device=device) for system in systems]
-    targets = {
-        key: value.to(dtype=dtype, device=device) for key, value in targets.items()
-    }
+    systems = [system.to(device=device) for system in systems]
+    targets = {key: value.to(device=device) for key, value in targets.items()}
+    return systems, targets
+
+
+@torch.jit.script
+def systems_and_targets_to_dtype(
+    systems: List[System],
+    targets: Dict[str, TensorMap],
+    dtype: torch.dtype,
+):
+    """
+    Changes the systems and targets to the specified floating point data type.
+
+    :param systems: List of systems.
+    :param targets: Dictionary of targets.
+    :param dtype: Desired floating point data type.
+    """
+
+    systems = [system.to(dtype=dtype) for system in systems]
+    targets = {key: value.to(dtype=dtype) for key, value in targets.items()}
     return systems, targets

--- a/tests/utils/test_transfer.py
+++ b/tests/utils/test_transfer.py
@@ -3,7 +3,35 @@ import torch
 from metatensor.torch import Labels, TensorMap
 from metatensor.torch.atomistic import System
 
-from metatrain.utils.transfer import systems_and_targets_to_dtype_and_device
+from metatrain.utils.transfer import (
+    systems_and_targets_to_device,
+    systems_and_targets_to_dtype,
+)
+
+
+def test_systems_and_targets_to_dtype():
+    system = System(
+        positions=torch.tensor([[1.0, 1.0, 1.0]]),
+        cell=torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]),
+        types=torch.tensor([1]),
+    )
+    targets = TensorMap(
+        keys=Labels.single(),
+        blocks=[metatensor.torch.block_from_array(torch.tensor([[1.0]]))],
+    )
+
+    systems = [system]
+    targets = {"energy": targets}
+
+    assert systems[0].positions.dtype == torch.float32
+    assert systems[0].cell.dtype == torch.float32
+    assert targets["energy"].block().values.dtype == torch.float32
+
+    systems, targets = systems_and_targets_to_dtype(systems, targets, torch.float64)
+
+    assert systems[0].positions.dtype == torch.float64
+    assert systems[0].cell.dtype == torch.float64
+    assert targets["energy"].block().values.dtype == torch.float64
 
 
 def test_systems_and_targets_to_dtype_and_device():
@@ -20,20 +48,14 @@ def test_systems_and_targets_to_dtype_and_device():
     systems = [system]
     targets = {"energy": targets}
 
-    assert systems[0].positions.dtype == torch.float32
     assert systems[0].positions.device == torch.device("cpu")
-    assert systems[0].cell.dtype == torch.float32
     assert systems[0].types.device == torch.device("cpu")
-    assert targets["energy"].block().values.dtype == torch.float32
     assert targets["energy"].block().values.device == torch.device("cpu")
 
-    systems, targets = systems_and_targets_to_dtype_and_device(
-        systems, targets, torch.float64, torch.device("meta")
+    systems, targets = systems_and_targets_to_device(
+        systems, targets, torch.device("meta")
     )
 
-    assert systems[0].positions.dtype == torch.float64
     assert systems[0].positions.device == torch.device("meta")
-    assert systems[0].cell.dtype == torch.float64
     assert systems[0].types.device == torch.device("meta")
-    assert targets["energy"].block().values.dtype == torch.float64
     assert targets["energy"].block().values.device == torch.device("meta")


### PR DESCRIPTION
This PR implements more vectorization of the composition model, speeding it up roughly by a factor of 4.

In addition, this PR moves the evaluation of the composition model to the GPU (but still in float64). This also helps a bit with speed, but the main reason is that `DistributedDataParallel`, which we use for multi-GPU training, really doesn't like that part of a model can be on CPU

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--358.org.readthedocs.build/en/358/

<!-- readthedocs-preview metatrain end -->