### PR TITLE
Don't copy model from temporary folder

### DIFF
--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -7,9 +7,6 @@ All notable changes to ``metatrain`` are documented here, following the `keep a
 changelog <https://keepachangelog.com/en/1.1.0/>`_ format. This project follows
 `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
-Unreleased
-----------
-
 .. Possible sections for each release:
 
 .. Fixed
@@ -23,6 +20,16 @@ Unreleased
 
 .. Removed
 .. #######
+
+Unreleased
+----------
+
+Changed
+#######
+
+- :func:`metatrain.util.io.load_model` does not copy a remote model to the current
+  directory.
+
 
 Version 2025.2 - 2025-03-11
 ---------------------------

--- a/docs/src/getting-started/checkpoints.rst
+++ b/docs/src/getting-started/checkpoints.rst
@@ -79,8 +79,8 @@ a file path.
     mtt export https://my.url.com/model.ckpt --output model.pt
 
 Downloading private HuggingFace models is also supported, by specifying the
-corresponding API token with the ``--huggingface_api_token`` flag or the
-``HF_TOKEN`` environment variable.
+corresponding API token with the ``--token`` flag or the ``HF_TOKEN`` environment
+variable.
 
 Keep in mind that a checkpoint (``.ckpt``) is only a temporary file, which can have
 several dependencies and may become unusable if the corresponding architecture is

--- a/src/metatrain/share/metatrain-completion.bash
+++ b/src/metatrain/share/metatrain-completion.bash
@@ -53,7 +53,7 @@ print(' '.join(find_all_architectures()))
           fi
           ;;
       esac
-      local opts="-h --help -o --output -m --metadata --huggingface_api_token"
+      local opts="-h --help -o --output -m --metadata --token"
       COMPREPLY=( $(compgen -W "${opts}" -- "${cur_word}") )
       return 0
       ;;

--- a/tests/resources/generate-outputs.sh
+++ b/tests/resources/generate-outputs.sh
@@ -9,3 +9,13 @@ cd $ROOT_DIR
 
 mtt train options.yaml -o model-32-bit.pt -r base_precision=32 # > /dev/null
 mtt train options.yaml -o model-64-bit.pt -r base_precision=64 # > /dev/null
+
+# upload results to private HF repo if token is set
+if [ -n "${HUGGINGFACE_TOKEN_METATRAIN:-}" ]; then
+    huggingface-cli upload \
+        "metatensor/metatrain-test" \
+        "model-32-bit.ckpt" \
+        "model.ckpt" \
+        --commit-message="Overwrite test model with new version" \
+        --token=$HUGGINGFACE_TOKEN_METATRAIN
+fi

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -1,7 +1,7 @@
+import os
 from pathlib import Path
 
 import pytest
-import torch
 from metatensor.torch.atomistic import MetatensorAtomisticModel
 
 from metatrain.soap_bpnn.model import SoapBpnn
@@ -48,9 +48,6 @@ def test_is_exported_file():
 def test_load_model_checkpoint(path):
     model = load_model(path)
     assert type(model) is SoapBpnn
-    if str(path).startswith("file:"):
-        # test that the checkpoint is also copied to the current directory
-        assert Path("model-32-bit.ckpt").exists()
 
 
 @pytest.mark.parametrize(
@@ -73,27 +70,30 @@ def test_load_model_yaml(suffix):
         load_model(f"foo{suffix}")
 
 
-def test_load_model_unknown_model(tmpdir):
-    architecture_name = "soap_bpnn"
-    path = "fake.ckpt"
+def test_load_model_token():
+    """Test that the export cli succeeds when exporting a private
+    model from HuggingFace."""
 
-    with tmpdir.as_cwd():
-        torch.save({"architecture_name": architecture_name}, path)
+    token = os.getenv("HUGGINGFACE_TOKEN_METATRAIN")
+    if token is None:
+        pytest.skip("HuggingFace token not found in environment.")
+    assert len(token) > 0
 
-        match = (
-            f"path '{path}' is not a valid checkpoint for the {architecture_name} "
-            "architecture"
-        )
-        with pytest.raises(ValueError, match=match):
-            load_model(path, architecture_name=architecture_name)
+    path = "https://huggingface.co/metatensor/metatrain-test/resolve/main/model.ckpt"
+    load_model(path, token=token)
 
 
-def test_load_model_no_architecture_name(monkeypatch, tmpdir):
-    monkeypatch.chdir(tmpdir)
-    architecture_name = "soap_bpnn"
-    path = "fake.ckpt"
-    torch.save({"not_architecture_name": architecture_name}, path)
+def test_load_model_token_invalid_url_style():
+    token = os.getenv("HUGGINGFACE_TOKEN_METATRAIN")
+    if token is None:
+        pytest.skip("HuggingFace token not found in environment.")
+    assert len(token) > 0
 
-    match = "No architecture name found in the checkpoint"
-    with pytest.raises(ValueError, match=match):
-        load_model(path, architecture_name=architecture_name)
+    # change `resolve` to ``foo`` to make the URL scheme invalid
+    path = "https://huggingface.co/metatensor/metatrain-test/foo/main/model.ckpt"
+
+    with pytest.raises(
+        ValueError,
+        match=f"URL '{path}' has an invalid format for the Hugging Face Hub.",
+    ):
+        load_model(path, token=token)


### PR DESCRIPTION
I think the current approach trying to guess the name is super complicated and very likely to fail. I would just not copy the file for now. I think this is not problematic because if users run the `export()` method they will have the model in a known location.

On top I will try to work on the planned caching in an upcoming PR!

I also cleaned up the fetching of hugging-face models a bit by using a regular expression instead string concentrations and splits.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--523.org.readthedocs.build/en/523/

<!-- readthedocs-preview metatrain end -->