### PR TITLE
Release 2025.4

### DIFF
--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -24,7 +24,15 @@ changelog <https://keepachangelog.com/en/1.1.0/>`_ format. This project follows
 Unreleased
 ----------
 
-Version 2025.3 - 2025-03-11
+Version 2025.4 - 2025-03-29
+---------------------------
+
+Changed
+#######
+
+- upgraded to ``metatensor.torch`` 0.7.4, which gives access to batched ASE evaluation
+
+Version 2025.3 - 2025-03-25
 ---------------------------
 
 Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "ase",
     "metatensor-learn==0.3.1",
     "metatensor-operations==0.3.2",
-    "metatensor-torch==0.7.3",
+    "metatensor-torch==0.7.4",
     "jsonschema",
     "omegaconf",
     "python-hostlist",


### PR DESCRIPTION
A release that relays the changes in `metatensor.torch` 0.7.4, including correct sphericart extension handling and convenient batched ASE evaluation

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--533.org.readthedocs.build/en/533/

<!-- readthedocs-preview metatrain end -->