### PR TITLE
Fix bug in `xyz` writer

### DIFF
--- a/src/metatrain/utils/data/writers/xyz.py
+++ b/src/metatrain/utils/data/writers/xyz.py
@@ -49,7 +49,7 @@ def write_xyz(
         info = {}
         arrays = {}
         for target_name, target_map in system_predictions.items():
-            if len(target_map.keys.names) != 1:
+            if len(target_map.keys) != 1:
                 raise ValueError(
                     "Only single-block `TensorMap`s can be "
                     "written to xyz files for the moment."


### PR DESCRIPTION
It was checking the number of names in the keys as opposed to the number of different entries (corresponding to the blocks)
