### PR TITLE
CLI and Python interface for adding model informations at export

### DIFF
--- a/docs/src/architectures/gap.rst
+++ b/docs/src/architectures/gap.rst
@@ -3,13 +3,10 @@
 GAP
 ===
 
-This is an implementation of the sparse `Gaussian Approximation Potential
-<GAP_>`_ (GAP) using `Smooth Overlap of Atomic Positions <SOAP_>`_ (SOAP)
-implemented in `rascaline <RASCALINE_>`_.
+This is an implementation of the sparse Gaussian Approximation Potential
+(GAP) :footcite:p:`bartok_representing_2013` using Smooth Overlap of Atomic Positions
+(SOAP) :footcite:p:`bartok_gaussian_2010` implemented in `rascaline <RASCALINE_>`_.
 
-
-.. _SOAP: https://doi.org/10.1103/PhysRevB.87.184115
-.. _GAP:  https://doi.org/10.1002/qua.24927
 .. _RASCALINE: https://github.com/Luthaf/rascaline
 
 The GAP model in metatrain can only train on CPU, but evaluation
@@ -149,3 +146,7 @@ training:
 ^^^^^^^^^
 :param regularizer: value of the energy regularizer. Default 0.001
 :param regularizer_forces: value of the forces regularizer. Default null
+
+References
+----------
+.. footbibliography::

--- a/docs/src/architectures/nanopet.rst
+++ b/docs/src/architectures/nanopet.rst
@@ -7,8 +7,9 @@ NanoPET
 
   This is an **experimental model**.  You should not use it for anything important.
 
