### PR TITLE
Fix Angstrom unit

### DIFF
--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -49,6 +49,7 @@ Changed
 - ``PET`` from the previous version is now deprecated and accessible as
   ``deprecated.pet``, while the old ``NativePET`` (``experimental.nativepet``) is
   now called ``PET`` (``pet`` from training option files)
+- The Angstrom character is now represented as ``A`` and not ``Å`` in the training logs
 
 Version 2025.5 - 2025-04-13
 ---------------------------

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -39,6 +39,13 @@ class DatasetInfo:
     def __init__(
         self, length_unit: str, atomic_types: List[int], targets: Dict[str, TargetInfo]
     ):
+        # Error if the length unit is not ASCII
+        if not all(ord(c) < 128 for c in length_unit):
+            raise ValueError(
+                f"The `length_unit` must be an ASCII string. Got {length_unit}. "
+                "If this is related to the Angstrom character, you can use A instead."
+            )
+
         self.length_unit = length_unit if length_unit is not None else ""
         self._atomic_types = set(atomic_types)
         self.targets = targets

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -29,7 +29,7 @@ class DatasetInfo:
     training functions of the individual models.
 
     :param length_unit: Unit of length used in the dataset. Examples are ``"angstrom"``
-        or ``"nanometer"``.
+        or ``"nanometer"``. If None, the unit will be set to the empty string.
     :param atomic_types: List containing all integer atomic types present in the
         dataset. ``atomic_types`` will be stored as a sorted list of **unique** atomic
         types.
@@ -37,8 +37,14 @@ class DatasetInfo:
     """
 
     def __init__(
-        self, length_unit: str, atomic_types: List[int], targets: Dict[str, TargetInfo]
+        self,
+        length_unit: Optional[str],
+        atomic_types: List[int],
+        targets: Dict[str, TargetInfo],
     ):
+        if length_unit is None:
+            length_unit = ""
+
         # Error if the length unit is not ASCII
         if not all(ord(c) < 128 for c in length_unit):
             raise ValueError(
@@ -46,7 +52,7 @@ class DatasetInfo:
                 "If this is related to the Angstrom character, you can use A instead."
             )
 
-        self.length_unit = length_unit if length_unit is not None else ""
+        self.length_unit = length_unit
         self._atomic_types = set(atomic_types)
         self.targets = targets
 

--- a/src/metatrain/utils/units.py
+++ b/src/metatrain/utils/units.py
@@ -17,7 +17,7 @@ def get_gradient_units(base_unit: str, gradient_name: str, length_unit: str) -> 
     if base_unit == "":
         return ""  # unknown unit for base quantity -> unknown unit for gradient
     if length_unit == "angstrom":
-        length_unit = "Å"  # prettier
+        length_unit = "A"  # prettier
     if gradient_name == "positions":
         return base_unit + "/" + length_unit
     elif gradient_name == "strain":

--- a/src/metatrain/utils/units.py
+++ b/src/metatrain/utils/units.py
@@ -16,7 +16,7 @@ def get_gradient_units(base_unit: str, gradient_name: str, length_unit: str) -> 
     """
     if base_unit == "":
         return ""  # unknown unit for base quantity -> unknown unit for gradient
-    if length_unit == "angstrom":
+    if length_unit == "angstrom" or length_unit == "Angstrom":
         length_unit = "A"  # prettier
     if gradient_name == "positions":
         return base_unit + "/" + length_unit

--- a/tests/utils/test_units.py
+++ b/tests/utils/test_units.py
@@ -8,7 +8,7 @@ def test_get_gradient_units():
     # Test the case where the base unit is empty
     assert get_gradient_units("", "positions", "angstrom") == ""
     # Test the case where the length unit is angstrom
-    assert get_gradient_units("unit", "positions", "angstrom") == "unit/Å"
+    assert get_gradient_units("unit", "positions", "angstrom") == "unit/A"
     # Test the case where the gradient name is strain
     assert get_gradient_units("unit", "strain", "angstrom") == "unit"
     # Test the case where the gradient name is unknown


### PR DESCRIPTION
Fixes #563 by representing the Angstrom character as A. This is consistent with metatensor

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--566.org.readthedocs.build/en/566/

<!-- readthedocs-preview metatrain end -->