### PR TITLE
enable the use of ewald calculator

### DIFF
--- a/docs/src/architectures/nanopet.rst
+++ b/docs/src/architectures/nanopet.rst
@@ -104,8 +104,7 @@ The model-related hyperparameters are
   (faster for smaller systems); ``smearing``: the width of the Gaussian function used
   to approximate the charge distribution in Fourier space; ``kspace_resolution``: the
   spatial resolution of the Fourier-space used for calculating long-range interactions;
-  ``prefactor``: conversion factor from Gaussian units used in the long-range calculator
-  to user's units; ``interpolation_nodes``: the number of grid points used in spline
+  ``interpolation_nodes``: the number of grid points used in spline
   interpolation for the P3M method.
 
 training

--- a/docs/src/architectures/nanopet.rst
+++ b/docs/src/architectures/nanopet.rst
@@ -100,11 +100,13 @@ The model-related hyperparameters are
   dimensionality ``d_pet``.
 :param zbl: Whether to use the ZBL short-range repulsion as the baseline for the model
 :param long_range: Parameters related to long-range interactions. ``enable``: whether
-  to use long-range interactions. ``smearing``: the width of the Gaussian function used
-  to approximate the charge distribution in Fourier space; ``interpolation_nodes``: the
-  number of grid points used in spline interpolation for the P3M method;
-  ``mesh_spacing``: the resolution of the Fourier-space grid used for calculating
-  long-range interactions.
+  to use long-range interactions; ``use_ewald``: whether to use an Ewald calculator
+  (faster for smaller systems); ``smearing``: the width of the Gaussian function used
+  to approximate the charge distribution in Fourier space; ``kspace_resolution``: the
+  spatial resolution of the Fourier-space used for calculating long-range interactions;
+  ``prefactor``: conversion factor from Gaussian units used in the long-range calculator
+  to user's units; ``interpolation_nodes``: the number of grid points used in spline
+  interpolation for the P3M method.
 
 training
 ########

--- a/docs/src/architectures/soap-bpnn.rst
+++ b/docs/src/architectures/soap-bpnn.rst
@@ -89,8 +89,7 @@ model
   (faster for smaller systems); ``smearing``: the width of the Gaussian function used
   to approximate the charge distribution in Fourier space; ``kspace_resolution``: the
   spatial resolution of the Fourier-space used for calculating long-range interactions;
-  ``prefactor``: conversion factor from Gaussian units used in the long-range calculator
-  to user's units; ``interpolation_nodes``: the number of grid points used in spline
+  ``interpolation_nodes``: the number of grid points used in spline
   interpolation for the P3M method.
 
 soap

--- a/docs/src/architectures/soap-bpnn.rst
+++ b/docs/src/architectures/soap-bpnn.rst
@@ -85,11 +85,13 @@ model
   many neurons as the SOAP-BPNN (i.e. ``num_neurons_per_layer`` below).
 :param zbl: Whether to use the ZBL short-range repulsion as the baseline for the model
 :param long_range: Parameters related to long-range interactions. ``enable``: whether
-  to use long-range interactions. ``smearing``: the width of the Gaussian function used
-  to approximate the charge distribution in Fourier space; ``interpolation_nodes``: the
-  number of grid points used in spline interpolation for the P3M method;
-  ``mesh_spacing``: the resolution of the Fourier-space grid used for calculating
-  long-range interactions.
+  to use long-range interactions; ``use_ewald``: whether to use an Ewald calculator
+  (faster for smaller systems); ``smearing``: the width of the Gaussian function used
+  to approximate the charge distribution in Fourier space; ``kspace_resolution``: the
+  spatial resolution of the Fourier-space used for calculating long-range interactions;
+  ``prefactor``: conversion factor from Gaussian units used in the long-range calculator
+  to user's units; ``interpolation_nodes``: the number of grid points used in spline
+  interpolation for the P3M method.
 
 soap
 ^^^^

--- a/src/metatrain/experimental/nanopet/default-hypers.yaml
+++ b/src/metatrain/experimental/nanopet/default-hypers.yaml
@@ -16,7 +16,6 @@ architecture:
       use_ewald: false
       smearing: 1.4
       kspace_resolution: 1.33
