### PR TITLE
Export to `{stem}.pt` instead of `exported-model.pt` by default

### DIFF
--- a/src/metatrain/cli/export.py
+++ b/src/metatrain/cli/export.py
@@ -68,7 +68,7 @@ def _prepare_export_model_args(args: argparse.Namespace) -> None:
         if key not in keys_to_keep:
             args.__dict__.pop(key)
     if args.__dict__.get("output") is None:
-        args.__dict__["output"] = Path.cwd() / (Path(path).stem + ".pt")
+        args.__dict__["output"] = Path(path).stem + ".pt"
 
 
 def export_model(model: Any, output: Union[Path, str]) -> None:

--- a/src/metatrain/cli/export.py
+++ b/src/metatrain/cli/export.py
@@ -43,7 +43,10 @@ def _add_export_model_parser(subparser: argparse._SubParsersAction) -> None:
         dest="output",
         type=str,
         required=False,
-        help="Filename of the exported model (default: %(default)s).",
+        help=(
+            "Filename of the exported model (default: <stem>.pt, "
+            "where <stem> is the name of the checkpoint without the extension)."
+        ),
     )
     parser.add_argument(
         "--huggingface_api_token",

--- a/src/metatrain/cli/export.py
+++ b/src/metatrain/cli/export.py
@@ -43,7 +43,6 @@ def _add_export_model_parser(subparser: argparse._SubParsersAction) -> None:
         dest="output",
         type=str,
         required=False,
-        default="exported-model.pt",
         help="Filename of the exported model (default: %(default)s).",
     )
     parser.add_argument(
@@ -68,9 +67,11 @@ def _prepare_export_model_args(args: argparse.Namespace) -> None:
     for key in original_keys:
         if key not in keys_to_keep:
             args.__dict__.pop(key)
+    if args.__dict__.get("output") is None:
+        args.__dict__["output"] = Path.cwd() / (Path(path).stem + ".pt")
 
 
-def export_model(model: Any, output: Union[Path, str] = "exported-model.pt") -> None:
+def export_model(model: Any, output: Union[Path, str]) -> None:
     """Export a trained model allowing it to make predictions.
 
     This includes predictions within molecular simulation engines. Exported models will

--- a/tests/cli/test_export_model.py
+++ b/tests/cli/test_export_model.py
@@ -138,7 +138,7 @@ def test_private_huggingface(monkeypatch, tmp_path):
         f"--huggingface_api_token={HF_TOKEN}",
     ]
 
-    output = "model-32-bit.pt"
+    output = "model.pt"
 
     subprocess.check_call(command)
     assert Path(output).is_file()

--- a/tests/cli/test_export_model.py
+++ b/tests/cli/test_export_model.py
@@ -64,7 +64,7 @@ def test_export_cli(monkeypatch, tmp_path, output, dtype):
     if output is not None:
         command += ["-o", output]
     else:
-        output = "exported-model.pt"
+        output = f"model-{dtype_string}-bit.pt"
 
     subprocess.check_call(command)
     assert Path(output).is_file()
@@ -138,7 +138,7 @@ def test_private_huggingface(monkeypatch, tmp_path):
         f"--huggingface_api_token={HF_TOKEN}",
     ]
 
-    output = "exported-model.pt"
+    output = "model-32-bit.pt"
 
     subprocess.check_call(command)
     assert Path(output).is_file()


### PR DESCRIPTION
I feel like this is nicer for the users

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - ~Issue referenced (for PRs that solve an issue)?~


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--411.org.readthedocs.build/en/411/

<!-- readthedocs-preview metatrain end -->