### PR TITLE
Add support for ase >= 3.23 and Python 3.13

### DIFF
--- a/.github/workflows/architecture-tests.yml
+++ b/.github/workflows/architecture-tests.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - run: pip install tox
 
     - name: run architecture tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - run: pip install tox
 
     - name: Test build integrity

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
       - name: setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: install dependencies
         run: python -m pip install tox
       - name: build documentation

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - run: pip install tox
 
     - name: Lint the code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     - name: setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - run: python -m pip install tox
     - name: Build package
       run: tox -e build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,12 +14,12 @@ jobs:
           - os: ubuntu-22.04
             python-version: "3.9"
           - os: ubuntu-22.04
-            python-version: "3.12"
+            python-version: "3.13"
           - os: macos-14
-            python-version: "3.12"
+            python-version: "3.13"
           # To be restored once we figure out the issue with the windows build
           # - os: windows-2019
-          #   python-version: "3.12"
+          #   python-version: "3.13"
 
     runs-on: ${{ matrix.os }}
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.13"
     rust: "1.75"
   jobs:
     pre_build:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,5 @@ sphinx >= 7
 sphinxcontrib-bibtex
 sphinx-gallery
 sphinx-toggleprompt
-setuptools  # required for sphinxcontrib-bibtex together with Python 3.12
+setuptools  # required for sphinxcontrib-bibtex together with Python 3.13
 tomli

--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -12,8 +12,10 @@ Unreleased
 
 .. Possible sections for each release:
 
-.. Added
-.. #####
+Added
+#####
+
+- Added support for Python 3.13 and ase >= 3.23
 
 .. Fixed
 .. #####

--- a/docs/src/dev-docs/utils/data/readers.rst
+++ b/docs/src/dev-docs/utils/data/readers.rst
@@ -44,6 +44,7 @@ ASE
 
 This section describes the parsers for the ASE library.
 
+.. autofunction:: metatrain.utils.data.readers.ase.read
 .. autofunction:: metatrain.utils.data.readers.ase.read_systems
 .. autofunction:: metatrain.utils.data.readers.ase.read_energy
 .. autofunction:: metatrain.utils.data.readers.ase.read_generic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,16 +9,14 @@ description = "Training and evaluating machine learning models for atomistic sys
 authors = [{name = "metatrain developers"}]
 
 dependencies = [
-    "ase < 3.23.0",
+    "ase",
     "metatensor-learn==0.3.1",
     "metatensor-operations==0.3.1",
     "metatensor-torch==0.7.2",
     "jsonschema",
     "omegaconf",
     "python-hostlist",
-    "torch",
     "vesin",
-    "numpy < 2.0.0"
 ]
 
 keywords = ["machine learning", "molecular modeling"]
@@ -44,7 +42,7 @@ homepage = "https://metatensor.github.io/metatrain"
 documentation = "https://metatensor.github.io/metatrain"
 repository = "https://github.com/metatensor/metatrain"
 issues = "https://github.com/metatensor/metatrain/issues"
-changelog = "https://metatensor.github.io/metatrain/latest/references/changelog.html"
+changelog = "https://metatensor.github.io/metatrain/latest/dev-docs/changelog.html"
 
 [project.scripts]
 mtt = "metatrain.__main__:main"
