### PR TITLE
fix torchscript error for LR-enabled models

### DIFF
--- a/src/metatrain/utils/long_range.py
+++ b/src/metatrain/utils/long_range.py
@@ -29,20 +29,20 @@ class LongRangeFeaturizer(torch.nn.Module):
 
         self.ewald_calculator = EwaldCalculator(
             potential=CoulombPotential(
-                smearing=hypers["smearing"],
+                smearing=float(hypers["smearing"]),
                 exclusion_radius=neighbor_list_options.cutoff,
             ),
             full_neighbor_list=neighbor_list_options.full_list,
-            lr_wavelength=hypers["kspace_resolution"],
+            lr_wavelength=float(hypers["kspace_resolution"]),
         )
         self.p3m_calculator = P3MCalculator(
             potential=CoulombPotential(
-                smearing=hypers["smearing"],
+                smearing=float(hypers["smearing"]),
                 exclusion_radius=neighbor_list_options.cutoff,
             ),
             interpolation_nodes=hypers["interpolation_nodes"],
             full_neighbor_list=neighbor_list_options.full_list,
-            mesh_spacing=hypers["kspace_resolution"],
+            mesh_spacing=float(hypers["kspace_resolution"]),
         )
         self.use_ewald = hypers["use_ewald"]
         self.direct_calculator = Calculator(


### PR DESCRIPTION
When `smearing` and `kspace_resolution` is given as integers, e.g.
```
      smearing: 2
      kspace_resolution: 1
```
the model can't be torchscripted as torch-pme expects `smearing` and `lr_wavelength`/`mesh_spacing` to be floats, but we pass them as integers. There might be cleaner fixes then just doing `smearing=float(hypers["smearing"]) `, but this is the fix I'm currently using for my work. LMKWYT


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--558.org.readthedocs.build/en/558/

<!-- readthedocs-preview metatrain end -->