### PR TITLE
Draft: Make nanoPET closer to Sergey's original PET

### DIFF
--- a/src/metatrain/experimental/nanopet/modules/attention.py
+++ b/src/metatrain/experimental/nanopet/modules/attention.py
@@ -18,8 +18,13 @@ class AttentionBlock(torch.nn.Module):
         super().__init__()
 
         self.num_heads = num_heads
-        self.in_proj = torch.nn.Linear(hidden_size, 3 * hidden_size, bias=False)
-        self.out_proj = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+        self.in_proj = torch.nn.Linear(hidden_size, 3 * hidden_size, bias=True)
+        self.out_proj = torch.nn.Linear(hidden_size, hidden_size, bias=True)
+
+        torch.nn.init.xavier_uniform_(self.in_proj.weight)
+        torch.nn.init.constant_(self.in_proj.bias, 0.0)
+        torch.nn.init.constant_(self.out_proj.bias, 0.0)
+
         self.layernorm = torch.nn.LayerNorm(normalized_shape=hidden_size)
         self.attention_dropout_rate = attention_dropout_rate
 
@@ -64,9 +69,4 @@ class AttentionBlock(torch.nn.Module):
         )
 
         # Output projection
-        outputs = self.out_proj(attention_output)
-
-        # Residual connection
-        outputs = (outputs + inputs) * 0.5**0.5
-
-        return outputs
+        return self.out_proj(attention_output)

--- a/src/metatrain/experimental/nanopet/modules/encoder.py
+++ b/src/metatrain/experimental/nanopet/modules/encoder.py
@@ -5,10 +5,8 @@ import torch
 
 class Encoder(torch.nn.Module):
     """
-    An encoder of edges. It generates a fixed-size representation of the
-    interatomic vector, the chemical element of the center and the chemical
-    element of the neighbor. The representations are then concatenated and
-    compressed to the initial fixed size.
+    Assemble the inputs for transformer layer: Mix geometric information
+    and previous features, and add a central token.
     """
 
     def __init__(
@@ -18,46 +16,31 @@ class Encoder(torch.nn.Module):
     ):
         super().__init__()
 
-        self.cartesian_encoder = torch.nn.Sequential(
-            torch.nn.Linear(in_features=3, out_features=4 * hidden_size, bias=False),
+        self.cartesian_encoder = torch.nn.Linear(
+            in_features=3, out_features=hidden_size
+        )
+
+        self.mixer = torch.nn.Sequential(
+            torch.nn.Linear(in_features=2 * hidden_size, out_features=hidden_size),
             torch.nn.SiLU(),
-            torch.nn.Linear(
-                in_features=4 * hidden_size, out_features=4 * hidden_size, bias=False
-            ),
-            torch.nn.SiLU(),
-            torch.nn.Linear(
-                in_features=4 * hidden_size, out_features=hidden_size, bias=False
-            ),
+            torch.nn.Linear(in_features=hidden_size, out_features=hidden_size),
         )
         self.center_encoder = torch.nn.Embedding(
             num_embeddings=n_species, embedding_dim=hidden_size
         )
-        self.neighbor_encoder = torch.nn.Embedding(
-            num_embeddings=n_species, embedding_dim=hidden_size
-        )
-        self.compressor = torch.nn.Linear(
-            in_features=3 * hidden_size, out_features=hidden_size, bias=False
-        )
 
     def forward(
         self,
-        features: Dict[str, torch.Tensor],
+        fixed: Dict[str, torch.Tensor],
+        features: torch.Tensor,
     ):
-        # Encode cartesian coordinates
-        cartesian_features = self.cartesian_encoder(features["cartesian"])
+        cartesian_features = self.cartesian_encoder(fixed["cartesian"])  # per edge
 
-        # Encode centers
-        center_features = self.center_encoder(features["center"])
+        center_features = self.center_encoder(fixed["center"])  # per node
 
-        # Encode neighbors
-        neighbor_features = self.neighbor_encoder(features["neighbor"])
+        features = torch.concatenate([cartesian_features, features], dim=-1)
+        features = self.mixer(features)
 
-        # Concatenate
-        encoded_features = torch.concatenate(
-            [cartesian_features, center_features, neighbor_features], dim=-1
-        )
+        features = torch.concatenate([features, center_features.unsqueeze(1)], dim=1)
 
-        # Compress
-        compressed_features = self.compressor(encoded_features)
-
-        return compressed_features
+        return features


### PR DESCRIPTION
This changes the following

* Different LayerNorm/residual structure in attention block
* Xavier init in QKV/turn on bias
* Input features for attention are generated from R_ij and previous messages
* Add central token

This does not implement predicting the energy based on nodes and edges... I don't know how. 😅 

Feel free to not merge this and close, I'm not a `metatrain` developer and I did a rather rough read through of the code before making the changes.

***

I've attached a reference implementation that closely follows the original PET code, using `flax.linen` (note that it doesn't do the correct attention with cutoffs):