@@ -130,7 +128,7 @@ follow_imports = 'skip'
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
-# ignore" a bunch of internal warnings with Python 3.12 and PyTorch
+# ignore" a bunch of internal warnings with Python 3.13 and PyTorch
 filterwarnings = [
     "ignore:ast.Str is deprecated and will be removed in Python 3.14:DeprecationWarning",
     "ignore:Attribute s is deprecated and will be removed in Python 3.14:DeprecationWarning",

--- a/src/metatrain/gap/tests/test_regression.py
+++ b/src/metatrain/gap/tests/test_regression.py
@@ -1,7 +1,6 @@
 import copy
 import random
 
-import ase.io
 import metatensor.torch
 import numpy as np
 import torch
@@ -10,6 +9,7 @@ from omegaconf import OmegaConf
 from metatrain.gap import GAP, Trainer
 from metatrain.utils.data import Dataset, DatasetInfo
 from metatrain.utils.data.readers import read_systems, read_targets
+from metatrain.utils.data.readers.ase import read
 from metatrain.utils.data.target_info import get_energy_target_info
 
 from . import DATASET_ETHANOL_PATH, DATASET_PATH, DEFAULT_HYPERS
@@ -90,7 +90,7 @@ def test_regression_train_and_invariance():
     assert torch.allclose(output["mtt::U0"].block().values, expected_output, rtol=0.3)
 
     # Tests that the model is rotationally invariant
-    system = ase.io.read(DATASET_PATH)
+    system = read(DATASET_PATH)
     system.numbers = np.ones(len(system.numbers))
 
     original_system = copy.deepcopy(system)
@@ -167,7 +167,7 @@ def test_ethanol_regression_train_and_invariance():
 
     # Predict on the first five systems
     output = gap(systems[:5], {"energy": gap.outputs["energy"]})
-    data = ase.io.read(DATASET_ETHANOL_PATH, ":5", format="extxyz")
+    data = read(DATASET_ETHANOL_PATH, ":5", format="extxyz")
 
     expected_output = torch.tensor([[i.info["energy"]] for i in data])
     assert torch.allclose(output["energy"].block().values, expected_output, rtol=0.1)
@@ -176,7 +176,7 @@ def test_ethanol_regression_train_and_invariance():
     # expected_forces = torch.vstack([torch.Tensor(i.arrays["forces"]) for i in data])
 
     # Tests that the model is rotationally invariant
-    system = ase.io.read(DATASET_ETHANOL_PATH)
+    system = read(DATASET_ETHANOL_PATH)
 
     original_system = copy.deepcopy(system)
     system.rotate(48, "y")

--- a/src/metatrain/pet/tests/test_pet_compatibility.py
+++ b/src/metatrain/pet/tests/test_pet_compatibility.py
@@ -1,4 +1,3 @@
-import ase
 import pytest
 import torch
 from metatensor.torch.atomistic import (
@@ -18,6 +17,7 @@ from metatrain.pet.modules.pet import PET
 from metatrain.pet.utils import systems_to_batch_dict
 from metatrain.utils.architectures import get_default_hypers
 from metatrain.utils.data import DatasetInfo
+from metatrain.utils.data.readers.ase import read
 from metatrain.utils.data.target_info import get_energy_target_info
 from metatrain.utils.neighbor_lists import get_system_with_neighbor_lists
 
@@ -57,7 +57,7 @@ def test_batch_dicts_compatibility(cutoff):
     """Tests that the batch dict computed with internal MTM routines
     is consitent with PET implementation."""
 
-    structure = ase.io.read(DATASET_PATH)
+    structure = read(DATASET_PATH)
     atomic_types = sorted(set(structure.numbers))
     system = systems_to_torch(structure)
     options = NeighborListOptions(cutoff=cutoff, full_list=True, strict=True)
@@ -93,7 +93,7 @@ def test_predictions_compatibility(cutoff):
     """Tests that predictions of the MTM implemetation of PET
     are consistent with the predictions of the original PET implementation."""
 
-    structure = ase.io.read(DATASET_PATH)
+    structure = read(DATASET_PATH)
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom",

--- a/src/metatrain/soap_bpnn/tests/test_equivariance.py
+++ b/src/metatrain/soap_bpnn/tests/test_equivariance.py
@@ -1,6 +1,5 @@
 import copy
 
-import ase.io
 import numpy as np
 import pytest
 import torch
@@ -8,6 +7,7 @@ from metatensor.torch.atomistic import System, systems_to_torch
 
 from metatrain.soap_bpnn import SoapBpnn
 from metatrain.utils.data import DatasetInfo
+from metatrain.utils.data.readers.ase import read
 from metatrain.utils.data.target_info import (
     get_energy_target_info,
     get_generic_target_info,
@@ -31,7 +31,7 @@ def test_rotational_invariance():
     )
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
 
-    system = ase.io.read(DATASET_PATH)
+    system = read(DATASET_PATH)
     original_system = copy.deepcopy(system)
     system.rotate(48, "y")
 
@@ -77,7 +77,7 @@ def test_equivariance_rotations(o3_lambda, o3_sigma):
     )
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
 
-    system = ase.io.read(DATASET_PATH)
+    system = read(DATASET_PATH)
     original_system = systems_to_torch(system)
     rotation = get_random_rotation()
     rotated_system = rotate_system(original_system, rotation)
@@ -128,7 +128,7 @@ def test_equivariance_inversion(o3_lambda, o3_sigma):
     )
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
 