-This is a more user-friendly re-implementation of the original PET (which lives in
-https://github.com/spozdn/pet), with slightly improved training and evaluation speed.
+This is a more user-friendly re-implementation of the original
+PET :footcite:p:`pozdnyakov_smooth_2023` (which lives in https://github.com/spozdn/pet),
+with slightly improved training and evaluation speed.
 
 Installation
 ------------
@@ -120,3 +121,7 @@ The hyperparameters for training are
     the current directory and in the checkpoint directory. The default is ``rmse_prod``,
     i.e., the product of the RMSEs for each target. Other options are ``mae_prod`` and
     ``loss``.
+
+References
+----------
+.. footbibliography::

--- a/docs/src/architectures/pet.rst
+++ b/docs/src/architectures/pet.rst
@@ -5,9 +5,10 @@ PET
 
 .. warning::
 
-  The metatrain interface to PET is **experimental**. You should not use it for
-  anything important. You can also fit PET using native scripts (not experimental)
-  from `here <https://spozdn.github.io/pet/train_model.html>`_.
+  The metatrain interface to PET :footcite:p:`pozdnyakov_smooth_2023` is
+  **experimental**. You should not use it for anything important. You can also fit PET
+  using native scripts (not experimental) from `here
+  <https://spozdn.github.io/pet/train_model.html>`_.
 
 
 Installation
@@ -170,8 +171,8 @@ to significantly increase the model's speed with minimal impact on accuracy. For
 practical use, especially when conducting massive calculations where model speed is
 crucial, it may be beneficial to set ``N_TRANS_LAYERS`` to ``2`` instead of the default
 value of ``3``. The ``N_TRANS_LAYERS`` hyperparameter controls the number of transformer
-layers in each message-passing block (see more details in the `PET paper
-<https://arxiv.org/abs/2305.19302>`_). This adjustment would result in a model that is
+layers in each message-passing block (For more details see
+:footcite:t:`pozdnyakov_smooth_2023`). This adjustment would result in a model that is
 about *1.5 times* more lightweight and faster, with an expected minimal deterioration in
 accuracy.
 
@@ -289,3 +290,7 @@ dataset)``.
 - ``USE_ADDITIONAL_SCALAR_ATTRIBUTES``: if using additional scalar attributes
   such as collinear spins
 - ``SCALAR_ATTRIBUTES_SIZE``: dimensionality of additional scalar attributes
+
+References
+----------
+.. footbibliography::

--- a/docs/src/dev-docs/new-architecture.rst
+++ b/docs/src/dev-docs/new-architecture.rst
@@ -89,10 +89,15 @@ method.
 
 .. code-block:: python
 
+    from metatensor.torch.atomistic import MetatensorAtomisticModel, ModelMetadata
+
     class ModelInterface:
 
         __supported_devices__ = ["cuda", "cpu"]
         __supported_dtypes__ = [torch.float64, torch.float32]
+        __default_metadata__ = ModelMetadata(
+            references = {"implementation": ["ref1"], "architecture": ["ref2"]}
+        )
 
         def __init__(self, model_hypers: Dict, dataset_info: DatasetInfo):
             self.hypers = model_hypers
@@ -113,7 +118,9 @@ method.
             """
             pass
 
-        def export(self) -> MetatensorAtomisticModel:
+            def export(
+        self, metadata: Optional[ModelMetadata] = None
+    ) -> MetatensorAtomisticModel:
             pass
 
 Note that the ``ModelInterface`` does not necessarily inherit from
@@ -122,6 +129,12 @@ Note that the ``ModelInterface`` does not necessarily inherit from
 capabilities of the model. These two lists should be sorted in order of preference since
 ``metatrain`` will use these to determine, based on the user request and
 machines' availability, the optimal ``dtype`` and ``device`` for training.
+
+The ``__default_metadata__`` is a class attribute that can be used to provide references
+that will be stored in the exported model. The references are stored in a dictionary
+with keys ``implementation`` and ``architecture``. The ``implementation`` key should
+contain references to the software used in the implementation of the architecture, while
+the ``architecture`` key should contain references about the general architecture.
 
 The ``export()`` method is required to transform a trained model into a standalone file
 to be used in combination with molecular dynamic engines to run simulations. We provide

--- a/docs/src/getting-started/checkpoints.rst
+++ b/docs/src/getting-started/checkpoints.rst
@@ -38,6 +38,38 @@ or
 
     mtt export model.ckpt --output model.pt
 
+Adding information about models
+-------------------------------
+
+You can also insert the model name, a description, the list of authors and references
+into the model. This information will be saved in the exported model and can will be
+displayed to users when the model is used, for example, in molecular dynamics
+simulations.
+
+.. code-block:: bash
+
+    mtt export model.ckpt --metadata metadata.yaml
+
+The ``metadata.yaml`` file should have the following structure:
+
+.. code-block:: yaml
+
+    name: My model
+    description: This model was trained on the QM9 dataset.
+    authors:
+      - John Doe
+      - Jane Doe
+    references:
+      model:
+        - https://arxiv.org/abs/1234.5678
+
+You can also add additional keywords like additional references to the metadata file.
+The fields are the same for :class:`ModelMetadata
+<metatensor.torch.atomistic.ModelMetadata>` class from metatensor.
+
+Exporting remote models
+-----------------------
+
 For a export of distribution of models the ``export`` command also supports parsing
 models from remote locations. To export a remote model you can provide a URL instead of
 a file path.

--- a/docs/static/refs.bib
+++ b/docs/static/refs.bib
@@ -56,6 +56,28 @@
     url = {https://doi.org/10.1063/5.0124363},
 }
 
+@article{pozdnyakov_smooth_2023,
+  title = {Smooth, Exact Rotational Symmetrization for Deep Learning on Point Clouds},
+  author = {Pozdnyakov, Sergey N. and Ceriotti, Michele},
+  year = {2023},
+  month = may,
+  journal = {arXiv.org},
+  urldate = {2025-01-24},
+  howpublished = {https://arxiv.org/abs/2305.19302v3},
+  langid = {english}
+}
 
-
-
+@article{bartok_gaussian_2010,
+  title = {Gaussian {{Approximation Potentials}}: {{The Accuracy}} of {{Quantum Mechanics}}, without the {{Electrons}}},
+  shorttitle = {Gaussian {{Approximation Potentials}}},
+  author = {Bart{\'o}k, Albert P. and Payne, Mike C. and Kondor, Risi and Cs{\'a}nyi, G{\'a}bor},
+  year = {2010},
+  month = apr,
+  journal = {Phys. Rev. Lett.},
+  volume = {104},
+  number = {13},
+  pages = {136403},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevLett.104.136403},
+  urldate = {2023-08-03}
+}

--- a/src/metatrain/cli/export.py
+++ b/src/metatrain/cli/export.py
@@ -1,9 +1,10 @@
 import argparse
 import logging
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Optional, Union
 
-from metatensor.torch.atomistic import is_atomistic_model
+from metatensor.torch.atomistic import ModelMetadata, is_atomistic_model
+from omegaconf import OmegaConf
 
 from ..utils.io import check_file_extension, load_model
 from .formatter import CustomHelpFormatter
@@ -49,6 +50,15 @@ def _add_export_model_parser(subparser: argparse._SubParsersAction) -> None:
         ),
     )
     parser.add_argument(
+        "-m",
+        "--metadata",
+        type=str,
+        required=False,
+        dest="metadata",
+        default=None,
+        help="metatdata file to be appended to the model.",
+    )
+    parser.add_argument(
         "--huggingface_api_token",
         dest="huggingface_api_token",
         type=str,
@@ -65,8 +75,14 @@ def _prepare_export_model_args(args: argparse.Namespace) -> None:
         path=path,
         **args.__dict__,
     )
-    keys_to_keep = ["model", "output"]  # only these are needed for `export_model``
+
+    if args.metadata is not None:
+        args.metadata = ModelMetadata(**OmegaConf.load(args.metadata))
+
+    # only these are needed for `export_model``
+    keys_to_keep = ["model", "output", "metadata"]
     original_keys = list(args.__dict__.keys())
+
     for key in original_keys:
         if key not in keys_to_keep:
             args.__dict__.pop(key)
@@ -74,7 +90,9 @@ def _prepare_export_model_args(args: argparse.Namespace) -> None:
         args.__dict__["output"] = Path(path).stem + ".pt"
 
 
-def export_model(model: Any, output: Union[Path, str]) -> None:
+def export_model(
+    model: Any, output: Union[Path, str], metadata: Optional[ModelMetadata] = None
+) -> None:
     """Export a trained model allowing it to make predictions.
 
     This includes predictions within molecular simulation engines. Exported models will
@@ -83,6 +101,7 @@ def export_model(model: Any, output: Union[Path, str]) -> None:
 
     :param model: model to be exported
     :param output: path to save the model
+    :param metadata: metadata to be appended to the model
     """
     path = str(
         Path(check_file_extension(filename=output, extension=".pt"))
@@ -92,7 +111,7 @@ def export_model(model: Any, output: Union[Path, str]) -> None:
     extensions_path = str(Path("extensions/").absolute().resolve())
 
     if not is_atomistic_model(model):
-        model = model.export()
+        model = model.export(metadata)
 
     model.save(path, collect_extensions=extensions_path)
     logger.info(f"Model exported to '{path}' and extensions to '{extensions_path}'")

--- a/src/metatrain/experimental/gap/model.py
+++ b/src/metatrain/experimental/gap/model.py
@@ -23,11 +23,23 @@ from skmatter._selection import _FPS
 from metatrain.utils.data.dataset import DatasetInfo
 
 from ...utils.additive import ZBL, CompositionModel
+from ...utils.metadata import append_metadata_references
 
 
 class GAP(torch.nn.Module):
     __supported_devices__ = ["cpu"]
     __supported_dtypes__ = [torch.float64]
+    __default_metadata__ = ModelMetadata(
+        references={
+            "implementation": [
+                "rascaline: https://github.com/Luthaf/rascaline",
+            ],
+            "architecture": [
+                "SOAP: https://doi.org/10.1002/qua.24927",
+                "GAP: https://doi.org/10.1103/PhysRevB.87.184115",
+            ],
+        }
+    )
 
     def __init__(self, model_hypers: Dict, dataset_info: DatasetInfo) -> None:
         super().__init__()
@@ -251,7 +263,9 @@ class GAP(torch.nn.Module):
 
         return return_dict
 
-    def export(self) -> MetatensorAtomisticModel:
+    def export(
+        self, metadata: Optional[ModelMetadata] = None
+    ) -> MetatensorAtomisticModel:
         interaction_ranges = [self.hypers["soap"]["cutoff"]]
         for additive_model in self.additive_models:
             if hasattr(additive_model, "cutoff_radius"):
@@ -273,7 +287,12 @@ class GAP(torch.nn.Module):
             self._subset_of_regressors.export_torch_script_model()
         )
 
-        return MetatensorAtomisticModel(self.eval(), ModelMetadata(), capabilities)
+        if metadata is None:
+            metadata = ModelMetadata()
+
+        append_metadata_references(metadata, self.__default_metadata__)
+
+        return MetatensorAtomisticModel(self.eval(), metadata, capabilities)
 
     def set_composition_weights(
         self,

--- a/src/metatrain/experimental/gap/tests/test_exported.py
+++ b/src/metatrain/experimental/gap/tests/test_exported.py
@@ -1,0 +1,66 @@
+import torch
+from metatensor.torch.atomistic import ModelMetadata
+from omegaconf import OmegaConf
+
+from metatrain.experimental.gap import GAP, Trainer
+from metatrain.utils.data import Dataset, DatasetInfo
+from metatrain.utils.data.readers import read_systems, read_targets
+from metatrain.utils.data.target_info import get_energy_target_info
+
+from . import DATASET_PATH, DEFAULT_HYPERS
+
+
+def test_export():
+    """Tests that export works with injected metadata"""
+
+    systems = read_systems(DATASET_PATH)
+
+    conf = {
+        "energy": {
+            "quantity": "energy",
+            "read_from": DATASET_PATH,
+            "reader": "ase",
+            "key": "U0",
+            "unit": "kcal/mol",
+            "type": "scalar",
+            "per_atom": False,
+            "num_subtargets": 1,
+            "forces": False,
+            "stress": False,
+            "virial": False,
+        }
+    }
+    targets, _ = read_targets(OmegaConf.create(conf))
+    dataset = Dataset.from_dict({"system": systems, "energy": targets["energy"]})
+
+    target_info_dict = {}
+    target_info_dict["energy"] = get_energy_target_info({"unit": "eV"})
+
+    dataset_info = DatasetInfo(
+        length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=target_info_dict
+    )
+
+    dataset_info = DatasetInfo(
+        length_unit="Angstrom",
+        atomic_types=[1, 6, 7, 8],
+        targets={
+            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+        },
+    )
+    model = GAP(DEFAULT_HYPERS["model"], dataset_info)
+
+    # we have to train gap before we can export...
+    trainer = Trainer(DEFAULT_HYPERS["training"])
+    trainer.train(
+        model=model,
+        dtype=torch.float64,
+        devices=[torch.device("cpu")],
+        train_datasets=[dataset],
+        val_datasets=[dataset],
+        checkpoint_dir=".",
+    )
+
+    exported = model.export(metadata=ModelMetadata(name="test"))
+
+    # test correct metadata
+    assert "This is the test model" in str(exported.metadata())

--- a/src/metatrain/experimental/nanopet/model.py
+++ b/src/metatrain/experimental/nanopet/model.py
@@ -17,6 +17,7 @@ from metatensor.torch.atomistic import (
 from ...utils.additive import ZBL, CompositionModel
 from ...utils.data import DatasetInfo, TargetInfo
 from ...utils.dtype import dtype_to_str
+from ...utils.metadata import append_metadata_references
 from ...utils.scaler import Scaler
 from .modules.encoder import Encoder
 from .modules.nef import (
@@ -49,6 +50,9 @@ class NanoPET(torch.nn.Module):
 
     __supported_devices__ = ["cuda", "cpu"]
     __supported_dtypes__ = [torch.float64, torch.float32]
+    __default_metadata__ = ModelMetadata(
+        references={"architecture": ["https://arxiv.org/abs/2305.19302v3"]}
+    )
 
     component_labels: Dict[str, List[List[Labels]]]
 
@@ -523,7 +527,9 @@ class NanoPET(torch.nn.Module):
 
         return model
 
-    def export(self) -> MetatensorAtomisticModel:
+    def export(
+        self, metadata: Optional[ModelMetadata] = None
+    ) -> MetatensorAtomisticModel:
         dtype = next(self.parameters()).dtype
         if dtype not in self.__supported_dtypes__:
             raise ValueError(f"unsupported dtype {self.dtype} for NanoPET")
@@ -548,7 +554,12 @@ class NanoPET(torch.nn.Module):
             dtype=dtype_to_str(dtype),
         )
 
-        return MetatensorAtomisticModel(self.eval(), ModelMetadata(), capabilities)
+        if metadata is None:
+            metadata = ModelMetadata()
+
+        append_metadata_references(metadata, self.__default_metadata__)
+
+        return MetatensorAtomisticModel(self.eval(), metadata, capabilities)
 
     def _add_output(self, target_name: str, target_info: TargetInfo) -> None:
         # one output shape for each tensor block, grouped by target (i.e. tensormap)

--- a/src/metatrain/experimental/nanopet/tests/test_exported.py
+++ b/src/metatrain/experimental/nanopet/tests/test_exported.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from metatensor.torch.atomistic import ModelEvaluationOptions, System
+from metatensor.torch.atomistic import ModelEvaluationOptions, ModelMetadata, System
 
 from metatrain.experimental.nanopet import NanoPET
 from metatrain.utils.data import DatasetInfo
@@ -28,7 +28,11 @@ def test_to(device, dtype):
         },
     )
     model = NanoPET(MODEL_HYPERS, dataset_info).to(dtype=dtype)
-    exported = model.export()
+
+    exported = model.export(metadata=ModelMetadata(name="test"))
+
+    # test correct metadata
+    assert "This is the test model" in str(exported.metadata())
 
     exported.to(device=device)
 

--- a/src/metatrain/experimental/pet/tests/test_exported.py
+++ b/src/metatrain/experimental/pet/tests/test_exported.py
@@ -3,6 +3,7 @@ import torch
 from metatensor.torch.atomistic import (
     ModelCapabilities,
     ModelEvaluationOptions,
+    ModelMetadata,
     ModelOutput,
     System,
 )
@@ -54,7 +55,11 @@ def test_to(device):
         supported_devices=["cpu", "cuda"],
     )
 
-    exported = model.export()
+    exported = model.export(metadata=ModelMetadata(name="test"))
+
+    # test correct metadata
+    assert "This is the test model" in str(exported.metadata())
+
     exported.to(device=device, dtype=dtype)
 
     system = System(

--- a/src/metatrain/experimental/soap_bpnn/model.py
+++ b/src/metatrain/experimental/soap_bpnn/model.py
@@ -20,6 +20,7 @@ from metatrain.utils.data.dataset import DatasetInfo
 
 from ...utils.additive import ZBL, CompositionModel
 from ...utils.dtype import dtype_to_str
+from ...utils.metadata import append_metadata_references
 from ...utils.scaler import Scaler
 from .spherical import TensorBasis
 
@@ -120,6 +121,17 @@ class MLPHeadMap(ModuleMap):
 class SoapBpnn(torch.nn.Module):
     __supported_devices__ = ["cuda", "cpu"]
     __supported_dtypes__ = [torch.float64, torch.float32]
+    __default_metadata__ = ModelMetadata(
+        references={
+            "implementation": [
+                "rascaline: https://github.com/Luthaf/rascaline",
+            ],
+            "architecture": [
+                "SOAP: https://doi.org/10.1002/qua.24927",
+                "BPNN: https://link.aps.org/doi/10.1103/PhysRevLett.98.146401",
+            ],
+        }
+    )
 
     component_labels: Dict[str, List[List[Labels]]]  # torchscript needs this
 
@@ -451,7 +463,9 @@ class SoapBpnn(torch.nn.Module):
 
         return model
 
-    def export(self) -> MetatensorAtomisticModel:
+    def export(
+        self, metadata: Optional[ModelMetadata] = None
+    ) -> MetatensorAtomisticModel:
         dtype = next(self.parameters()).dtype
         if dtype not in self.__supported_dtypes__:
             raise ValueError(f"unsupported dtype {self.dtype} for SoapBpnn")
@@ -476,7 +490,12 @@ class SoapBpnn(torch.nn.Module):
             dtype=dtype_to_str(dtype),
         )
 
-        return MetatensorAtomisticModel(self.eval(), ModelMetadata(), capabilities)
+        if metadata is None:
+            metadata = ModelMetadata()
+
+        append_metadata_references(metadata, self.__default_metadata__)
+
+        return MetatensorAtomisticModel(self.eval(), metadata, capabilities)
 
     def _add_output(self, target_name: str, target: TargetInfo) -> None:
         # register bases of spherical tensors (TensorBasis)

--- a/src/metatrain/experimental/soap_bpnn/tests/test_exported.py
+++ b/src/metatrain/experimental/soap_bpnn/tests/test_exported.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from metatensor.torch.atomistic import ModelEvaluationOptions, System
+from metatensor.torch.atomistic import ModelEvaluationOptions, ModelMetadata, System
 
 from metatrain.experimental.soap_bpnn import SoapBpnn
 from metatrain.utils.data import DatasetInfo
@@ -26,7 +26,10 @@ def test_to(device, dtype):
         targets={"energy": get_energy_target_info({"unit": "eV"})},
     )
     model = SoapBpnn(MODEL_HYPERS, dataset_info).to(dtype=dtype)
-    exported = model.export()
+    exported = model.export(metadata=ModelMetadata(name="test"))
+
+    # test correct metadata
+    assert "This is the test model" in str(exported.metadata())
 
     exported.to(device=device)
 

--- a/src/metatrain/utils/metadata.py
+++ b/src/metatrain/utils/metadata.py
@@ -1,0 +1,22 @@
+import json
+
+from metatensor.torch.atomistic import ModelMetadata
+
+
+def append_metadata_references(self: ModelMetadata, other: ModelMetadata) -> None:
+    """Append ``references`` to an existing ModelMetadata object.
+
+    :param self: The metadata object to be appeneded.
+    :param other: The metadata object to update with.
+    """
+
+    self_dict = json.loads(self._get_method("__getstate__")())
+    other_dict = json.loads(other._get_method("__getstate__")())
+
+    for key, values in other_dict["references"].items():
+        if key not in self_dict["references"]:
+            self_dict["references"][key] = values
+        else:
+            self_dict["references"][key] += values
+
+    self._get_method("__setstate__")(json.dumps(self_dict))

--- a/tests/utils/test_metadata.py
+++ b/tests/utils/test_metadata.py
@@ -1,0 +1,39 @@
+import json
+
+from metatensor.torch.atomistic import ModelMetadata
+
+from metatrain.utils.metadata import append_metadata_references
+
+
+def test_append_metadata_new_keys():
+    self_meta = ModelMetadata(references={"implementation": ["ref1"]})
+    other_meta = ModelMetadata(references={"architecture": ["ref2"]})
+
+    append_metadata_references(self_meta, other_meta)
+
+    result = json.loads(self_meta._get_method("__getstate__")())
+    assert result["references"]["implementation"] == ["ref1"]
+    assert result["references"]["architecture"] == ["ref2"]
+
+
+def test_append_metadata_existing_keys():
+    self_meta = ModelMetadata(references={"implementation": ["ref1"]})
+    other_meta = ModelMetadata(references={"implementation": ["ref2"]})
+
+    append_metadata_references(self_meta, other_meta)
+
+    result = json.loads(self_meta._get_method("__getstate__")())
+    assert result["references"]["implementation"] == ["ref1", "ref2"]
+
+
+def test_append_metadata_mixed_keys():
+    self_meta = ModelMetadata(references={"implementation": ["ref1"]})
+    other_meta = ModelMetadata(
+        references={"implementation": ["ref2"], "architecture": ["ref3"]}
+    )
+
+    append_metadata_references(self_meta, other_meta)
+
+    result = json.loads(self_meta._get_method("__getstate__")())
+    assert result["references"]["implementation"] == ["ref1", "ref2"]
+    assert result["references"]["architecture"] == ["ref3"]


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

This PR allows users to inject metadata about their trained models when they export the checkpoints.

On the lower end the `export` method of all architectures was altered to allow an (optional) argument passing an 
`ModelMetadata` instance. This instance will be extended by some metadata that is defined by the architecture developer.

For the CLI and Python interface the `export` method now contains an additional flag parsing a yaml file that contains metadata. 

@DavideTisi, @frostedoyster can you maybe provide references you would like me to put for GAP, SOAP-BPNN and PET etc. THANKS!

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--481.org.readthedocs.build/en/481/

<!-- readthedocs-preview metatrain end -->