### PR TITLE
Add YYYY.minor version scheme, fix tests not running in tmpdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 *.so
 
 # Distribution / packaging
+_version.py
 .Python
 build/
 develop-eggs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ mtt = "metatrain.__main__:main"
 [build-system]
 requires = [
     "setuptools >= 68",
+    "setuptools_scm>=8",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
@@ -73,11 +74,14 @@ gap = [
     "scipy",
 ]
 
+[tool.check-manifest]
+ignore = ["src/metatrain/_version.py"]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 
-[tool.setuptools.dynamic]
-version = {attr = "metatrain.__version__"}
+[tool.setuptools_scm]
+version_file = "src/metatrain/_version.py"
 
 [tool.coverage.report]
 skip_covered = true
@@ -98,7 +102,7 @@ source = [
 ]
 
 [tool.ruff]
-exclude = ["docs/src/examples/**"]
+exclude = ["docs/src/examples/**", "src/metatrain/_version.py"]
 line-length = 88
 
 [tool.ruff.lint]

--- a/src/metatrain/__init__.py
+++ b/src/metatrain/__init__.py
@@ -1,6 +1,8 @@
 import secrets
 from pathlib import Path
 
+from ._version import __version__  # noqa: F401
+
 
 PACKAGE_ROOT = Path(__file__).parent.resolve()
 
@@ -8,5 +10,3 @@ PACKAGE_ROOT = Path(__file__).parent.resolve()
 # A constant as "session" variable to set the random seed to a fixed value that do not
 # change within the execution of the program.
 RANDOM_SEED = secrets.randbelow(2**32)
-
-__version__ = "2023.11.29"

--- a/src/metatrain/experimental/gap/tests/test_torchscript.py
+++ b/src/metatrain/experimental/gap/tests/test_torchscript.py
@@ -64,7 +64,7 @@ def test_torchscript():
     )
 
 
-def test_torchscript_save():
+def test_torchscript_save_load(tmpdir):
     """Tests that the model can be jitted and saved."""
     targets = {}
     targets["mtt::U0"] = get_energy_target_info({"unit": "eV"})
@@ -73,8 +73,7 @@ def test_torchscript_save():
         length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=targets
     )
     gap = GAP(DEFAULT_HYPERS["model"], dataset_info)
-    torch.jit.save(
-        torch.jit.script(gap),
-        "gap.pt",
-    )
-    torch.jit.load("gap.pt")
+
+    with tmpdir.as_cwd():
+        torch.jit.save(torch.jit.script(gap), "gap.pt")
+        torch.jit.load("gap.pt")

--- a/src/metatrain/experimental/nanopet/tests/test_torchscript.py
+++ b/src/metatrain/experimental/nanopet/tests/test_torchscript.py
@@ -38,7 +38,7 @@ def test_torchscript():
     )
 
 
-def test_torchscript_save_load():
+def test_torchscript_save_load(tmpdir):
     """Tests that the model can be jitted and saved."""
 
     dataset_info = DatasetInfo(
@@ -49,8 +49,7 @@ def test_torchscript_save_load():
         },
     )
     model = NanoPET(MODEL_HYPERS, dataset_info)
-    torch.jit.save(
-        torch.jit.script(model),
-        "model.pt",
-    )
-    torch.jit.load("model.pt")
+
+    with tmpdir.as_cwd():
+        torch.jit.save(torch.jit.script(model), "model.pt")
+        torch.jit.load("model.pt")

--- a/src/metatrain/experimental/pet/tests/test_torchscript.py
+++ b/src/metatrain/experimental/pet/tests/test_torchscript.py
@@ -26,7 +26,7 @@ def test_torchscript():
     torch.jit.script(model)
 
 