```python
import jax
import jax.numpy as jnp

import e3x
import flax.linen as nn

from jaxtyping import Array, Bool, Float, Int, Num, Shaped

from collections.abc import Sequence


class PET(nn.Module):
    cutoff: float = 5.0
    num_hidden: int = 128
    num_attention_layers: int = 2
    num_message_passing_layers: int = 2
    num_heads: int = 4
    cutoff_fn: str = "cosine_cutoff"

    @nn.compact
    def __call__(
        self,
        R_ij: Float[Array, "pairs 3"],
        i: Int[Array, " pairs"],
        j: Int[Array, " pairs"],
        Z_i: Int[Array, " nodes"],
        reverse: Int[Array, " pairs"],
        pair_mask: Bool[Array, " pairs"],
        node_mask: Bool[Array, " nodes"],
    ):
        num_pairs = R_ij.shape[0]
        num_nodes = Z_i.shape[0]  # -> N
        R_ij = R_ij.reshape(num_nodes, -1, 3)  # -> [N, P, 3]
        num_neighbors = R_ij.shape[1]  # -> P (neighbors)
        # assumption: there is AT LEAST one padded neighbor, which
        # we can hijack for center tokens

        R_ij = R_ij.reshape(num_pairs, 3)

        num_hidden = self.num_hidden  # [F]

        cutoff_fn = getattr(e3x.nn.functions, self.cutoff_fn)

        r_ij = e3x.ops.norm(R_ij, axis=-1)

        cutoffs = cutoff_fn(r_ij, cutoff=self.cutoff)
        cutoffs *= pair_mask

        # make initial edge features/messages
        messages = ChemicalEmbedding(num_features=self.num_hidden)(Z_i)
        messages = messages[j] * pair_mask[..., None]

        # we'll use the last neighbor for the central token, adjust mask to match
        pair_mask_with_central_tokens = pair_mask.reshape(num_nodes, num_neighbors)
        pair_mask_with_central_tokens = pair_mask_with_central_tokens.at[:, -1].set(True)

        predictions = 0.0
        for l in range(self.num_message_passing_layers):
            geometric = masked(
                Linear(features=num_hidden, name=f"Linear_geometric_{l}"),
                R_ij,
                pair_mask,
            )
            tokens = masked(
                MLP(features=[num_hidden, num_hidden], name=f"MLP_token_{l}"),
                jnp.concatenate([geometric, messages], axis=-1),
                pair_mask,
            )

            central = (
                ChemicalEmbedding(num_features=self.num_hidden)(Z_i) * node_mask[..., None]
            )

            tokens = tokens.reshape(num_nodes, num_neighbors, num_hidden)
            tokens = tokens.at[:, -1, :].set(central)

            output_tokens = Transformer(
                num_layers=self.num_attention_layers, num_heads=self.num_heads
            )(
                tokens,
                cutoffs.reshape(num_nodes, num_neighbors),
                pair_mask_with_central_tokens,
            )
            central_tokens = output_tokens[:, -1, :]

            output_tokens = output_tokens.at[:, -1, :].set(0.0)
            output_tokens = output_tokens.reshape(num_pairs, -1)

            predictor = MLP(features=[num_hidden, num_hidden, 1], name=f"MLP_predict_{l}")

            central_predictions = masked(predictor, central_tokens, node_mask)[:, 0]
            predictions += central_predictions

            pair_predictions = masked(predictor, output_tokens, pair_mask)
            pair_predictions *= cutoffs[..., None]
            pair_predictions = pair_predictions.reshape(num_nodes, num_neighbors, -1).sum(
                axis=1
            )[:, 0]
            predictions += pair_predictions

            messages = 0.5 * (messages + output_tokens[reverse])

        return predictions


class Transformer(nn.Module):
    num_layers: int = 2
    num_heads: int = 4

    @nn.compact
    def __call__(
        self,
        x: Float[Array, "nodes neighbors features"],
        cutoffs: Float[Array, "nodes neighbors"],
        pair_mask: Bool[Array, "nodes neighbors"],
    ):
        num_nodes, num_neighbors, num_features = x.shape
        num_pairs = num_nodes * num_neighbors

        for _ in range(self.num_layers):
            attended = Attention(num_heads=self.num_heads)(x, cutoffs, pair_mask)
            x += attended
            x = masked(
                nn.LayerNorm(),
                x.reshape(num_pairs, num_features),
                pair_mask.reshape(num_pairs),
            )
            y = masked(
                MLP(
                    features=[4 * num_features, num_features],
                ),
                x,
                pair_mask.reshape(num_pairs),
            )

            x += y
            x = masked(
                nn.LayerNorm(),
                x,
                pair_mask.reshape(num_pairs),
            ).reshape(num_nodes, num_neighbors, num_features)

        return x


class Attention(nn.Module):
    num_heads: int = 4

    @nn.compact
    def __call__(
        self,
        x: Float[Array, "nodes neighbors features"],
        cutoffs: Float[Array, "nodes neighbors"],
        pair_mask: Bool[Array, "nodes neighbors"],
    ):
        num_nodes, num_neighbors, num_features = x.shape
        num_heads = self.num_heads
        num_features_per_head = num_features // num_heads
        num_pairs = num_nodes * num_neighbors

        qkv = masked(
            Linear(features=3 * num_features, kernel_init="xavier", bias_init="zeros"),
            x.reshape(num_pairs, -1),
            pair_mask.reshape(num_pairs),
        )

        q, k, v = jnp.split(qkv, 3, axis=-1)
        q = q.reshape(num_nodes, num_neighbors, num_heads, num_features_per_head)
        k = k.reshape(num_nodes, num_neighbors, num_heads, num_features_per_head)
        v = v.reshape(num_nodes, num_neighbors, num_heads, num_features_per_head)

        attended = jax.nn.dot_product_attention(
            q, k, v, mask=pair_mask.reshape(num_nodes, 1, -1, 1)
        )
        # , bias=cutoffs.reshape(num_nodes, 1, -1, 1)
        attended = masked(
            Linear(features=num_features, bias_init="zeros"),
            attended.reshape(num_pairs, -1),
            pair_mask.reshape(num_pairs),
        ).reshape(num_nodes, num_neighbors, num_features)

        return attended


class ChemicalEmbedding(nn.Module):
    num_features: int
    total_species: int = 100

    @nn.compact
    def __call__(self, species: Int[Array, " nodes"]) -> Float[Array, "nodes num_features"]:
        return nn.Embed(num_embeddings=self.total_species, features=self.num_features)(
            species
        )


class MLP(nn.Module):
    features: Sequence[int]
    activation: str = "silu"
    use_bias: bool = True

    @nn.compact
    def __call__(self, x):
        activation = getattr(jax.nn, self.activation)
        num_layers = len(self.features)

        for i, f in enumerate(self.features):
            x = Linear(features=f, use_bias=self.use_bias)(x)
            if i != num_layers - 1:
                x = activation(x)

        return x


def torch_bias_init(fan_in):
    def do_init(key, shape, dtype):
        return jax.random.uniform(key, (shape[-1],), dtype, -1) * jnp.sqrt(1 / fan_in)

    return do_init


class Linear(nn.Module):
    # torch-style Linear layer:
    # https://github.com/pytorch/pytorch/blob/v2.6.0/torch/nn/modules/linear.py#L118C8-L118C59
    # -- everything is initialised from uniform [-1/sqrt(fan_in),+1/sqrt(fan_in)]
    features: int
    use_bias: bool = True
    kernel_init: str = "torch"
    bias_init: str = "torch"

    @nn.compact
    def __call__(self, x):
        fan_in = x.shape[-1]
        if self.kernel_init == "torch":
            kernel_init = jax.nn.initializers.variance_scaling(
                1.0 / 3.0, "fan_in", "uniform"
            )
        elif self.kernel_init == "xavier":
            kernel_init = jax.nn.initializers.xavier_uniform()

        if self.bias_init == "torch":
            bias_init = torch_bias_init(fan_in)
        elif self.bias_init == "zeros":
            bias_init = nn.initializers.zeros_init()

        return nn.Dense(
            features=self.features,
            use_bias=self.use_bias,
            kernel_init=kernel_init,
            bias_init=bias_init,
        )(x)


def masked(
    fn: callable,
    x: Shaped[Array, "*shared features"],
    mask: Bool[Array, " *shared"],
    fn_value: float = 0.0,  # value to be passed into fn
    return_value: float = 0.0,  # value to be returned
):
    fn_value = jnp.array(fn_value, dtype=x.dtype)
    return_value = jnp.array(return_value, dtype=x.dtype)

    return jnp.where(
        mask[..., None], fn(jnp.where(mask[..., None], x, fn_value)), return_value
    )
```



<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--524.org.readthedocs.build/en/524/

<!-- readthedocs-preview metatrain end -->