### PR TITLE
Architecture code should not import metatrain.utils with a relative path

### DIFF
--- a/docs/src/dev-docs/new-architecture.rst
+++ b/docs/src/dev-docs/new-architecture.rst
@@ -81,6 +81,20 @@ requirements to be stable. The usual structure of architecture looks as
     ``metatrain``. Once a new architecture folder with the required files is created
     ``metatrain`` will include the architecture automatically.
 
+.. note::
+    Because achitectures can live in either ``src/metatrain/<architecture>``,
+    ``src/metatrain/experimental/<architecture>``, or
+    ``src/metatrain/deprecated/<architecture>``; the code inside should use
+    absolute imports use the tools provided by metatrain.
+
+    .. code-block:: python
+
+        # do not do this
+        from ..utils.dtype import dtype_to_str
+
+        # Do this instead
+        from metatrain.utils.dtype import dtype_to_str
+
 Model class (``model.py``)
 --------------------------
 The ``ModelInterface``, is recommended to be located in a file called ``model.py``

--- a/src/metatrain/deprecated/pet/model.py
+++ b/src/metatrain/deprecated/pet/model.py
@@ -12,13 +12,13 @@ from metatensor.torch.atomistic import (
     System,
 )
 
+from metatrain.utils.additive import ZBL
 from metatrain.utils.data import DatasetInfo
 from metatrain.utils.data.target_info import is_auxiliary_output
+from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.metadata import append_metadata_references
+from metatrain.utils.sum_over_atoms import sum_over_atoms
 
-from ...utils.additive import ZBL
-from ...utils.dtype import dtype_to_str
-from ...utils.metadata import append_metadata_references
-from ...utils.sum_over_atoms import sum_over_atoms
 from .modules.pet import PET as RawPET
 from .utils import load_raw_pet_model, systems_to_batch_dict
 

--- a/src/metatrain/deprecated/pet/trainer.py
+++ b/src/metatrain/deprecated/pet/trainer.py
@@ -11,8 +11,9 @@ import numpy as np
 import torch
 from torch_geometric.nn import DataParallel
 
