### PR TITLE
quick slurm fix

### DIFF
--- a/src/metatrain/utils/distributed/slurm.py
+++ b/src/metatrain/utils/distributed/slurm.py
@@ -4,7 +4,7 @@ import hostlist
 
 
 def is_slurm():
-    return "SLURM_JOB_ID" in os.environ
+    return ("SLURM_JOB_ID" in os.environ) and ("SLURM_PROCID" in os.environ)
 
 
 def is_slurm_main_process():


### PR DESCRIPTION
This PR is a quick fix for the robustness of the SLURM environment check. As @DavideTisi and I observed in #422 , when running the training after SSHing into a node reserved by `salloc`, the code throws an error. I think this occurs because reserving resources, SSHing to the node and running a job through a terminal session on that node is not a SLURM-managed process. So, this process has a job ID (since we got the node from some job), but not a process ID, so it's basically the same as running the training on a local workstation.

Considering this, I changed the `is_slurm` function, which will now return `True` only if the environment has both a job ID and a process ID.


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--435.org.readthedocs.build/en/435/

<!-- readthedocs-preview metatrain end -->