### PR TITLE
Add more loss types and options

### DIFF
--- a/docs/src/architectures/alchemical-model.rst
+++ b/docs/src/architectures/alchemical-model.rst
@@ -61,16 +61,17 @@ hyperparameters to tune are (in decreasing order of importance):
   especially on larger datasets, at the cost of increased training and evaluation time.
 - ``loss``: This section describes the loss function to be used, and it has three
   subsections. 1. ``weights``. This controls the weighting of different contributions
-  to the loss (e.g., energy, forces, virial, etc.). The default values work well for
-  most datasets, but they might need to be adjusted. For example, to set a weight of
-  1.0 for the energy and 0.1 for the forces, you can set the following in the
-  ``options.yaml`` file under ``loss``: ``weights: {"energy": 1.0, "forces": 0.1}``. 2.
-  ``type``. This controls the type of loss to be used. The default value is ``mse``,
-  and other options are ``mae`` and ``huber``. ``huber`` is a subsection of its own,
-  and it requires the user to specify the ``deltas`` parameters in a similar way to how
-  the ``weights`` are specified (e.g., ``deltas: {"energy": 0.1, "forces": 0.01}``). 3.
-  ``reduction``. This controls how the loss is reduced over batches. The default value
-  is ``sum``, and the other allowed option is ``mean``.
+  to the loss (e.g., energy, forces, virial, etc.). The default values of 1.0 for all
+  targets work well for most datasets, but they might need to be adjusted. For example,
+  to set a weight of 1.0 for the energy and 0.1 for the forces, you can set the
+  following in the ``options.yaml`` file under ``loss``:
+  ``weights: {"energy": 1.0, "forces": 0.1}``. 2. ``type``. This controls the type of
+  loss to be used. The default value is ``mse``, and other options are ``mae`` and
+  ``huber``. ``huber`` is a subsection of its own, and it requires the user to specify
+  the ``deltas`` parameters in a similar way to how the ``weights`` are specified (e.g.,
+  ``deltas: {"energy": 0.1, "forces": 0.01}``). 3. ``reduction``. This controls how the
+  loss is reduced over batches. The default value is ``sum``, and the other allowed
+  option is ``mean``.
 
 
 Architecture Hyperparameters

--- a/docs/src/architectures/alchemical-model.rst
+++ b/docs/src/architectures/alchemical-model.rst
@@ -59,11 +59,18 @@ hyperparameters to tune are (in decreasing order of importance):
   This hyperparameter controls the size and depth of the descriptors and the neural
   network. In general, increasing this might lead to better accuracy,
   especially on larger datasets, at the cost of increased training and evaluation time.
-- ``loss_weights``: This controls the weighting of different contributions to the loss
-  (e.g., energy, forces, virial, etc.). The default values work well for most datasets,
-  but they might need to be adjusted. For example, to set a weight of 1.0 for the energy
-  and 0.1 for the forces, you can set the following in the ``options.yaml`` file:
-  ``loss_weights: {"energy": 1.0, "forces": 0.1}``.
+- ``loss``: This section describes the loss function to be used, and it has three
+  subsections. 1. ``weights``. This controls the weighting of different contributions
+  to the loss (e.g., energy, forces, virial, etc.). The default values work well for
+  most datasets, but they might need to be adjusted. For example, to set a weight of
+  1.0 for the energy and 0.1 for the forces, you can set the following in the
+  ``options.yaml`` file under ``loss``: ``weights: {"energy": 1.0, "forces": 0.1}``. 2.
+  ``type``. This controls the type of loss to be used. The default value is ``mse``,
+  and other options are ``mae`` and ``huber``. ``huber`` is a subsection of its own,
+  and it requires the user to specify the ``deltas`` parameters in a similar way to how
+  the ``weights`` are specified (e.g., ``deltas: {"energy": 0.1, "forces": 0.01}``). 3.
+  ``reduction``. This controls how the loss is reduced over batches. The default value
+  is ``sum``, and the other allowed option is ``mean``.
 
 
 Architecture Hyperparameters

--- a/docs/src/architectures/soap-bpnn.rst
+++ b/docs/src/architectures/soap-bpnn.rst
@@ -55,14 +55,21 @@ hyperparameters to tune are (in decreasing order of importance):
 - ``radial_scaling`` hyperparameters: These hyperparameters control the radial scaling
   of the SOAP descriptor. In general, the default values should work well, but they
   might need to be adjusted for specific datasets.
