### PR TITLE
Update PET maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,5 +4,5 @@
 
 **/soap_bpnn            @frostedoyster
 **/alchemical_model     @abmazitov
-**/pet                  @spozdn @abmazitov
+**/pet                  @abmazitov
 **/gap                  @DavideTisi

--- a/src/metatrain/experimental/pet/__init__.py
+++ b/src/metatrain/experimental/pet/__init__.py
@@ -15,6 +15,5 @@ __authors__ = [
 ]
 
 __maintainers__ = [
-    ("Sergey Pozdnyakov <sergey.pozdnyakov@epfl.ch>", "@spozdn"),
     ("Arslan Mazitov <arslan.mazitov@epfl.ch>", "@abmazitov"),
 ]


### PR DESCRIPTION
This removes @spozdn from the maintainer list: he is maintaining the upstream PET model at https://github.com/spozdn/pet/, and @abmazitov is maintaining the integration in metatrain.

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--400.org.readthedocs.build/en/400/

<!-- readthedocs-preview metatrain end -->