### PR TITLE
Only save config from main process

### DIFF
--- a/src/metatrain/cli/train.py
+++ b/src/metatrain/cli/train.py
@@ -367,9 +367,12 @@ def train_model(
     # SAVE EXPANDED OPTIONS ###
     ###########################
 
-    OmegaConf.save(
-        config=options, f=Path(checkpoint_dir) / "options_restart.yaml", resolve=True
-    )
+    if is_main_process():
+        OmegaConf.save(
+            config=options,
+            f=Path(checkpoint_dir) / "options_restart.yaml",
+            resolve=True,
+        )
 
     ###########################
     # SETTING UP MODEL ########


### PR DESCRIPTION
Otherwise, during distributed training, many processes might try to save the file

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--391.org.readthedocs.build/en/391/

<!-- readthedocs-preview metatrain end -->