-def test_torchscript_save_load():
+def test_torchscript_save_load(tmpdir):
     """Tests that the model can be jitted and saved."""
 
     dataset_info = DatasetInfo(
@@ -39,8 +39,7 @@ def test_torchscript_save_load():
     raw_pet = PET(ARCHITECTURAL_HYPERS, 0.0, len(model.atomic_types))
     model.set_trained_model(raw_pet)
     torch.jit.script(model)
-    torch.jit.save(
-        torch.jit.script(model),
-        "pet.pt",
-    )
-    torch.jit.load("pet.pt")
+
+    with tmpdir.as_cwd():
+        torch.jit.save(torch.jit.script(model), "pet.pt")
+        torch.jit.load("pet.pt")

--- a/src/metatrain/experimental/soap_bpnn/tests/test_torchscript.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_torchscript.py
@@ -107,7 +107,7 @@ def test_torchscript_spherical(o3_lambda, o3_sigma):
     )
 
 
-def test_torchscript_save_load():
+def test_torchscript_save_load(tmpdir):
     """Tests that the model can be jitted and saved."""
 
     dataset_info = DatasetInfo(
@@ -116,8 +116,7 @@ def test_torchscript_save_load():
         targets={"energy": get_energy_target_info({"unit": "eV"})},
     )
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
-    torch.jit.save(
-        torch.jit.script(model),
-        "model.pt",
-    )
-    torch.jit.load("model.pt")
+
+    with tmpdir.as_cwd():
+        torch.jit.save(torch.jit.script(model), "model.pt")
+        torch.jit.load("model.pt")

--- a/tests/cli/test_export_model.py
+++ b/tests/cli/test_export_model.py
@@ -81,17 +81,17 @@ def test_export_cli(monkeypatch, tmp_path, output, dtype):
     assert next(model.parameters()).device.type == "cpu"
 
 
-def test_export_cli_unknown_architecture(monkeypatch, tmp_path):
-    monkeypatch.chdir(tmp_path)
-    torch.save({"architecture_name": "foo"}, "fake.ckpt")
+def test_export_cli_unknown_architecture(tmpdir):
+    with tmpdir.as_cwd():
+        torch.save({"architecture_name": "foo"}, "fake.ckpt")
 
-    stdout = str(
-        subprocess.run(["mtt", "export", "fake.ckpt"], capture_output=True).stdout
-    )
+        stdout = str(
+            subprocess.run(["mtt", "export", "fake.ckpt"], capture_output=True).stdout
+        )
 
-    assert "architecture 'foo' not found in the available architectures" in stdout
-    for architecture_name in find_all_architectures():
-        assert architecture_name in stdout
+        assert "architecture 'foo' not found in the available architectures" in stdout
+        for architecture_name in find_all_architectures():
+            assert architecture_name in stdout
 
 
 def test_reexport(monkeypatch, tmp_path):

--- a/tests/utils/data/test_targets_ase.py
+++ b/tests/utils/data/test_targets_ase.py
@@ -59,15 +59,13 @@ def ase_systems() -> List[ase.Atoms]:
     return [ase_system(), ase_system()]
 
 
-def test_read_energy_ase(monkeypatch, tmp_path):
-    monkeypatch.chdir(tmp_path)
-
+def test_read_energy_ase(tmpdir):
     filename = "systems.xyz"
-
     systems = ase_systems()
-    ase.io.write(filename, systems)
 
-    results = _read_energy_ase(filename=filename, key="true_energy")
+    with tmpdir.as_cwd():
+        ase.io.write(filename, systems)
+        results = _read_energy_ase(filename=filename, key="true_energy")
 
     for result, atoms in zip(results, systems):
         expected = torch.tensor([[atoms.info["true_energy"]]], dtype=torch.float64)

--- a/tests/utils/test_additive.py
+++ b/tests/utils/test_additive.py
@@ -218,8 +218,11 @@ def test_composition_model_torchscript(tmpdir):
     composition_model(
         [system], {"energy": ModelOutput(quantity="energy", unit="", per_atom=False)}
     )
-    torch.jit.save(composition_model, tmpdir / "composition_model.pt")
-    composition_model = torch.jit.load(tmpdir / "composition_model.pt")
+
+    with tmpdir.as_cwd():
+        torch.jit.save(composition_model, "composition_model.pt")
+        composition_model = torch.jit.load("composition_model.pt")
+
     composition_model(
         [system], {"energy": ModelOutput(quantity="energy", unit="", per_atom=False)}
     )

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -73,18 +73,19 @@ def test_load_model_yaml(suffix):
         load_model(f"foo{suffix}")
 
 