-from ...utils.data import Dataset, check_datasets
-from ...utils.io import check_file_extension
+from metatrain.utils.data import Dataset, check_datasets
+from metatrain.utils.io import check_file_extension
+
 from . import PET as WrappedPET
 from .modules.analysis import adapt_hypers
 from .modules.data_preparation import (

--- a/src/metatrain/experimental/nanopet/model.py
+++ b/src/metatrain/experimental/nanopet/model.py
@@ -14,13 +14,14 @@ from metatensor.torch.atomistic import (
     System,
 )
 
-from ...utils.additive import ZBL, CompositionModel
-from ...utils.data import DatasetInfo, TargetInfo
-from ...utils.dtype import dtype_to_str
-from ...utils.long_range import DummyLongRangeFeaturizer, LongRangeFeaturizer
-from ...utils.metadata import append_metadata_references
-from ...utils.scaler import Scaler
-from ...utils.sum_over_atoms import sum_over_atoms
+from metatrain.utils.additive import ZBL, CompositionModel
+from metatrain.utils.data import DatasetInfo, TargetInfo
+from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.long_range import DummyLongRangeFeaturizer, LongRangeFeaturizer
+from metatrain.utils.metadata import append_metadata_references
+from metatrain.utils.scaler import Scaler
+from metatrain.utils.sum_over_atoms import sum_over_atoms
+
 from .modules.encoder import Encoder
 from .modules.nef import (
     edge_array_to_nef,

--- a/src/metatrain/experimental/nanopet/trainer.py
+++ b/src/metatrain/experimental/nanopet/trainer.py
@@ -7,27 +7,35 @@ import torch
 import torch.distributed
 from torch.utils.data import DataLoader, DistributedSampler
 
-from ...utils.additive import remove_additive
-from ...utils.augmentation import RotationalAugmenter
-from ...utils.data import CombinedDataLoader, Dataset, _is_disk_dataset, collate_fn
-from ...utils.distributed.distributed_data_parallel import DistributedDataParallel
-from ...utils.distributed.slurm import DistributedEnvironment
-from ...utils.evaluate_model import evaluate_model
-from ...utils.external_naming import to_external_name
-from ...utils.io import check_file_extension
-from ...utils.logging import ROOT_LOGGER, MetricLogger
-from ...utils.loss import TensorMapDictLoss
-from ...utils.metrics import MAEAccumulator, RMSEAccumulator, get_selected_metric
-from ...utils.neighbor_lists import (
+from metatrain.utils.additive import remove_additive
+from metatrain.utils.augmentation import RotationalAugmenter
+from metatrain.utils.data import (
+    CombinedDataLoader,
+    Dataset,
+    _is_disk_dataset,
+    collate_fn,
+)
+from metatrain.utils.distributed.distributed_data_parallel import (
+    DistributedDataParallel,
+)
+from metatrain.utils.distributed.slurm import DistributedEnvironment
+from metatrain.utils.evaluate_model import evaluate_model
+from metatrain.utils.external_naming import to_external_name
+from metatrain.utils.io import check_file_extension
+from metatrain.utils.logging import ROOT_LOGGER, MetricLogger
+from metatrain.utils.loss import TensorMapDictLoss
+from metatrain.utils.metrics import MAEAccumulator, RMSEAccumulator, get_selected_metric
+from metatrain.utils.neighbor_lists import (
     get_requested_neighbor_lists,
     get_system_with_neighbor_lists,
 )
-from ...utils.per_atom import average_by_num_atoms
-from ...utils.scaler import remove_scale
-from ...utils.transfer import (
+from metatrain.utils.per_atom import average_by_num_atoms
+from metatrain.utils.scaler import remove_scale
+from metatrain.utils.transfer import (
     systems_and_targets_to_device,
     systems_and_targets_to_dtype,
 )
+
 from .model import NanoPET
 
 

--- a/src/metatrain/gap/model.py
+++ b/src/metatrain/gap/model.py
@@ -19,10 +19,9 @@ from metatensor.torch.atomistic import (
 )
 from skmatter._selection import _FPS as _FPS_skmatter
 
+from metatrain.utils.additive import ZBL, CompositionModel
 from metatrain.utils.data.dataset import DatasetInfo
-
-from ..utils.additive import ZBL, CompositionModel
-from ..utils.metadata import append_metadata_references
+from metatrain.utils.metadata import append_metadata_references
 
 
 class GAP(torch.nn.Module):

--- a/src/metatrain/gap/trainer.py
+++ b/src/metatrain/gap/trainer.py
@@ -6,14 +6,13 @@ import metatensor.torch
 import torch
 from metatensor.torch import TensorMap
 
-from metatrain.utils.data import Dataset
-
-from ..utils.additive import remove_additive
-from ..utils.data import check_datasets
-from ..utils.neighbor_lists import (
+from metatrain.utils.additive import remove_additive
+from metatrain.utils.data import Dataset, check_datasets
+from metatrain.utils.neighbor_lists import (
     get_requested_neighbor_lists,
     get_system_with_neighbor_lists,
 )
+
 from . import GAP
 from .model import torch_tensor_map_to_core
 

--- a/src/metatrain/pet/model.py
+++ b/src/metatrain/pet/model.py
@@ -15,13 +15,14 @@ from metatensor.torch.atomistic import (
 )
 from torch import nn
 
-from ..utils.additive import ZBL, CompositionModel
-from ..utils.data import DatasetInfo, TargetInfo
-from ..utils.dtype import dtype_to_str
-from ..utils.long_range import DummyLongRangeFeaturizer, LongRangeFeaturizer
-from ..utils.metadata import append_metadata_references
-from ..utils.scaler import Scaler
-from ..utils.sum_over_atoms import sum_over_atoms
+from metatrain.utils.additive import ZBL, CompositionModel
+from metatrain.utils.data import DatasetInfo, TargetInfo
+from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.long_range import DummyLongRangeFeaturizer, LongRangeFeaturizer
+from metatrain.utils.metadata import append_metadata_references
+from metatrain.utils.scaler import Scaler
+from metatrain.utils.sum_over_atoms import sum_over_atoms
+
 from .modules.finetuning import apply_finetuning_strategy
 from .modules.structures import remap_neighborlists, systems_to_batch
 from .modules.transformer import CartesianTransformer

--- a/src/metatrain/pet/trainer.py
+++ b/src/metatrain/pet/trainer.py
@@ -7,27 +7,35 @@ import torch
 from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.data import DataLoader, DistributedSampler
 
-from ..utils.additive import remove_additive
-from ..utils.augmentation import RotationalAugmenter
-from ..utils.data import CombinedDataLoader, Dataset, _is_disk_dataset, collate_fn
-from ..utils.distributed.distributed_data_parallel import DistributedDataParallel
-from ..utils.distributed.slurm import DistributedEnvironment
-from ..utils.evaluate_model import evaluate_model
-from ..utils.external_naming import to_external_name
-from ..utils.io import check_file_extension
-from ..utils.logging import ROOT_LOGGER, MetricLogger
-from ..utils.loss import TensorMapDictLoss
-from ..utils.metrics import MAEAccumulator, RMSEAccumulator, get_selected_metric
-from ..utils.neighbor_lists import (
+from metatrain.utils.additive import remove_additive
+from metatrain.utils.augmentation import RotationalAugmenter
+from metatrain.utils.data import (
+    CombinedDataLoader,
+    Dataset,
+    _is_disk_dataset,
+    collate_fn,
+)
+from metatrain.utils.distributed.distributed_data_parallel import (
+    DistributedDataParallel,
+)
+from metatrain.utils.distributed.slurm import DistributedEnvironment
+from metatrain.utils.evaluate_model import evaluate_model
+from metatrain.utils.external_naming import to_external_name
+from metatrain.utils.io import check_file_extension
+from metatrain.utils.logging import ROOT_LOGGER, MetricLogger
+from metatrain.utils.loss import TensorMapDictLoss
+from metatrain.utils.metrics import MAEAccumulator, RMSEAccumulator, get_selected_metric
+from metatrain.utils.neighbor_lists import (
     get_requested_neighbor_lists,
     get_system_with_neighbor_lists,
 )
-from ..utils.per_atom import average_by_num_atoms
-from ..utils.scaler import remove_scale
-from ..utils.transfer import (
+from metatrain.utils.per_atom import average_by_num_atoms
+from metatrain.utils.scaler import remove_scale
+from metatrain.utils.transfer import (
     systems_and_targets_to_device,
     systems_and_targets_to_dtype,
 )
+
 from .model import PET
 from .modules.finetuning import apply_finetuning_strategy
 

--- a/src/metatrain/soap_bpnn/model.py
+++ b/src/metatrain/soap_bpnn/model.py
@@ -15,15 +15,15 @@ from metatensor.torch.learn.nn import Linear as LinearMap
 from metatensor.torch.learn.nn import ModuleMap
 from spex.metatensor import SoapPowerSpectrum
 
+from metatrain.utils.additive import ZBL, CompositionModel
 from metatrain.utils.data import TargetInfo
 from metatrain.utils.data.dataset import DatasetInfo
+from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.long_range import DummyLongRangeFeaturizer, LongRangeFeaturizer
+from metatrain.utils.metadata import append_metadata_references
+from metatrain.utils.scaler import Scaler
+from metatrain.utils.sum_over_atoms import sum_over_atoms
 
-from ..utils.additive import ZBL, CompositionModel
-from ..utils.dtype import dtype_to_str
-from ..utils.long_range import DummyLongRangeFeaturizer, LongRangeFeaturizer
-from ..utils.metadata import append_metadata_references
-from ..utils.scaler import Scaler
-from ..utils.sum_over_atoms import sum_over_atoms
 from .spherical import TensorBasis
 
 

--- a/src/metatrain/soap_bpnn/trainer.py
+++ b/src/metatrain/soap_bpnn/trainer.py
@@ -7,26 +7,34 @@ import torch
 import torch.distributed
 from torch.utils.data import DataLoader, DistributedSampler
 
-from ..utils.additive import remove_additive
-from ..utils.data import CombinedDataLoader, Dataset, _is_disk_dataset, collate_fn
-from ..utils.distributed.distributed_data_parallel import DistributedDataParallel
-from ..utils.distributed.slurm import DistributedEnvironment
-from ..utils.evaluate_model import evaluate_model
-from ..utils.external_naming import to_external_name
-from ..utils.io import check_file_extension
-from ..utils.logging import ROOT_LOGGER, MetricLogger
-from ..utils.loss import TensorMapDictLoss
-from ..utils.metrics import MAEAccumulator, RMSEAccumulator, get_selected_metric
-from ..utils.neighbor_lists import (
+from metatrain.utils.additive import remove_additive
+from metatrain.utils.data import (
+    CombinedDataLoader,
+    Dataset,
+    _is_disk_dataset,
+    collate_fn,
+)
+from metatrain.utils.distributed.distributed_data_parallel import (
+    DistributedDataParallel,
+)
+from metatrain.utils.distributed.slurm import DistributedEnvironment
+from metatrain.utils.evaluate_model import evaluate_model
+from metatrain.utils.external_naming import to_external_name
+from metatrain.utils.io import check_file_extension
+from metatrain.utils.logging import ROOT_LOGGER, MetricLogger
+from metatrain.utils.loss import TensorMapDictLoss
+from metatrain.utils.metrics import MAEAccumulator, RMSEAccumulator, get_selected_metric
+from metatrain.utils.neighbor_lists import (
     get_requested_neighbor_lists,
     get_system_with_neighbor_lists,
 )
-from ..utils.per_atom import average_by_num_atoms
-from ..utils.scaler import remove_scale
-from ..utils.transfer import (
+from metatrain.utils.per_atom import average_by_num_atoms
+from metatrain.utils.scaler import remove_scale
+from metatrain.utils.transfer import (
     systems_and_targets_to_device,
     systems_and_targets_to_dtype,
 )
+
 from .model import SoapBpnn
 
 


### PR DESCRIPTION
This makes it a lot easier to move the code around to `deprectated`/from `experimental`

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--587.org.readthedocs.build/en/587/

<!-- readthedocs-preview metatrain end -->