-- ``loss_weights``: This controls the weighting of different contributions to the loss
-  (e.g., energy, forces, virial, etc.). The default values work well for most datasets,
-  but they might need to be adjusted. For example, to set a weight of 1.0 for the energy
-  and 0.1 for the forces, you can set the following in the ``options.yaml`` file:
-  ``loss_weights: {"energy": 1.0, "forces": 0.1}``.
 - ``layernorm``: Whether to use layer normalization before the neural network. Setting
   this hyperparameter to ``false`` will lead to slower convergence of training, but
   might lead to better generalization outside of the training set distribution.
+- ``loss``: This section describes the loss function to be used, and it has three
+  subsections. 1. ``weights``. This controls the weighting of different contributions
+  to the loss (e.g., energy, forces, virial, etc.). The default values work well for
+  most datasets, but they might need to be adjusted. For example, to set a weight of
+  1.0 for the energy and 0.1 for the forces, you can set the following in the
+  ``options.yaml`` file under ``loss``: ``weights: {"energy": 1.0, "forces": 0.1}``. 2.
+  ``type``. This controls the type of loss to be used. The default value is ``mse``,
+  and other options are ``mae`` and ``huber``. ``huber`` is a subsection of its own,
+  and it requires the user to specify the ``deltas`` parameters in a similar way to how
+  the ``weights`` are specified (e.g., ``deltas: {"energy": 0.1, "forces": 0.01}``). 3.
+  ``reduction``. This controls how the loss is reduced over batches. The default value
+  is ``sum``, and the other allowed option is ``mean``.
 
 
 All Hyperparameters

--- a/docs/src/architectures/soap-bpnn.rst
+++ b/docs/src/architectures/soap-bpnn.rst
@@ -60,16 +60,17 @@ hyperparameters to tune are (in decreasing order of importance):
   might lead to better generalization outside of the training set distribution.
 - ``loss``: This section describes the loss function to be used, and it has three
   subsections. 1. ``weights``. This controls the weighting of different contributions
-  to the loss (e.g., energy, forces, virial, etc.). The default values work well for
-  most datasets, but they might need to be adjusted. For example, to set a weight of
-  1.0 for the energy and 0.1 for the forces, you can set the following in the
-  ``options.yaml`` file under ``loss``: ``weights: {"energy": 1.0, "forces": 0.1}``. 2.
-  ``type``. This controls the type of loss to be used. The default value is ``mse``,
-  and other options are ``mae`` and ``huber``. ``huber`` is a subsection of its own,
-  and it requires the user to specify the ``deltas`` parameters in a similar way to how
-  the ``weights`` are specified (e.g., ``deltas: {"energy": 0.1, "forces": 0.01}``). 3.
-  ``reduction``. This controls how the loss is reduced over batches. The default value
-  is ``sum``, and the other allowed option is ``mean``.
+  to the loss (e.g., energy, forces, virial, etc.). The default values of 1.0 for all
+  targets work well for most datasets, but they might need to be adjusted. For example,
+  to set a weight of 1.0 for the energy and 0.1 for the forces, you can set the
+  following in the ``options.yaml`` file under ``loss``:
+  ``weights: {"energy": 1.0, "forces": 0.1}``. 2. ``type``. This controls the type of
+  loss to be used. The default value is ``mse``, and other options are ``mae`` and
+  ``huber``. ``huber`` is a subsection of its own, and it requires the user to specify
+  the ``deltas`` parameters in a similar way to how the ``weights`` are specified (e.g.,
+  ``deltas: {"energy": 0.1, "forces": 0.01}``). 3. ``reduction``. This controls how the
+  loss is reduced over batches. The default value is ``sum``, and the other allowed
+  option is ``mean``.
 
 
 All Hyperparameters

--- a/src/metatrain/experimental/alchemical_model/default-hypers.yaml
+++ b/src/metatrain/experimental/alchemical_model/default-hypers.yaml
@@ -26,5 +26,8 @@ architecture:
     log_interval: 5
     checkpoint_interval: 25
     per_structure_targets: []
-    loss_weights: {}
     log_mae: False
+    loss:
+      weights: {}
+      type: mse
+      reduction: sum

--- a/src/metatrain/experimental/alchemical_model/default-hypers.yaml
+++ b/src/metatrain/experimental/alchemical_model/default-hypers.yaml
@@ -28,6 +28,6 @@ architecture:
     per_structure_targets: []
     log_mae: False
     loss:
-      weights: {}
       type: mse
+      weights: {}
       reduction: sum

--- a/src/metatrain/experimental/alchemical_model/schema-hypers.json
+++ b/src/metatrain/experimental/alchemical_model/schema-hypers.json
@@ -93,17 +93,57 @@
             "type": "string"
           }
         },
