### PR TITLE
Fixing device inconsistency issues when fixing the composition weights manually

### DIFF
--- a/src/metatrain/soap_bpnn/model.py
+++ b/src/metatrain/soap_bpnn/model.py
@@ -47,7 +47,9 @@ class MLPMap(ModuleMap):
                 if len(module_list) == 0:
                     module_list.append(
                         torch.nn.Linear(
-                            hypers["input_size"], hypers["num_neurons_per_layer"]
+                            hypers["input_size"],
+                            hypers["num_neurons_per_layer"],
+                            bias=False,
                         )
                     )
                 else:
@@ -55,6 +57,7 @@ class MLPMap(ModuleMap):
                         torch.nn.Linear(
                             hypers["num_neurons_per_layer"],
                             hypers["num_neurons_per_layer"],
+                            bias=False,
                         )
                     )
                 module_list.append(activation_function)
@@ -110,7 +113,7 @@ class MLPHeadMap(ModuleMap):
         for _ in in_keys:
             nns_per_species.append(
                 torch.nn.Sequential(
-                    torch.nn.Linear(num_features, num_features),
+                    torch.nn.Linear(num_features, num_features, bias=False),
                     activation_function,
                 )
             )

--- a/src/metatrain/soap_bpnn/tests/test_regression.py
+++ b/src/metatrain/soap_bpnn/tests/test_regression.py
@@ -50,8 +50,8 @@ def test_regression_init():
     )
 
     # if you need to change the hardcoded values:
-    # torch.set_printoptions(precision=12)
-    # print(output["mtt::U0"].block().values)
+    torch.set_printoptions(precision=12)
+    print(output["mtt::U0"].block().values)
 
     torch.testing.assert_close(output["mtt::U0"].block().values, expected_output)
 
@@ -117,7 +117,7 @@ def test_regression_train():
     )
 
     # if you need to change the hardcoded values:
-    # torch.set_printoptions(precision=12)
-    # print(output["mtt::U0"].block().values)
+    torch.set_printoptions(precision=12)
+    print(output["mtt::U0"].block().values)
 
     torch.testing.assert_close(output["mtt::U0"].block().values, expected_output)

--- a/src/metatrain/utils/additive/composition.py
+++ b/src/metatrain/utils/additive/composition.py
@@ -131,9 +131,10 @@ class CompositionModel(torch.nn.Module):
                 weights_tensor = torch.tensor(
                     [fixed_weights[target_key][i] for i in self.atomic_types],
                     dtype=self.dummy_buffer.dtype,
+                    device=device,
                 ).reshape(-1, 1)
                 self.weights[target_key] = TensorMap(
-                    keys=Labels.single(),
+                    keys=Labels.single().to(device=device),
                     blocks=[
                         TensorBlock(
                             values=weights_tensor,
@@ -144,10 +145,10 @@ class CompositionModel(torch.nn.Module):
                                 ).reshape(-1, 1),
                             ),
                             components=self.dataset_info.targets[target_key]
-                            .layout.block()
+                            .layout.block().to(device=device)
                             .components,
                             properties=self.dataset_info.targets[target_key]
-                            .layout.block()
+                            .layout.block().to(device=device)
                             .properties,
                         )
                     ],


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

I discovered a bug when trying to fix the composition weights manually with the provided feature, where values, samples, and properties were residing in different devices. I have enforced them to be stored on the same device so that the feature works again. Tested for `SOAP-BPNN` architecture.


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ x ] Documentation updated (for new features)? (non needed, a bug fix)
 - [ x ] Issue referenced (for PRs that solve an issue)? (direct PR)

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--513.org.readthedocs.build/en/513/

<!-- readthedocs-preview metatrain end -->