### PR TITLE
Same-second follow-up

### DIFF
--- a/src/metatrain/__main__.py
+++ b/src/metatrain/__main__.py
@@ -97,6 +97,7 @@ def main():
                         break
                     except FileExistsError:
                         i += 1
+                checkpoint_dir = Path(checkpoint_dir)
         args.checkpoint_dir = checkpoint_dir
 
         log_file = checkpoint_dir / "train.log"


### PR DESCRIPTION
The old version didn't work because of this:
```
        # define and create `checkpoint_dir` based on current directory, date and time
        checkpoint_dir = _datetime_output_path(now=datetime.now())
        if is_main_process():
            try:
                os.makedirs(checkpoint_dir)
            except FileExistsError:
                # directory already exists from a different run, add a suffix
                # (.1, .2, ...) to the directory name
                initial_checkpoint_dir = checkpoint_dir
                i = 1
                while True:
                    try:
                        checkpoint_dir = f"{initial_checkpoint_dir}.{i}"
                        os.makedirs(checkpoint_dir)
                        break
                    except FileExistsError:
                        i += 1
                checkpoint_dir = Path(checkpoint_dir)
        args.checkpoint_dir = checkpoint_dir

        log_file = checkpoint_dir / "train.log"
        error_file = checkpoint_dir / error_file
```

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--450.org.readthedocs.build/en/450/

<!-- readthedocs-preview metatrain end -->