### PR TITLE
Pass last-layer features from PET to metatrain-PET

### DIFF
--- a/docs/src/advanced-concepts/auxiliary-outputs.rst
+++ b/docs/src/advanced-concepts/auxiliary-outputs.rst
@@ -16,11 +16,11 @@ by one or more architectures in the library:
 The following table shows the architectures that support each of the
 auxiliary outputs:
 
-+------------------------------------------+-----------+------------------+-----+
-| Auxiliary output                         | SOAP-BPNN | Alchemical Model | PET |
-+------------------------------------------+-----------+------------------+-----+
-| ``mtt::aux::last_layer_features``        | Yes       |       No         | No  |
-+------------------------------------------+-----------+------------------+-----+
++------------------------------------------+-----------+------------------+-----+-----+
+| Auxiliary output                         | SOAP-BPNN | Alchemical Model | PET | GAP |
++------------------------------------------+-----------+------------------+-----+-----+
+| ``mtt::aux::last_layer_features``        | Yes       |       No         | Yes | No  |
++------------------------------------------+-----------+------------------+-----+-----+
 
 The following tables show the metadata that is expected for each of the
 auxiliary outputs:

--- a/src/metatrain/experimental/pet/model.py
+++ b/src/metatrain/experimental/pet/model.py
@@ -63,9 +63,12 @@ class PET(torch.nn.Module):
 
         # last-layer feature size (for LLPR module)
         self.last_layer_feature_size = (
-            self.hypers["N_GNN_LAYERS"] * self.hypers["HEAD_N_NEURONS"] * 2
+            self.hypers["N_GNN_LAYERS"]
+            * self.hypers["HEAD_N_NEURONS"]
+            * (1 + self.hypers["USE_BOND_ENERGIES"])
         )
-        # times 2 because of the concatenation of the node and edge features
+        # if they are enabled, the edge features are concatenated
+        # to the node features
 
         # additive models: these are handled by the trainer at training
         # time, and they are added to the output at evaluation time
@@ -143,7 +146,6 @@ class PET(torch.nn.Module):
 
         if "mtt::aux::last_layer_features" in outputs:
             ll_features = output["last_layer_features"]
-            print(ll_features.shape)
             block = TensorBlock(
                 values=ll_features,
                 samples=samples,

--- a/src/metatrain/experimental/pet/trainer.py
+++ b/src/metatrain/experimental/pet/trainer.py
@@ -256,9 +256,9 @@ Units of the Energy and Forces are the same units given in input"""
             else:
                 pet_model.hypers.TARGET_TYPE = "structural"
                 pet_model.TARGET_TYPE = "structural"
-            pet_model = pet_model.to(device=device, dtype=dtype)
         else:
             pet_model = PET(ARCHITECTURAL_HYPERS, 0.0, len(all_species))
+        pet_model = pet_model.to(device=device, dtype=dtype)
         num_params = sum([p.numel() for p in pet_model.parameters()])
         logging.info(f"Number of parameters: {num_params}")
 


### PR DESCRIPTION
PET can output last-layer features. This passes them through the metatrain interface so that e.g. exported models can be used in chemiscope (after #398) or the LLPR module

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--407.org.readthedocs.build/en/407/

<!-- readthedocs-preview metatrain end -->