### PR TITLE
Remove the need to specify the architecture when exporting

### DIFF
--- a/docs/src/dev-docs/new-architecture.rst
+++ b/docs/src/dev-docs/new-architecture.rst
@@ -160,7 +160,9 @@ methods for ``train()``, ``save_checkpoint()`` and ``load_checkpoint()``.
 
 The format of checkpoints is not defined by ``metatrain`` and can be any format that
 can be loaded by the trainer (to restart training) and by the model (to export the
-checkpoint).
+checkpoint). The only requirements are that the checkpoint must be loadable with
+``torch.load()``, it must be a dictionary, and it must contain the name of the
+architecture under the ``architecture_name`` key.
 
 Init file (``__init__.py``)
 ---------------------------

--- a/docs/src/getting-started/checkpoints.rst
+++ b/docs/src/getting-started/checkpoints.rst
@@ -30,13 +30,13 @@ positional arguments
 
 .. code-block:: bash
 
-    mtt export experimental.soap_bpnn model.ckpt -o model.pt
+    mtt export model.ckpt -o model.pt
 
 or
 
 .. code-block:: bash
 
-    mtt export experimental.soap_bpnn model.ckpt --output model.pt
+    mtt export model.ckpt --output model.pt
 
 For a export of distribution of models the ``export`` command also supports parsing
 models from remote locations. To export a remote model you can provide a URL instead of
@@ -44,7 +44,7 @@ a file path.
 
 .. code-block:: bash
 
-    mtt export experimental.soap_bpnn https://my.url.com/model.ckpt --output model.pt
+    mtt export https://my.url.com/model.ckpt --output model.pt
 
 Downloading private HuggingFace models is also supported, by specifying the
 corresponding API token with the ``--huggingface_api_token`` flag.

--- a/src/metatrain/cli/export.py
+++ b/src/metatrain/cli/export.py
@@ -5,7 +5,6 @@ from typing import Any, Union
 
 from metatensor.torch.atomistic import is_atomistic_model
 
-from ..utils.architectures import find_all_architectures
 from ..utils.io import check_file_extension, load_model
 from .formatter import CustomHelpFormatter
 
@@ -30,12 +29,6 @@ def _add_export_model_parser(subparser: argparse._SubParsersAction) -> None:
     )
     parser.set_defaults(callable="export_model")
 