-      prefactor: 1.0
       interpolation_nodes: 5
 
   training:

--- a/src/metatrain/experimental/nanopet/default-hypers.yaml
+++ b/src/metatrain/experimental/nanopet/default-hypers.yaml
@@ -13,9 +13,11 @@ architecture:
     zbl: False
     long_range: 
       enable: false
+      use_ewald: false
       smearing: 1.4
+      kspace_resolution: 1.33
+      prefactor: 1.0
       interpolation_nodes: 5
-      mesh_spacing: 1.33
 
   training:
     distributed: False

--- a/src/metatrain/experimental/nanopet/model.py
+++ b/src/metatrain/experimental/nanopet/model.py
@@ -139,7 +139,7 @@ class NanoPET(torch.nn.Module):
         if self.hypers["long_range"]["enable"]:
             self.long_range = True
             self.long_range_featurizer = LongRangeFeaturizer(
-                self.hypers["long_range"],
+                hypers=self.hypers["long_range"],
                 feature_dim=self.hypers["d_pet"],
                 neighbor_list_options=self.requested_nl,
             )

--- a/src/metatrain/experimental/nanopet/schema-hypers.json
+++ b/src/metatrain/experimental/nanopet/schema-hypers.json
@@ -55,9 +55,6 @@
             "kspace_resolution": {
               "type": "number"
             },
-            "prefactor": {
-              "type": "number"
-            },
             "interpolation_nodes": {
               "type": "integer"
             }

--- a/src/metatrain/experimental/nanopet/schema-hypers.json
+++ b/src/metatrain/experimental/nanopet/schema-hypers.json
@@ -46,14 +46,20 @@
             "enable": {
               "type": "boolean"
             },
+            "use_ewald": {
+              "type": "boolean"
+            },
             "smearing": {
+              "type": "number"
+            },
+            "kspace_resolution": {
+              "type": "number"
+            },
+            "prefactor": {
               "type": "number"
             },
             "interpolation_nodes": {
               "type": "integer"
-            },
-            "mesh_spacing": {
-              "type": "number"
             }
           }
         }

--- a/src/metatrain/soap_bpnn/default-hypers.yaml
+++ b/src/metatrain/soap_bpnn/default-hypers.yaml
@@ -34,7 +34,6 @@ architecture:
       use_ewald: false
       smearing: 1.4
       kspace_resolution: 1.33
-      prefactor: 1.0
       interpolation_nodes: 5
 
   training:

--- a/src/metatrain/soap_bpnn/default-hypers.yaml
+++ b/src/metatrain/soap_bpnn/default-hypers.yaml
@@ -31,9 +31,11 @@ architecture:
     zbl: false
     long_range: 
       enable: false
+      use_ewald: false
       smearing: 1.4
+      kspace_resolution: 1.33
+      prefactor: 1.0
       interpolation_nodes: 5
-      mesh_spacing: 1.33
 
   training:
     distributed: False

--- a/src/metatrain/soap_bpnn/schema-hypers.json
+++ b/src/metatrain/soap_bpnn/schema-hypers.json
@@ -141,9 +141,6 @@
             "kspace_resolution": {
               "type": "number"
             },
-            "prefactor": {
-              "type": "number"
-            },
             "interpolation_nodes": {
               "type": "integer"
             }

--- a/src/metatrain/soap_bpnn/schema-hypers.json
+++ b/src/metatrain/soap_bpnn/schema-hypers.json
@@ -132,14 +132,20 @@
             "enable": {
               "type": "boolean"
             },
+            "use_ewald": {
+              "type": "boolean"
+            },
             "smearing": {
+              "type": "number"
+            },
+            "kspace_resolution": {
+              "type": "number"
+            },
+            "prefactor": {
               "type": "number"
             },
             "interpolation_nodes": {
               "type": "integer"
-            },
-            "mesh_spacing": {
-              "type": "number"
             }
           }
         }

--- a/src/metatrain/utils/long_range.py
+++ b/src/metatrain/utils/long_range.py
@@ -20,22 +20,35 @@ class LongRangeFeaturizer(torch.nn.Module):
 
         try:
             from torchpme import CoulombPotential
