### PR TITLE
Also print the error class name in the log

### DIFF
--- a/src/metatrain/utils/errors.py
+++ b/src/metatrain/utils/errors.py
@@ -12,8 +12,8 @@ class ArchitectureError(Exception):
 
     def __init__(self, exception):
         super().__init__(
-            f"{exception}\n\nThe error above most likely originates from an "
-            "architecture.\n\nIf you think this is a bug, please contact its "
-            "maintainer (see the architecture's documentation) and include the full "
-            "traceback error.log."
+            f"{exception.__class__.__name__}: {exception}\n\n"
+            "The error above most likely originates from an architecture.\n\n"
+            "If you think this is a bug, please contact its maintainer (see the "
+            "architecture's documentation) and include the full traceback error.log."
         )


### PR DESCRIPTION
`KeyError: foobar` is much better than `foobar` when developing the code

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--586.org.readthedocs.build/en/586/

<!-- readthedocs-preview metatrain end -->