-def test_load_model_unknown_model(monkeypatch, tmpdir):
-    monkeypatch.chdir(tmpdir)
+def test_load_model_unknown_model(tmpdir):
     architecture_name = "experimental.soap_bpnn"
     path = "fake.ckpt"
-    torch.save({"architecture_name": architecture_name}, path)
 
-    match = (
-        f"path '{path}' is not a valid checkpoint for the {architecture_name} "
-        "architecture"
-    )
-    with pytest.raises(ValueError, match=match):
-        load_model(path, architecture_name=architecture_name)
+    with tmpdir.as_cwd():
+        torch.save({"architecture_name": architecture_name}, path)
+
+        match = (
+            f"path '{path}' is not a valid checkpoint for the {architecture_name} "
+            "architecture"
+        )
+        with pytest.raises(ValueError, match=match):
+            load_model(path, architecture_name=architecture_name)
 
 
 def test_load_model_no_architecture_name(monkeypatch, tmpdir):

--- a/tests/utils/test_llpr.py
+++ b/tests/utils/test_llpr.py
@@ -112,13 +112,9 @@ def test_llpr(tmpdir):
         llpr_model.capabilities,
     )
 
-    exported_model.save(
-        file=str(tmpdir / "llpr_model.pt"),
-        collect_extensions=str(tmpdir / "extensions"),
-    )
-    llpr_model = load_model(
-        str(tmpdir / "llpr_model.pt"), extensions_directory=str(tmpdir / "extensions")
-    )
+    with tmpdir.as_cwd():
+        exported_model.save(file="llpr_model.pt", collect_extensions="extensions")
+        llpr_model = load_model("llpr_model.pt", extensions_directory="extensions")
 
     evaluation_options = ModelEvaluationOptions(
         length_unit="angstrom",
@@ -252,13 +248,9 @@ def test_llpr_covariance_as_pseudo_hessian(tmpdir):
         llpr_model.capabilities,
     )
 
-    exported_model.save(
-        file=str(tmpdir / "llpr_model.pt"),
-        collect_extensions=str(tmpdir / "extensions"),
-    )
-    llpr_model = load_model(
-        str(tmpdir / "llpr_model.pt"), extensions_directory=str(tmpdir / "extensions")
-    )
+    with tmpdir.as_cwd():
+        exported_model.save(file="llpr_model.pt", collect_extensions="extensions")
+        llpr_model = load_model("llpr_model.pt", extensions_directory="extensions")
 
     evaluation_options = ModelEvaluationOptions(
         length_unit="angstrom",

--- a/tests/utils/test_scaler.py
+++ b/tests/utils/test_scaler.py
@@ -205,6 +205,9 @@ def test_scaler_torchscript(tmpdir):
 
     scaler = torch.jit.script(scaler)
     scaler(fake_output)
-    torch.jit.save(scaler, tmpdir / "scaler.pt")
-    scaler = torch.jit.load(tmpdir / "scaler.pt")
+
+    with tmpdir.as_cwd():
+        torch.jit.save(scaler, tmpdir / "scaler.pt")
+        scaler = torch.jit.load(tmpdir / "scaler.pt")
+
     scaler(fake_output)


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

As discussed in the meeting this PRs adds a YYYY.minor versioning scheme. The version is created automatically using the latest git tag using setuptools-scm. For testing I created a local tag `git tag v2025.0` and I get the correct version using `mtt --version`

`metatrain 2025.1.dev0+g277db0b9.d20250131`

Since we don't have tags on github you will see a version like

`metatrain-0.1.dev295+gb3bcd8d`

until we do our first release.

While doing this I found that a couple of tests are writing files to the repo and not in a tempdir. I fixed these as well.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--464.org.readthedocs.build/en/464/

<!-- readthedocs-preview metatrain end -->