-        "loss_weights": {
+        "log_mae": {
+          "type": "boolean"
+        },
+        "loss": {
           "type": "object",
-          "patternProperties": {
-            ".*": {
-              "type": "number"
+          "properties": {
+            "weights": {
+              "type": "object",
+              "patternProperties": {
+                ".*": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false
+            },
+            "reduction": {
+              "type": "string",
+              "enum": ["sum", "mean", "none"]
+            },
+            "type": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": ["mse", "mae"]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "huber": {
+                      "type": "object",
+                      "properties": {
+                        "deltas": {
+                          "type": "object",
+                          "patternProperties": {
+                            ".*": {
+                              "type": "number"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": ["deltas"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
             }
           },
           "additionalProperties": false
-        },
-        "log_mae": {
-          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/src/metatrain/experimental/alchemical_model/trainer.py
+++ b/src/metatrain/experimental/alchemical_model/trainer.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 from pathlib import Path
 from typing import List, Union
@@ -186,13 +187,14 @@ class Trainer:
             to_external_name(key, model.outputs): value
             for key, value in loss_weights_dict.items()
         }
+        # Update the loss weights in the hypers:
+        loss_hypers = copy.deepcopy(self.hypers["loss"])
+        loss_hypers["weights"] = loss_weights_dict
         logging.info(f"Training with loss weights: {loss_weights_dict_external}")
 
         # Create a loss function:
         loss_fn = TensorMapDictLoss(
-            loss_weights_dict,
-            reduction=self.hypers["loss"]["reduction"],
-            type=self.hypers["loss"]["type"],
+            **loss_hypers,
         )
 
         # Create an optimizer:

--- a/src/metatrain/experimental/alchemical_model/trainer.py
+++ b/src/metatrain/experimental/alchemical_model/trainer.py
@@ -175,11 +175,11 @@ class Trainer:
         loss_weights_dict = {}
         for output_name in outputs_list:
             loss_weights_dict[output_name] = (
-                self.hypers["loss_weights"][
+                self.hypers["loss"]["weights"][
                     to_external_name(output_name, model.outputs)
                 ]
                 if to_external_name(output_name, model.outputs)
-                in self.hypers["loss_weights"]
+                in self.hypers["loss"]["weights"]
                 else 1.0
             )
         loss_weights_dict_external = {
@@ -189,7 +189,11 @@ class Trainer:
         logging.info(f"Training with loss weights: {loss_weights_dict_external}")
 
         # Create a loss function:
-        loss_fn = TensorMapDictLoss(loss_weights_dict)
+        loss_fn = TensorMapDictLoss(
+            loss_weights_dict,
+            reduction=self.hypers["loss"]["reduction"],
+            type=self.hypers["loss"]["type"],
+        )
 
         # Create an optimizer:
         optimizer = torch.optim.Adam(

--- a/src/metatrain/experimental/soap_bpnn/default-hypers.yaml
+++ b/src/metatrain/experimental/soap_bpnn/default-hypers.yaml
@@ -35,6 +35,8 @@ architecture:
     checkpoint_interval: 25
     fixed_composition_weights: {}
     per_structure_targets: []
-    loss_type: mse
-    loss_weights: {}
     log_mae: False
+    loss:
+      weights: {}
+      type: mse
+      reduction: sum

--- a/src/metatrain/experimental/soap_bpnn/default-hypers.yaml
+++ b/src/metatrain/experimental/soap_bpnn/default-hypers.yaml
@@ -37,6 +37,6 @@ architecture:
     per_structure_targets: []
     log_mae: False
     loss:
-      weights: {}
       type: mse
+      weights: {}
       reduction: sum

--- a/src/metatrain/experimental/soap_bpnn/default-hypers.yaml
+++ b/src/metatrain/experimental/soap_bpnn/default-hypers.yaml
@@ -35,5 +35,6 @@ architecture:
     checkpoint_interval: 25
     fixed_composition_weights: {}
     per_structure_targets: []
+    loss_type: mse
     loss_weights: {}
     log_mae: False

--- a/src/metatrain/experimental/soap_bpnn/schema-hypers.json
+++ b/src/metatrain/experimental/soap_bpnn/schema-hypers.json
@@ -141,20 +141,57 @@
             "type": "string"
           }
         },
-        "loss_type": {
-          "type": "string"
+        "log_mae": {
+          "type": "boolean"
         },
-        "loss_weights": {
+        "loss": {
           "type": "object",
-          "patternProperties": {
-            ".*": {
-              "type": "number"
+          "properties": {
+            "weights": {
+              "type": "object",
+              "patternProperties": {
+                ".*": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false
+            },
+            "reduction": {
+              "type": "string",
+              "enum": ["sum", "mean", "none"]
+            },
+            "type": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": ["mse", "mae"]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "huber": {
+                      "type": "object",
+                      "properties": {
+                        "deltas": {
+                          "type": "object",
+                          "patternProperties": {
+                            ".*": {
+                              "type": "number"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": ["deltas"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
             }
           },
           "additionalProperties": false
-        },
-        "log_mae": {
-          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/src/metatrain/experimental/soap_bpnn/schema-hypers.json
+++ b/src/metatrain/experimental/soap_bpnn/schema-hypers.json
@@ -141,6 +141,9 @@
             "type": "string"
           }
         },
+        "loss_type": {
+          "type": "string"
+        },
         "loss_weights": {
           "type": "object",
           "patternProperties": {

--- a/src/metatrain/experimental/soap_bpnn/trainer.py
+++ b/src/metatrain/experimental/soap_bpnn/trainer.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import warnings
 from pathlib import Path
@@ -202,13 +203,13 @@ class Trainer:
             to_external_name(key, train_targets): value
             for key, value in loss_weights_dict.items()
         }
+        loss_hypers = copy.deepcopy(self.hypers["loss"])
+        loss_hypers["weights"] = loss_weights_dict
         logging.info(f"Training with loss weights: {loss_weights_dict_external}")
 
         # Create a loss function:
         loss_fn = TensorMapDictLoss(
-            loss_weights_dict,
-            reduction=self.hypers["loss"]["reduction"],
-            type=self.hypers["loss"]["type"],
+            **loss_hypers,
         )
 
         # Create an optimizer:

--- a/src/metatrain/experimental/soap_bpnn/trainer.py
+++ b/src/metatrain/experimental/soap_bpnn/trainer.py
@@ -191,11 +191,11 @@ class Trainer:
         loss_weights_dict = {}
         for output_name in outputs_list:
             loss_weights_dict[output_name] = (
-                self.hypers["loss_weights"][
+                self.hypers["loss"]["weights"][
                     to_external_name(output_name, train_targets)
                 ]
                 if to_external_name(output_name, train_targets)
-                in self.hypers["loss_weights"]
+                in self.hypers["loss"]["weights"]
                 else 1.0
             )
         loss_weights_dict_external = {
@@ -205,7 +205,11 @@ class Trainer:
         logging.info(f"Training with loss weights: {loss_weights_dict_external}")
 
         # Create a loss function:
-        loss_fn = TensorMapDictLoss(loss_weights_dict, type=self.hypers["loss_type"])
+        loss_fn = TensorMapDictLoss(
+            loss_weights_dict,
+            reduction=self.hypers["loss"]["reduction"],
+            type=self.hypers["loss"]["type"],
+        )
 
         # Create an optimizer:
         optimizer = torch.optim.Adam(

--- a/src/metatrain/experimental/soap_bpnn/trainer.py
+++ b/src/metatrain/experimental/soap_bpnn/trainer.py
@@ -205,7 +205,7 @@ class Trainer:
         logging.info(f"Training with loss weights: {loss_weights_dict_external}")
 
         # Create a loss function:
-        loss_fn = TensorMapDictLoss(loss_weights_dict)
+        loss_fn = TensorMapDictLoss(loss_weights_dict, type=self.hypers["loss_type"])
 
         # Create an optimizer:
         optimizer = torch.optim.Adam(

--- a/src/metatrain/utils/loss.py
+++ b/src/metatrain/utils/loss.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, Union
 
 import torch
 from metatensor.torch import TensorMap
@@ -30,8 +30,14 @@ class TensorMapLoss:
         reduction: str = "sum",
         weight: float = 1.0,
         gradient_weights: Optional[Dict[str, float]] = None,
+        type: Union[str, dict] = "mse",
     ):
-        self.loss = torch.nn.MSELoss(reduction=reduction)
+        if type == "mse":
+            self.loss = torch.nn.MSELoss(reduction=reduction)
+        elif type == "mae":
+            self.loss = torch.nn.L1Loss(reduction=reduction)
+        else:
+            raise ValueError(f"Unknown loss type: {type}")
         self.weight = weight
         self.gradient_weights = {} if gradient_weights is None else gradient_weights
 
@@ -129,6 +135,7 @@ class TensorMapDictLoss:
         self,
         weights: Dict[str, float],
         reduction: str = "sum",
+        type: Union[str, dict] = "mse",
     ):
         outputs = [key for key in weights.keys() if "gradients" not in key]
         self.losses = {}
@@ -145,6 +152,7 @@ class TensorMapDictLoss:
                 reduction=reduction,
                 weight=value_weight,
                 gradient_weights=gradient_weights,
+                type=type,
             )
 
     def __call__(

--- a/src/metatrain/utils/loss.py
+++ b/src/metatrain/utils/loss.py
@@ -2,6 +2,9 @@ from typing import Dict, Optional, Tuple, Union
 
 import torch
 from metatensor.torch import TensorMap
+from omegaconf import DictConfig
+
+from metatrain.utils.external_naming import to_internal_name
 
 
 # This file defines losses for metatensor models.
@@ -32,14 +35,32 @@ class TensorMapLoss:
         gradient_weights: Optional[Dict[str, float]] = None,
         type: Union[str, dict] = "mse",
     ):
+        if gradient_weights is None:
+            gradient_weights = {}
+
+        losses = {}
         if type == "mse":
-            self.loss = torch.nn.MSELoss(reduction=reduction)
+            losses["values"] = torch.nn.MSELoss(reduction=reduction)
+            for key in gradient_weights.keys():
+                losses[key] = torch.nn.MSELoss(reduction=reduction)
         elif type == "mae":
-            self.loss = torch.nn.L1Loss(reduction=reduction)
+            losses["values"] = torch.nn.L1Loss(reduction=reduction)
+            for key in gradient_weights.keys():
+                losses[key] = torch.nn.L1Loss(reduction=reduction)
+        elif isinstance(type, dict) and "huber" in type:
+            # Huber loss
+            deltas = type["huber"]["deltas"]
+            losses["values"] = torch.nn.HuberLoss(
+                reduction=reduction, delta=deltas["values"]
+            )
+            for key in gradient_weights.keys():
+                losses[key] = torch.nn.HuberLoss(reduction=reduction, delta=deltas[key])
         else:
             raise ValueError(f"Unknown loss type: {type}")
+
+        self.losses = losses
         self.weight = weight
-        self.gradient_weights = {} if gradient_weights is None else gradient_weights
+        self.gradient_weights = gradient_weights
 
     def __call__(
         self, tensor_map_1: TensorMap, tensor_map_2: TensorMap
@@ -103,12 +124,12 @@ class TensorMapLoss:
 
         values_1 = tensor_map_1.block().values
         values_2 = tensor_map_2.block().values
-        loss += self.weight * self.loss(values_1, values_2)
+        loss += self.weight * self.losses["values"](values_1, values_2)
 
         for gradient_name, gradient_weight in self.gradient_weights.items():
             values_1 = tensor_map_1.block().gradient(gradient_name).values
             values_2 = tensor_map_2.block().gradient(gradient_name).values
-            loss += gradient_weight * self.loss(values_1, values_2)
+            loss += gradient_weight * self.losses[gradient_name](values_1, values_2)
 
         return loss
 
@@ -148,11 +169,12 @@ class TensorMapDictLoss:
                         "_gradients", ""
                     )
                     gradient_weights[gradient_name] = weight
+            type_output = _process_type(type, output)
             self.losses[output] = TensorMapLoss(
                 reduction=reduction,
                 weight=value_weight,
                 gradient_weights=gradient_weights,
-                type=type,
+                type=type_output,
             )
 
     def __call__(
@@ -175,3 +197,27 @@ class TensorMapDictLoss:
             loss += target_loss
 
         return loss
+
+
+def _process_type(type: Union[str, DictConfig], output: str) -> Union[str, dict]:
+    if not isinstance(type, str):
+        assert "huber" in type
+        # we process the Huber loss delta dict to make it similar to the
+        # `weights` dict
+        type_output = {"huber": {"deltas": {}}}  # type: ignore
+        for key, delta in type["huber"]["deltas"].items():
+            key_internal = to_internal_name(key)
+            if key_internal == output:
+                type_output["huber"]["deltas"]["values"] = delta
+            elif key_internal.startswith(output) and key_internal.endswith(
+                "_gradients"
+            ):
+                gradient_name = key_internal.replace(f"{output}_", "").replace(
+                    "_gradients", ""
+                )
+                type_output["huber"]["deltas"][gradient_name] = delta
+            else:
+                pass
+    else:
+        type_output = type  # type: ignore
+    return type_output


### PR DESCRIPTION
This PR implements more loss options. Now the user can choose the type of the loss (`rmse`, `mae`, `huber`) as well as the reduction used (`sum` or `mean`).



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 ~- [ ] Issue referenced (for PRs that solve an issue)?~


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--385.org.readthedocs.build/en/385/

<!-- readthedocs-preview metatrain end -->