### PR TITLE
Rename `model_hypers` to `model_data`

### DIFF
--- a/src/metatrain/experimental/nanopet/model.py
+++ b/src/metatrain/experimental/nanopet/model.py
@@ -499,7 +499,7 @@ class NanoPET(torch.nn.Module):
 
         # Load the checkpoint
         checkpoint = torch.load(path, weights_only=False, map_location="cpu")
-        model_hypers = checkpoint["model_data"]
+        model_data = checkpoint["model_data"]
         model_state_dict = checkpoint["model_state_dict"]
 
         # Create the model

--- a/src/metatrain/experimental/nanopet/model.py
+++ b/src/metatrain/experimental/nanopet/model.py
@@ -499,7 +499,7 @@ class NanoPET(torch.nn.Module):
 
         # Load the checkpoint
         checkpoint = torch.load(path, weights_only=False, map_location="cpu")
-        model_hypers = checkpoint["model_hypers"]
+        model_hypers = checkpoint["model_data"]
         model_state_dict = checkpoint["model_state_dict"]
 
         # Create the model

--- a/src/metatrain/experimental/nanopet/model.py
+++ b/src/metatrain/experimental/nanopet/model.py
@@ -503,7 +503,7 @@ class NanoPET(torch.nn.Module):
         model_state_dict = checkpoint["model_state_dict"]
 
         # Create the model
-        model = cls(**model_hypers)
+        model = cls(**model_data)
         state_dict_iter = iter(model_state_dict.values())
         next(state_dict_iter)  # skip `species_to_species_index` buffer (int)
         dtype = next(state_dict_iter).dtype

--- a/src/metatrain/experimental/nanopet/trainer.py
+++ b/src/metatrain/experimental/nanopet/trainer.py
@@ -478,7 +478,7 @@ class Trainer:
     def save_checkpoint(self, model, path: Union[str, Path]):
         checkpoint = {
             "architecture_name": "experimental.nanopet",
-            "model_hypers": {
+            "model_data": {
                 "model_hypers": model.hypers,
                 "dataset_info": model.dataset_info,
             },

--- a/src/metatrain/experimental/soap_bpnn/model.py
+++ b/src/metatrain/experimental/soap_bpnn/model.py
@@ -431,11 +431,11 @@ class SoapBpnn(torch.nn.Module):
 
         # Load the checkpoint
         checkpoint = torch.load(path, weights_only=False, map_location="cpu")
-        model_hypers = checkpoint["model_hypers"]
+        model_data = checkpoint["model_data"]
         model_state_dict = checkpoint["model_state_dict"]
 
         # Create the model
-        model = cls(**model_hypers)
+        model = cls(**model_data)
         dtype = next(iter(model_state_dict.values())).dtype
         model.to(dtype).load_state_dict(model_state_dict)
 

--- a/src/metatrain/experimental/soap_bpnn/trainer.py
+++ b/src/metatrain/experimental/soap_bpnn/trainer.py
@@ -464,7 +464,7 @@ class Trainer:
     def save_checkpoint(self, model, path: Union[str, Path]):
         checkpoint = {
             "architecture_name": "experimental.soap_bpnn",
-            "model_hypers": {
+            "model_data": {
                 "model_hypers": model.hypers,
                 "dataset_info": model.dataset_info,
             },


### PR DESCRIPTION
A section of the checkpoints was misnamed. It was originally called `model_hypers`, which contained the true model hypers (which were also named `model_hypers`) + information on the dataset it was originally trained on. This changes the higher-level `model-hypers` to `model_data`, which is more descriptive and removes the nested `model_hypers`

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--465.org.readthedocs.build/en/465/

<!-- readthedocs-preview metatrain end -->