### PR TITLE
Change metatensor serialization format to `.npz`

### DIFF
--- a/src/metatrain/utils/data/writers/__init__.py
+++ b/src/metatrain/utils/data/writers/__init__.py
@@ -8,7 +8,7 @@ from .metatensor import write_mts
 from .xyz import write_xyz
 
 
-PREDICTIONS_WRITERS = {".xyz": write_xyz, ".mts": write_mts}
+PREDICTIONS_WRITERS = {".xyz": write_xyz, ".npz": write_mts}
 """:py:class:`dict`: dictionary mapping file suffixes to a prediction writers"""
 
 

--- a/src/metatrain/utils/data/writers/metatensor.py
+++ b/src/metatrain/utils/data/writers/metatensor.py
@@ -14,7 +14,7 @@ def write_mts(
     capabilities: ModelCapabilities,
     predictions: Dict[str, TensorMap],
 ) -> None:
-    """A metatensor-format prediction writer. Writes the predictions to `.mts` files.
+    """A metatensor-format prediction writer. Writes the predictions to `.npz` files.
 
     :param filename: name of the file to save to.
     :param systems: structures to be written to the file (not written by this writer).
@@ -25,6 +25,6 @@ def write_mts(
     filename_base = Path(filename).stem
     for prediction_name, prediction_tmap in predictions.items():
         save(
-            filename_base + "_" + prediction_name + ".mts",
+            filename_base + "_" + prediction_name + ".npz",
             prediction_tmap.to("cpu").to(torch.float64),
         )

--- a/tests/utils/data/test_writers.py
+++ b/tests/utils/data/test_writers.py
@@ -198,7 +198,7 @@ def test_write_xyz_cell(monkeypatch, tmp_path):
         assert atoms.info["virial"].shape == (3, 3)
 
 
-@pytest.mark.parametrize("filename", ("test_output.xyz", "test_output.mts"))
+@pytest.mark.parametrize("filename", ("test_output.xyz", "test_output.npz"))
 @pytest.mark.parametrize("fileformat", (None, "same_as_filename"))
 @pytest.mark.parametrize("cell", (None, torch.eye(3)))
 def test_write_predictions(filename, fileformat, cell, monkeypatch, tmp_path):
@@ -224,15 +224,15 @@ def test_write_predictions(filename, fileformat, cell, monkeypatch, tmp_path):
             if cell is not None:
                 assert frame.info["stress"].shape == (3, 3)
 
-    elif filename.endswith(".mts"):
-        tensormap = metatensor.torch.load(filename.split(".")[0] + "_energy.mts")
+    elif filename.endswith(".npz"):
+        tensormap = metatensor.torch.load(filename.split(".")[0] + "_energy.npz")
         assert tensormap.block().values.shape == (2, 1)
         assert tensormap.block().gradient("positions").values.shape == (4, 3, 1)
         if cell is not None:
             assert tensormap.block().gradient("strain").values.shape == (2, 3, 3, 1)
 
     else:
-        ValueError("This test only does `.xyz` and `.mts`")
+        ValueError("This test only does `.xyz` and `.npz`")
 
 
 def test_write_predictions_unknown_fileformat():


### PR DESCRIPTION
This fixes a mistake in #476, where we were saving `TensorMap` object as `.mts`, while in reality `metatensor-torch` 0.6.3 still wants `.npz`.


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--483.org.readthedocs.build/en/483/

<!-- readthedocs-preview metatrain end -->