### PR TITLE
Fix missing best_metric in the temporary PET checkpoints

### DIFF
--- a/src/metatrain/experimental/pet/trainer.py
+++ b/src/metatrain/experimental/pet/trainer.py
@@ -610,9 +610,11 @@ Units of the Energy and Forces are the same units given in input"""
                 else:
                     lora_state_dict = None
                 last_model_checkpoint = {
+                    "architecture_name": "experimental.pet",
                     "trainer_state_dict": trainer_state_dict,
                     "model_state_dict": last_model_state_dict,
                     "best_model_state_dict": self.best_model_state_dict,
+                    "best_metric": self.best_metric,
                     "hypers": self.hypers,
                     "epoch": self.epoch,
                     "dataset_info": model.dataset_info,


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Another leftover from #399, adds `architecture name` and `best_metric` to the temporary checkpoints


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--410.org.readthedocs.build/en/410/

<!-- readthedocs-preview metatrain end -->