### PR TITLE
Move last-layer feature registration inside `_add_output()`

### DIFF
--- a/src/metatrain/experimental/nanopet/model.py
+++ b/src/metatrain/experimental/nanopet/model.py
@@ -109,12 +109,6 @@ class NanoPET(torch.nn.Module):
         self.outputs = {
             "features": ModelOutput(unit="", per_atom=True)
         }  # the model is always capable of outputting the internal features
-        for target_name in dataset_info.targets.keys():
-            # the model can always output the last-layer features for the targets
-            ll_features_name = (
-                f"mtt::aux::{target_name.replace('mtt::', '')}_last_layer_features"
-            )
-            self.outputs[ll_features_name] = ModelOutput(per_atom=True)
 
         self.heads = torch.nn.ModuleDict()
         self.head_types = self.hypers["heads"]
@@ -578,6 +572,11 @@ class NanoPET(torch.nn.Module):
                 f"Unsupported head type {self.head_types[target_name]} "
                 f"for target {target_name}"
             )
+
+        ll_features_name = (
+            f"mtt::aux::{target_name.replace('mtt::', '')}_last_layer_features"
+        )
+        self.outputs[ll_features_name] = ModelOutput(per_atom=True)
 
         self.last_layers[target_name] = torch.nn.ModuleDict(
             {

--- a/src/metatrain/experimental/soap_bpnn/model.py
+++ b/src/metatrain/experimental/soap_bpnn/model.py
@@ -173,12 +173,6 @@ class SoapBpnn(torch.nn.Module):
         self.outputs = {
             "features": ModelOutput(unit="", per_atom=True)
         }  # the model is always capable of outputting the internal features
-        for target_name in dataset_info.targets.keys():
-            # the model can always output the last-layer features for the targets
-            ll_features_name = (
-                f"mtt::aux::{target_name.replace('mtt::', '')}_last_layer_features"
-            )
-            self.outputs[ll_features_name] = ModelOutput(per_atom=True)
 
         self.single_label = Labels.single()
 
@@ -535,6 +529,11 @@ class SoapBpnn(torch.nn.Module):
                 f"Unsupported head type {self.head_types[target_name]} "
                 f"for target {target_name}"
             )
+
+        ll_features_name = (
+            f"mtt::aux::{target_name.replace('mtt::', '')}_last_layer_features"
+        )
+        self.outputs[ll_features_name] = ModelOutput(per_atom=True)
 
         # last linear layers, one per block
         self.last_layers[target_name] = torch.nn.ModuleDict({})


### PR DESCRIPTION
In this way, they will also be registered if the user restarts training with new ouptuts


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--457.org.readthedocs.build/en/457/

<!-- readthedocs-preview metatrain end -->