### PR TITLE
Update URLs of buttons in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,16 +129,16 @@ Contributors
 Thanks goes to all people that make ``metatrain`` possible:
 
 .. image:: https://contrib.rocks/image?repo=lab-cosmo/metatrain
-  :target: https://github.com/lab-cosmo/metatrain/graphs/contributors
+  :target: https://github.com/metatensor/metatrain/graphs/contributors
 
 .. |tests| image:: https://github.com/lab-cosmo/metatrain/workflows/Tests/badge.svg
   :alt: Github Actions Tests Job Status
-  :target: https://github.com/lab-cosmo/metatrain/actions?query=branch%3Amain
+  :target: https://github.com/metatensor/metatrain/actions?query=branch%3Amain
 
 .. |codecov| image:: https://codecov.io/gh/lab-cosmo/metatrain/branch/main/graph/badge.svg
   :alt: Code coverage
-  :target: https://codecov.io/gh/lab-cosmo/metatrain
+  :target: https://codecov.io/gh/metatensor/metatrain
 
 .. |docs| image:: https://img.shields.io/badge/documentation-latest-sucess
   :alt: Documentation
-  :target: https://lab-cosmo.github.io/metatrain/latest/
+  :target: https://metatensor.github.io/metatrain/latest


### PR DESCRIPTION
Currently, the documentation button in the README points to this [URL](https://lab-cosmo.github.io/metatrain/latest/), which is no longer available. And this is also the case of the codecov button. This PR updates all this kind of URLs in the README.



# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--416.org.readthedocs.build/en/416/

<!-- readthedocs-preview metatrain end -->