-    system = ase.io.read(DATASET_PATH)
+    system = read(DATASET_PATH)
     original_system = systems_to_torch(system)
     inverted_system = System(
         positions=original_system.positions * (-1),

--- a/tests/cli/dump_spherical_targets.py
+++ b/tests/cli/dump_spherical_targets.py
@@ -1,7 +1,8 @@
-import ase.io
 import numpy as np
 import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
+
+from metatrain.utils.data.readers.ase import read
 
 
 def l0_components_from_matrix(A):
@@ -30,7 +31,7 @@ def dump_spherical_targets(path_in, path_out, with_scalar_part=False):
     # spherical coordinates, and saves them in metatensor format (suitable for
     # training a model with spherical targets).
 
-    structures = ase.io.read(path_in, ":")
+    structures = read(path_in, ":")
 
     polarizabilities_l2 = np.array(
         [

--- a/tests/cli/test_eval_model.py
+++ b/tests/cli/test_eval_model.py
@@ -3,7 +3,6 @@ import shutil
 import subprocess
 from pathlib import Path
 
-import ase.io
 import pytest
 import torch
 from omegaconf import OmegaConf
@@ -11,6 +10,7 @@ from omegaconf import OmegaConf
 from metatrain.cli.eval import eval_model
 from metatrain.soap_bpnn import __model__
 from metatrain.utils.data import DatasetInfo
+from metatrain.utils.data.readers.ase import read
 from metatrain.utils.data.target_info import get_energy_target_info
 
 from . import EVAL_OPTIONS_PATH, MODEL_HYPERS, MODEL_PATH, RESOURCES_PATH
@@ -74,7 +74,7 @@ def test_eval(monkeypatch, tmp_path, caplog, model_name, options):
     assert "ms per atom" in log
 
     # Test file is written predictions
-    frames = ase.io.read("foo.xyz", ":")
+    frames = read("foo.xyz", ":")
     frames[0].info["energy"]
 
 
@@ -106,7 +106,7 @@ def test_eval_batch_size(monkeypatch, tmp_path, caplog, model_name, options):
     assert "inaccurate average timings" in log
 
     # Test file is written predictions
-    frames = ase.io.read("foo.xyz", ":")
+    frames = read("foo.xyz", ":")
     frames[0].info["energy"]
 
 
@@ -153,7 +153,7 @@ def test_eval_multi_dataset(monkeypatch, tmp_path, caplog, model, options):
 
     # Test file is written predictions
     for i in range(2):
-        frames = ase.io.read(f"foo_{i}.xyz", ":")
+        frames = read(f"foo_{i}.xyz", ":")
         frames[0].info["energy"]
 
 

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -17,6 +17,7 @@ from omegaconf import OmegaConf
 from metatrain import RANDOM_SEED
 from metatrain.cli.train import _process_continue_from, train_model
 from metatrain.utils.data import DiskDatasetWriter
+from metatrain.utils.data.readers.ase import read
 from metatrain.utils.errors import ArchitectureError
 from metatrain.utils.neighbor_lists import get_system_with_neighbor_lists
 
@@ -209,7 +210,7 @@ def test_train_explicit_validation_test(
     monkeypatch.chdir(tmp_path)
     caplog.set_level(logging.DEBUG)
 
-    systems = ase.io.read(DATASET_PATH_QM9, ":")
+    systems = read(DATASET_PATH_QM9, ":")
 
     ase.io.write("qm9_reduced_100.xyz", systems[:50])
 
@@ -252,11 +253,6 @@ def test_train_multiple_datasets(monkeypatch, tmp_path, options):
 
     systems_qm9 = ase.io.read(DATASET_PATH_QM9, ":")
     systems_ethanol = ase.io.read(DATASET_PATH_ETHANOL, ":")
-
-    # delete calculator to avoid warnings during writing. Remove once updated to ase >=
-    # 3.23.0
-    for atoms in systems_ethanol:
-        atoms.calc = None
 
     ase.io.write("qm9_reduced_100.xyz", systems_qm9[:50])
     ase.io.write("ethanol_reduced_100.xyz", systems_ethanol[:50])
@@ -356,7 +352,7 @@ def test_unit_check_is_performed(
     """Test that error is raised if units are inconsistent between the datasets."""
     monkeypatch.chdir(tmp_path)
 
-    systems = ase.io.read(DATASET_PATH_QM9, ":")
+    systems = read(DATASET_PATH_QM9, ":")
 
     ase.io.write("qm9_reduced_100.xyz", systems[:50])
 
@@ -387,7 +383,7 @@ def test_inconsistent_number_of_datasets(
     i.e one train dataset but two validation datasets. Same for the test dataset."""
     monkeypatch.chdir(tmp_path)
 
-    systems = ase.io.read(DATASET_PATH_QM9, ":")
+    systems = read(DATASET_PATH_QM9, ":")
 
     ase.io.write("qm9_reduced_100.xyz", systems[:50])
 
@@ -687,7 +683,7 @@ def test_train_disk_dataset(monkeypatch, tmp_path, options):
 
     disk_dataset_writer = DiskDatasetWriter("qm9_reduced_100.zip")
     for i in range(100):
-        frame = ase.io.read("qm9_reduced_100.xyz", index=i)
+        frame = read("qm9_reduced_100.xyz", index=i)
         system = systems_to_torch(frame, dtype=torch.float64)
         system = get_system_with_neighbor_lists(
             system,

--- a/tests/utils/data/test_readers_ase.py
+++ b/tests/utils/data/test_readers_ase.py
@@ -18,14 +18,15 @@ from metatrain.utils.data.readers.ase import (
 )
 
 
-def test_read_energies(monkeypatch, tmp_path):
+@pytest.mark.parametrize("key", ["true_energy", "energy"])
+def test_read_energies(monkeypatch, tmp_path, key):
     monkeypatch.chdir(tmp_path)
 
     filename = "systems.xyz"
     systems = ase_systems()
     ase.io.write(filename, systems)
 
-    results = _read_energy_ase(filename, key="true_energy")
+    results = _read_energy_ase(filename, key=key)
 
     assert type(results) is list
     assert len(results) == len(systems)
@@ -36,14 +37,15 @@ def test_read_energies(monkeypatch, tmp_path):
         assert result.properties == Labels("energy", torch.tensor([[0]]))
 
 
-def test_read_forces(monkeypatch, tmp_path):
+@pytest.mark.parametrize("key", ["true_forces", "forces"])
+def test_read_forces(monkeypatch, tmp_path, key):
     monkeypatch.chdir(tmp_path)
 
     filename = "systems.xyz"
     systems = ase_systems()
     ase.io.write(filename, systems)
 
-    results = _read_forces_ase(filename, key="forces")
+    results = _read_forces_ase(filename, key=key)
 
     assert type(results) is list
     assert len(results) == len(systems)
@@ -56,15 +58,16 @@ def test_read_forces(monkeypatch, tmp_path):
         assert result.properties == Labels("energy", torch.tensor([[0]]))
 
 
+@pytest.mark.parametrize("key", ["stress", "stress-3x3"])
 @pytest.mark.parametrize("reader_func", [_read_stress_ase, _read_virial_ase])
-def test_read_stress_virial(reader_func, monkeypatch, tmp_path):
+def test_read_stress_virial(reader_func, monkeypatch, tmp_path, key):
     monkeypatch.chdir(tmp_path)
 
     filename = "systems.xyz"
     systems = ase_systems()
     ase.io.write(filename, systems)
 
-    results = reader_func(filename, key="stress-3x3")
+    results = reader_func(filename, key=key)
 
     assert type(results) is list
     assert len(results) == len(systems)

--- a/tests/utils/data/test_writers.py
+++ b/tests/utils/data/test_writers.py
@@ -1,12 +1,12 @@
 from typing import Dict, List, Tuple
 
-import ase.io
 import metatensor.torch
 import pytest
 import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
 from metatensor.torch.atomistic import ModelCapabilities, ModelOutput, System
 
+from metatrain.utils.data.readers.ase import read
 from metatrain.utils.data.writers import write_predictions, write_xyz
 
 
@@ -80,7 +80,7 @@ def test_write_xyz(monkeypatch, tmp_path):
     write_xyz(filename, systems, capabilities, predictions)
 
     # Read the file and verify its contents
-    frames = ase.io.read(filename, index=":")
+    frames = read(filename, index=":")
     assert len(frames) == len(systems)
     for i, atoms in enumerate(frames):
         assert atoms.info["energy"] == float(predictions["energy"].block().values[i, 0])
@@ -123,7 +123,7 @@ def test_write_components_and_properties_xyz(monkeypatch, tmp_path):
     write_xyz(filename, systems, capabilities, predictions)
 
     # Read the file and verify its contents
-    frames = ase.io.read(filename, index=":")
+    frames = read(filename, index=":")
     assert len(frames) == len(systems)
     for atoms in frames:
         assert atoms.info["dos"].shape == (3, 100)
@@ -168,7 +168,7 @@ def test_write_components_and_properties_xyz_per_atom(monkeypatch, tmp_path):
     write_xyz(filename, systems, capabilities, predictions)
 
     # Read the file and verify its contents
-    frames = ase.io.read(filename, index=":")
+    frames = read(filename, index=":")
     assert len(frames) == len(systems)
     for atoms in frames:
         assert atoms.arrays["dos"].shape == (2, 300)
@@ -187,7 +187,7 @@ def test_write_xyz_cell(monkeypatch, tmp_path):
     write_xyz(filename, systems, capabilities, predictions)
 
     # Read the file and verify its contents
-    frames = ase.io.read(filename, index=":")
+    frames = read(filename, index=":")
     for i, atoms in enumerate(frames):
         cell_actual = torch.tensor(atoms.cell.array, dtype=cell_expected.dtype)
         torch.testing.assert_close(cell_actual, cell_expected)
@@ -214,7 +214,7 @@ def test_write_predictions(filename, fileformat, cell, monkeypatch, tmp_path):
     )
 
     if filename.endswith(".xyz"):
-        frames = ase.io.read(filename, index=":")
+        frames = read(filename, index=":")
         assert len(frames) == len(systems)
         for i, frame in enumerate(frames):
             assert frame.info["energy"] == float(


### PR DESCRIPTION
Fixes #157


This marks the end of the crusade against `ase`.

I updated the logic to use the methods `get_potential_energy`, `get_forces` and `get_stress` if the keys are `"energy"`, `"forces"` or `"stress"`. We now support only ase >= 3.23!

This change also allows us to use Numpy > 2.0 and with this Python 3.13.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--497.org.readthedocs.build/en/497/

<!-- readthedocs-preview metatrain end -->