-    parser.add_argument(
-        "architecture_name",
-        type=str,
-        choices=find_all_architectures(),
-        help="name of the model's architecture",
-    )
     parser.add_argument(
         "path",
         type=str,
@@ -66,10 +59,8 @@ def _add_export_model_parser(subparser: argparse._SubParsersAction) -> None:
 def _prepare_export_model_args(args: argparse.Namespace) -> None:
     """Prepare arguments for export_model."""
     path = args.__dict__.pop("path")
-    architecture_name = args.__dict__.pop("architecture_name")
     args.model = load_model(
         path=path,
-        architecture_name=architecture_name,
         **args.__dict__,
     )
     keys_to_keep = ["model", "output"]  # only these are needed for `export_model``

--- a/src/metatrain/experimental/alchemical_model/trainer.py
+++ b/src/metatrain/experimental/alchemical_model/trainer.py
@@ -371,6 +371,7 @@ class Trainer:
 
     def save_checkpoint(self, model, path: Union[str, Path]):
         checkpoint = {
+            "architecture_name": "experimental.alchemical_model",
             "model_hypers": {
                 "model_hypers": model.hypers,
                 "dataset_info": model.dataset_info,

--- a/src/metatrain/experimental/pet/trainer.py
+++ b/src/metatrain/experimental/pet/trainer.py
@@ -754,6 +754,7 @@ Units of the Energy and Forces are the same units given in input"""
         else:
             lora_state_dict = None
         last_model_checkpoint = {
+            "architecture_name": "experimental.pet",
             "trainer_state_dict": trainer_state_dict,
             "model_state_dict": last_model_state_dict,
             "best_model_state_dict": self.best_model_state_dict,
@@ -765,6 +766,7 @@ Units of the Energy and Forces are the same units given in input"""
             "lora_state_dict": lora_state_dict,
         }
         best_model_checkpoint = {
+            "architecture_name": "experimental.pet",
             "trainer_state_dict": None,
             "model_state_dict": self.best_model_state_dict,
             "best_model_state_dict": None,

--- a/src/metatrain/experimental/soap_bpnn/trainer.py
+++ b/src/metatrain/experimental/soap_bpnn/trainer.py
@@ -411,6 +411,7 @@ class Trainer:
 
     def save_checkpoint(self, model, path: Union[str, Path]):
         checkpoint = {
+            "architecture_name": "experimental.soap_bpnn",
             "model_hypers": {
                 "model_hypers": model.hypers,
                 "dataset_info": model.dataset_info,

--- a/src/metatrain/utils/io.py
+++ b/src/metatrain/utils/io.py
@@ -92,6 +92,8 @@ def load_model(
         architectures
     """
 
+    print("LOADING MODEL")
+
     if Path(path).suffix in [".yaml", ".yml"]:
         raise ValueError(
             f"path '{path}' seems to be a YAML option file and not a model"
@@ -159,7 +161,8 @@ def load_model(
         if architecture_name not in find_all_architectures():
             raise ValueError(
                 f"Checkpoint architecture '{architecture_name}' not found "
-                "in the available architectures"
+                "in the available architectures. Available architectures are: "
+                f"{find_all_architectures()}"
             )
         architecture = import_architecture(architecture_name)
 
@@ -167,6 +170,6 @@ def load_model(
             return architecture.__model__.load_checkpoint(path)
         except Exception as err:
             raise ValueError(
-                f"path '{path}' is not a valid model file for the {architecture_name} "
+                f"path '{path}' is not a valid checkpoint for the {architecture_name} "
                 "architecture"
             ) from err

--- a/src/metatrain/utils/io.py
+++ b/src/metatrain/utils/io.py
@@ -92,8 +92,6 @@ def load_model(
         architectures
     """
 
-    print("LOADING MODEL")
-
     if Path(path).suffix in [".yaml", ".yml"]:
         raise ValueError(
             f"path '{path}' seems to be a YAML option file and not a model"

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -156,6 +156,4 @@ def test_run_information(capfd, monkeypatch, tmp_path):
     assert f"Package directory: {PACKAGE_ROOT}" in stdout_log
     assert f"Working directory: {Path('.').absolute()}" in stdout_log
     assert f"Metatrain version: {__version__}" in stdout_log
-    assert (
-        "Executed command: mtt export experimental.soap_bpnn model.ckpt" in stdout_log
-    )
+    assert "Executed command: mtt export model.ckpt" in stdout_log

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -149,7 +149,7 @@ def test_run_information(capfd, monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
 
     with pytest.raises(CalledProcessError):
-        subprocess.check_call(["mtt", "export", "experimental.soap_bpnn", "model.ckpt"])
+        subprocess.check_call(["mtt", "export", "model.ckpt"])
 
     stdout_log = capfd.readouterr().out
 

--- a/tests/cli/test_export_model.py
+++ b/tests/cli/test_export_model.py
@@ -57,7 +57,6 @@ def test_export_cli(monkeypatch, tmp_path, output, dtype):
     command = [
         "mtt",
         "export",
-        "experimental.soap_bpnn",
         str(RESOURCES_PATH / f"model-{dtype_string}-bit.ckpt"),
     ]
 
@@ -129,7 +128,6 @@ def test_private_huggingface(monkeypatch, tmp_path):
     command = [
         "mtt",
         "export",
-        "experimental.soap_bpnn",
         "https://huggingface.co/metatensor/metatrain-test/resolve/main/model.ckpt",
         f"--huggingface_api_token={HF_TOKEN}",
     ]

--- a/tests/cli/test_export_model.py
+++ b/tests/cli/test_export_model.py
@@ -80,12 +80,17 @@ def test_export_cli(monkeypatch, tmp_path, output, dtype):
     assert next(model.parameters()).device.type == "cpu"
 
 
-def test_export_cli_architecture_names_choices():
-    stderr = str(subprocess.run(["mtt", "export", "foo"], capture_output=True).stderr)
+def test_export_cli_unknown_architecture(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    torch.save({"architecture_name": "foo"}, "fake.ckpt")
 
-    assert "invalid choice: 'foo'" in stderr
+    stdout = str(
+        subprocess.run(["mtt", "export", "fake.ckpt"], capture_output=True).stdout
+    )
+
+    assert "architecture 'foo' not found in the available architectures" in stdout
     for architecture_name in find_all_architectures():
-        assert architecture_name in stderr
+        assert architecture_name in stdout
 
 
 def test_reexport(monkeypatch, tmp_path):

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -85,3 +85,14 @@ def test_load_model_unknown_model(monkeypatch, tmpdir):
     )
     with pytest.raises(ValueError, match=match):
         load_model(path, architecture_name=architecture_name)
+
+
+def test_load_model_no_architecture_name(monkeypatch, tmpdir):
+    monkeypatch.chdir(tmpdir)
+    architecture_name = "experimental.soap_bpnn"
+    path = "fake.ckpt"
+    torch.save({"not_architecture_name": architecture_name}, path)
+
+    match = "No architecture name found in the checkpoint"
+    with pytest.raises(ValueError, match=match):
+        load_model(path, architecture_name=architecture_name)

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+import torch
 from metatensor.torch.atomistic import MetatensorAtomisticModel
 
 from metatrain.experimental.soap_bpnn.model import SoapBpnn
@@ -45,7 +46,7 @@ def test_is_exported_file():
     ],
 )
 def test_load_model_checkpoint(path):
-    model = load_model(path, architecture_name="experimental.soap_bpnn")
+    model = load_model(path)
     assert type(model) is SoapBpnn
     if str(path).startswith("file:"):
         # test that the checkpoint is also copied to the current directory
@@ -61,7 +62,7 @@ def test_load_model_checkpoint(path):
     ],
 )
 def test_load_model_exported(path):
-    model = load_model(path, architecture_name="experimental.soap_bpnn")
+    model = load_model(path)
     assert type(model) is MetatensorAtomisticModel
 
 
@@ -69,30 +70,18 @@ def test_load_model_exported(path):
 def test_load_model_yaml(suffix):
     match = f"path 'foo{suffix}' seems to be a YAML option file and not a model"
     with pytest.raises(ValueError, match=match):
-        load_model(
-            f"foo{suffix}",
-            architecture_name="experimental.soap_bpnn",
-        )
+        load_model(f"foo{suffix}")
 
 
-def test_load_model_unknown_model():
-    architecture_name = "experimental.pet"
-    path = RESOURCES_PATH / "model-32-bit.ckpt"
+def test_load_model_unknown_model(monkeypatch, tmpdir):
+    monkeypatch.chdir(tmpdir)
+    architecture_name = "experimental.soap_bpnn"
+    path = "fake.ckpt"
+    torch.save({"architecture_name": architecture_name}, path)
 
     match = (
-        f"path '{path}' is not a valid model file for the {architecture_name} "
+        f"path '{path}' is not a valid checkpoint for the {architecture_name} "
         "architecture"
     )
     with pytest.raises(ValueError, match=match):
         load_model(path, architecture_name=architecture_name)
-
-
-def test_extensions_directory_and_architecture_name():
-    match = (
-        r"Both ``extensions_directory`` \('.'\) and ``architecture_name`` \('foo'\) "
-        r"are given which are mutually exclusive. An ``extensions_directory`` is only "
-        r"required for \*exported\* models while an ``architecture_name`` is only "
-        r"needed for model \*checkpoints\*."
-    )
-    with pytest.raises(ValueError, match=match):
-        load_model("model.pt", extensions_directory=".", architecture_name="foo")

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,6 @@ deps =
 changedir = tests
 extras =  # architectures used in the package tests
     soap-bpnn
-    pet
 allowlist_externals = bash
 commands_pre = bash {toxinidir}/tests/resources/generate-outputs.sh
 commands =


### PR DESCRIPTION
Closes #383, also closes #384 as it removes the need for PET in the package tests



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--405.org.readthedocs.build/en/405/

<!-- readthedocs-preview metatrain end -->