-            from torchpme.calculators import Calculator, P3MCalculator
+            from torchpme.calculators import Calculator, EwaldCalculator, P3MCalculator
         except ImportError:
             raise ImportError(
                 "`torch-pme` is required for long-range models. "
                 "Please install it with `pip install torch-pme`."
             )
 
-        self.calculator = P3MCalculator(
-            potential=CoulombPotential(
-                smearing=hypers["smearing"],
-                exclusion_radius=neighbor_list_options.cutoff,
-            ),
-            interpolation_nodes=hypers["interpolation_nodes"],
-            full_neighbor_list=neighbor_list_options.full_list,
-            mesh_spacing=hypers["mesh_spacing"],
-        )
+        if hypers["use_ewald"]:
+            self.calculator = EwaldCalculator(
+                potential=CoulombPotential(
+                    smearing=hypers["smearing"],
+                    exclusion_radius=neighbor_list_options.cutoff,
+                ),
+                full_neighbor_list=neighbor_list_options.full_list,
+                lr_wavelength=hypers["kspace_resolution"],
+                prefactor=hypers["prefactor"],
+            )
+        else:
+            self.calculator = P3MCalculator(
+                potential=CoulombPotential(
+                    smearing=hypers["smearing"],
+                    exclusion_radius=neighbor_list_options.cutoff,
+                ),
+                interpolation_nodes=hypers["interpolation_nodes"],
+                full_neighbor_list=neighbor_list_options.full_list,
+                mesh_spacing=hypers["kspace_resolution"],
+                prefactor=hypers["prefactor"],
+            )
+
         self.direct_calculator = Calculator(
             potential=CoulombPotential(
                 smearing=None,

--- a/tests/utils/test_long_range.py
+++ b/tests/utils/test_long_range.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-import torchpme
 from metatensor.torch.atomistic import systems_to_torch
 
 from metatrain.experimental.nanopet import NanoPET
@@ -68,44 +67,4 @@ def test_long_range(periodicity, model_name, tmpdir):
         model(
             systems,
             {"energy": model.outputs["energy"]},
-        )
-
-
-@pytest.mark.parametrize("use_ewald", [True, False])
-@pytest.mark.parametrize("model_name", ["experimental.nanopet", "soap_bpnn"])
-def test_use_ewald(use_ewald, model_name, tmpdir):
-    """Tests that the Ewald calculator is used when use_ewald=True."""
-    structures = read(RESOURCES_PATH / "carbon_reduced_100.xyz", ":10")
-    systems = systems_to_torch(structures)
-
-    dataset_info = DatasetInfo(
-        length_unit="Angstrom",
-        atomic_types=[1, 6, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
-    )
-
-    hypers = get_default_hypers(model_name)
-    hypers["model"]["long_range"]["enable"] = True
-    hypers["model"]["long_range"]["use_ewald"] = use_ewald
-    if model_name == "soap_bpnn":
-        model = SoapBpnn(hypers["model"], dataset_info)
-    else:
-        model = NanoPET(hypers["model"], dataset_info)
-    requested_nls = get_requested_neighbor_lists(model)
-
-    systems = [
-        get_system_with_neighbor_lists(system, requested_nls) for system in systems
-    ]
-    model.train()
-    model(
-        systems,
-        {"energy": model.outputs["energy"]},
-    )
-    if use_ewald:
-        assert isinstance(
-            model.long_range_featurizer.calculator, torchpme.calculators.EwaldCalculator
-        )
-    else:
-        assert isinstance(
-            model.long_range_featurizer.calculator, torchpme.calculators.P3MCalculator
         )

--- a/tests/utils/test_long_range.py
+++ b/tests/utils/test_long_range.py
@@ -1,7 +1,9 @@
 import pytest
 import torch
+import torchpme
 from metatensor.torch.atomistic import systems_to_torch
 
+from metatrain.experimental.nanopet import NanoPET
 from metatrain.soap_bpnn import SoapBpnn
 from metatrain.utils.architectures import get_default_hypers
 from metatrain.utils.data import DatasetInfo
@@ -18,7 +20,9 @@ from . import RESOURCES_PATH
 
 
 @pytest.mark.parametrize("periodicity", [True, False])
-def test_long_range(periodicity, tmpdir):
+# we only have torchPME integration for nanoPET and SOAP-BPNN for now
+@pytest.mark.parametrize("model_name", ["experimental.nanopet", "soap_bpnn"])
+def test_long_range(periodicity, model_name, tmpdir):
     """Tests that the long-range module can predict successfully."""
 
     if periodicity:
@@ -33,22 +37,18 @@ def test_long_range(periodicity, tmpdir):
         targets={"energy": get_energy_target_info({"unit": "eV"})},
     )
 
-    hypers = get_default_hypers("soap_bpnn")
+    hypers = get_default_hypers(model_name)
     hypers["model"]["long_range"]["enable"] = True
-    model = SoapBpnn(hypers["model"], dataset_info)
+    if model_name == "soap_bpnn":
+        model = SoapBpnn(hypers["model"], dataset_info)
+    else:
+        model = NanoPET(hypers["model"], dataset_info)
     requested_nls = get_requested_neighbor_lists(model)
 
     systems = [
         get_system_with_neighbor_lists(system, requested_nls) for system in systems
     ]
 
-    model(
-        systems,
-        {"energy": model.outputs["energy"]},
-    )
-
-    # now torchscripted
-    model = torch.jit.script(model)
     model(
         systems,
         {"energy": model.outputs["energy"]},
@@ -68,4 +68,44 @@ def test_long_range(periodicity, tmpdir):
         model(
             systems,
             {"energy": model.outputs["energy"]},
+        )
+
+
+@pytest.mark.parametrize("use_ewald", [True, False])
+@pytest.mark.parametrize("model_name", ["experimental.nanopet", "soap_bpnn"])
+def test_use_ewald(use_ewald, model_name, tmpdir):
+    """Tests that the Ewald calculator is used when use_ewald=True."""
+    structures = read(RESOURCES_PATH / "carbon_reduced_100.xyz", ":10")
+    systems = systems_to_torch(structures)
+
+    dataset_info = DatasetInfo(
+        length_unit="Angstrom",
+        atomic_types=[1, 6, 8],
+        targets={"energy": get_energy_target_info({"unit": "eV"})},
+    )
+
+    hypers = get_default_hypers(model_name)
+    hypers["model"]["long_range"]["enable"] = True
+    hypers["model"]["long_range"]["use_ewald"] = use_ewald
+    if model_name == "soap_bpnn":
+        model = SoapBpnn(hypers["model"], dataset_info)
+    else:
+        model = NanoPET(hypers["model"], dataset_info)
+    requested_nls = get_requested_neighbor_lists(model)
+
+    systems = [
+        get_system_with_neighbor_lists(system, requested_nls) for system in systems
+    ]
+    model.train()
+    model(
+        systems,
+        {"energy": model.outputs["energy"]},
+    )
+    if use_ewald:
+        assert isinstance(
+            model.long_range_featurizer.calculator, torchpme.calculators.EwaldCalculator
+        )
+    else:
+        assert isinstance(
+            model.long_range_featurizer.calculator, torchpme.calculators.P3MCalculator
         )


### PR DESCRIPTION
Based on training results after #500 , @PicoCentauri and I have discussed about adding the option to use the Ewald calculator as the default PME calculator seems to be 2-3x slower at moderately sized systems (~100 atoms).

I have added a `use_ewald` flag which defines the calculator used (Ewald or P3M). As the spatial resolution is defined by different parameters in Ewald and P3M (`lr_wavelength` and `mesh_spacing`), I added a unified `kspace_resolution` parameter that controls this.  

P.S. Maybe we should also add something on how to set up the torch-pme calculators (choosing them, tuning/selecting hypers etc) or just add a reference to https://github.com/lab-cosmo/torch-pme

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - ~~[ ] Issue referenced (for PRs that solve an issue)?~~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--510.org.readthedocs.build/en/510/

<!-- readthedocs-preview metatrain end -->