### PR TITLE
Don't access `model.outputs` but define a new function for it

### DIFF
--- a/docs/src/dev-docs/new-architecture.rst
+++ b/docs/src/dev-docs/new-architecture.rst
@@ -104,7 +104,11 @@ method.
 
 .. code-block:: python
 
-    from metatensor.torch.atomistic import MetatensorAtomisticModel, ModelMetadata
+    from metatensor.torch.atomistic import (
+        MetatensorAtomisticModel,
+        ModelMetadata,
+        ModelOutput,
+    )
 
     class ModelInterface:
 
@@ -115,8 +119,15 @@ method.
         )
 
         def __init__(self, model_hypers: Dict, dataset_info: DatasetInfo):
-            self.hypers = model_hypers
-            self.dataset_info = dataset_info
+            ...
+
+        def supported_outputs(self) -> Dict[str, ModelOutput]:
+            """
+            Get the set of outputs currently supported by this model.
+
+            This will likely be the same outputs that are set as this model
+            capabilities in ``export()``
+            """
 
         @classmethod
         def load_checkpoint(
@@ -131,7 +142,6 @@ method.
                 Required values are "restart" and "finetune", "export" but can be
                 extended to other values.
             """
-            pass
 
         def restart(cls, dataset_info: DatasetInfo) -> "ModelInterface":
             """Restart training.
@@ -142,12 +152,11 @@ method.
             It enables transfer learning (changing the targets), and fine-tuning (same
             targets, different datasets)
             """
-            pass
 
-            def export(
-        self, metadata: Optional[ModelMetadata] = None
-    ) -> MetatensorAtomisticModel:
-            pass
+        def export(
+            self, metadata: Optional[ModelMetadata] = None
+        ) -> MetatensorAtomisticModel:
+            ...
 
 Note that the ``ModelInterface`` does not necessarily inherit from
 :py:class:`torch.nn.Module` since training can be performed in any way.

--- a/src/metatrain/deprecated/pet/model.py
+++ b/src/metatrain/deprecated/pet/model.py
@@ -272,6 +272,18 @@ class PET(torch.nn.Module):
 
         return model
 
+    def supported_outputs(self) -> Dict[str, ModelOutput]:
+        return {
+            self.target_name: ModelOutput(
+                quantity=self.dataset_info.targets[self.target_name].quantity,
+                unit=self.dataset_info.targets[self.target_name].unit,
+                per_atom=False,
+            ),
+            f"mtt::aux::{self.target_name.replace('mtt::', '')}_last_layer_features": ModelOutput(  # noqa: E501
+                unit="unitless", per_atom=True
+            ),
+        }
+
     def export(
         self, metadata: Optional[ModelMetadata] = None
     ) -> MetatensorAtomisticModel:
@@ -291,16 +303,7 @@ class PET(torch.nn.Module):
         interaction_range = max(interaction_ranges)
 
         capabilities = ModelCapabilities(
-            outputs={
-                self.target_name: ModelOutput(
-                    quantity=self.dataset_info.targets[self.target_name].quantity,
-                    unit=self.dataset_info.targets[self.target_name].unit,
-                    per_atom=False,
-                ),
-                f"mtt::aux::{self.target_name.replace('mtt::', '')}_last_layer_features": ModelOutput(  # noqa: E501
-                    unit="unitless", per_atom=True
-                ),
-            },
+            outputs=self.supported_outputs(),
             atomic_types=self.atomic_types,
             interaction_range=interaction_range,
             length_unit=self.dataset_info.length_unit,

--- a/src/metatrain/experimental/nanopet/model.py
+++ b/src/metatrain/experimental/nanopet/model.py
@@ -186,6 +186,9 @@ class NanoPET(torch.nn.Module):
 
         self.single_label = Labels.single()
 
+    def supported_outputs(self) -> Dict[str, ModelOutput]:
+        return self.outputs
+
     def restart(self, dataset_info: DatasetInfo) -> "NanoPET":
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)

--- a/src/metatrain/gap/model.py
+++ b/src/metatrain/gap/model.py
@@ -165,6 +165,9 @@ class GAP(torch.nn.Module):
             )
         self.additive_models = torch.nn.ModuleList(additive_models)
 
+    def supported_outputs(self) -> Dict[str, ModelOutput]:
+        return self.outputs
+
     def restart(self, dataset_info: DatasetInfo) -> "GAP":
         raise ValueError("GAP does not allow restarting training")
 

--- a/src/metatrain/pet/model.py
+++ b/src/metatrain/pet/model.py
@@ -168,6 +168,9 @@ class PET(torch.nn.Module):
 
         self.single_label = Labels.single()
 
+    def supported_outputs(self) -> Dict[str, ModelOutput]:
+        return self.outputs
+
     def restart(self, dataset_info: DatasetInfo) -> "PET":
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)

--- a/src/metatrain/soap_bpnn/model.py
+++ b/src/metatrain/soap_bpnn/model.py
@@ -306,6 +306,9 @@ class SoapBpnn(torch.nn.Module):
         # scaler: this is also handled by the trainer at training time
         self.scaler = Scaler(model_hypers={}, dataset_info=dataset_info)
 
+    def supported_outputs(self) -> Dict[str, ModelOutput]:
+        return self.outputs
+
     def restart(self, dataset_info: DatasetInfo) -> "SoapBpnn":
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)

--- a/src/metatrain/utils/additive/composition.py
+++ b/src/metatrain/utils/additive/composition.py
@@ -465,6 +465,9 @@ class CompositionModel(torch.nn.Module):
 
         return composition_result_dict
 
+    def supported_outputs(self) -> Dict[str, ModelOutput]:
+        return self.outputs
+
     def _add_output(self, target_name: str, target_info: TargetInfo) -> None:
         self.outputs[target_name] = ModelOutput(
             quantity=target_info.quantity,

--- a/src/metatrain/utils/additive/zbl.py
+++ b/src/metatrain/utils/additive/zbl.py
@@ -111,6 +111,9 @@ class ZBL(torch.nn.Module):
 
         return self({}, self.dataset_info.union(dataset_info))
 
+    def supported_outputs(self):
+        return self.outputs
+
     def forward(
         self,
         systems: List[System],

--- a/src/metatrain/utils/evaluate_model.py
+++ b/src/metatrain/utils/evaluate_model.py
@@ -46,10 +46,10 @@ def evaluate_model(
         message="This system's positions or cell requires grad, but the neighbors",
     )
 
-    model_outputs = _get_outputs(model)
-    # Assert that all targets are within the model's capabilities:
+    model_outputs = _get_supported_outputs(model)
+    # Assert that all targets are within the model's supported outputs:
     if not set(targets.keys()).issubset(model_outputs.keys()):
-        raise ValueError("Not all targets are within the model's capabilities.")
+        raise ValueError("Not all targets are within the model's supported outputs")
 
     # Find if there are any energy targets that require gradients:
     energy_targets = []
@@ -214,13 +214,13 @@ def _strain_gradients_to_block(gradients_list):
     )
 
 
-def _get_outputs(
+def _get_supported_outputs(
     model: Union[torch.nn.Module, torch.jit._script.RecursiveScriptModule],
 ):
     if is_atomistic_model(model):
         return model.capabilities().outputs
     else:
-        return model.outputs
+        return model.supported_outputs()
 
 
 def _get_model_outputs(


### PR DESCRIPTION
`model.output` is part of the metatrain <=> architecture interface, (is was used in `evaluate_model`), so let's make this explicit.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--588.org.readthedocs.build/en/588/

<!-- readthedocs-preview metatrain end -->