### PR TITLE
Implement `ModelMetadata` storing in checkpoints

### DIFF
--- a/src/metatrain/cli/export.py
+++ b/src/metatrain/cli/export.py
@@ -159,7 +159,7 @@ def export_model(
             extensions_path = None
 
         if not is_atomistic_model(model):
-            model = model.export()
+            model = model.export(metadata)
 
         model.save(path, collect_extensions=extensions_path)
     if extensions_path is not None:

--- a/src/metatrain/cli/export.py
+++ b/src/metatrain/cli/export.py
@@ -9,7 +9,7 @@ from metatensor.torch.atomistic import ModelMetadata, is_atomistic_model
 from omegaconf import OmegaConf
 
 from ..utils.io import check_file_extension, load_model
-from ..utils.metadata import update_metadata_references
+from ..utils.metadata import append_metadata_references
 from .formatter import CustomHelpFormatter
 
 
@@ -138,10 +138,12 @@ def export_model(
 
         path = str(Path(output).absolute().resolve())
         extensions_path = None
+
         if metadata is not None:
             current_metadata = checkpoint.get("metadata", ModelMetadata())
-            update_metadata_references(metadata, current_metadata)
+            append_metadata_references(metadata, current_metadata)
             checkpoint["metadata"] = metadata
+
         torch.save(checkpoint, path)
     else:
         model = load_model(path=path, token=token)

--- a/src/metatrain/cli/export.py
+++ b/src/metatrain/cli/export.py
@@ -9,7 +9,7 @@ from metatensor.torch.atomistic import ModelMetadata, is_atomistic_model
 from omegaconf import OmegaConf
 
 from ..utils.io import check_file_extension, load_model
-from ..utils.metadata import append_metadata_references
+from ..utils.metadata import update_metadata_references
 from .formatter import CustomHelpFormatter
 
 
@@ -140,8 +140,8 @@ def export_model(
         extensions_path = None
         if metadata is not None:
             current_metadata = checkpoint.get("metadata", ModelMetadata())
-            append_metadata_references(current_metadata, metadata)
-            checkpoint["metadata"] = current_metadata
+            update_metadata_references(metadata, current_metadata)
+            checkpoint["metadata"] = metadata
         torch.save(checkpoint, path)
     else:
         model = load_model(path=path, token=token)
@@ -157,7 +157,7 @@ def export_model(
             extensions_path = None
 
         if not is_atomistic_model(model):
-            model = model.export(metadata)
+            model = model.export()
 
         model.save(path, collect_extensions=extensions_path)
     if extensions_path is not None:

--- a/src/metatrain/experimental/nanopet/model.py
+++ b/src/metatrain/experimental/nanopet/model.py
@@ -18,6 +18,7 @@ from ...utils.additive import ZBL, CompositionModel
 from ...utils.data import DatasetInfo, TargetInfo
 from ...utils.dtype import dtype_to_str
 from ...utils.long_range import DummyLongRangeFeaturizer, LongRangeFeaturizer
+from ...utils.metadata import append_metadata_references
 from ...utils.scaler import Scaler
 from ...utils.sum_over_atoms import sum_over_atoms
 from .modules.encoder import Encoder
@@ -614,7 +615,12 @@ class NanoPET(torch.nn.Module):
             dtype=dtype_to_str(dtype),
         )
 
-        return MetatensorAtomisticModel(self.eval(), self.__metadata__, capabilities)
+        if metadata is None:
+            metadata = self.__metadata__
+        else:
+            append_metadata_references(metadata, self.__metadata__)
+
+        return MetatensorAtomisticModel(self.eval(), metadata, capabilities)
 
     def _add_output(self, target_name: str, target_info: TargetInfo) -> None:
         # warn that, for Cartesian tensors, we assume that they are symmetric

--- a/src/metatrain/experimental/nanopet/trainer.py
+++ b/src/metatrain/experimental/nanopet/trainer.py
@@ -474,6 +474,7 @@ class Trainer:
     def save_checkpoint(self, model, path: Union[str, Path]):
         checkpoint = {
             "architecture_name": "experimental.nanopet",
+            "metadata": model.__metadata__,
             "model_data": {
                 "model_hypers": model.hypers,
                 "dataset_info": model.dataset_info,

--- a/src/metatrain/gap/model.py
+++ b/src/metatrain/gap/model.py
@@ -22,6 +22,7 @@ from skmatter._selection import _FPS as _FPS_skmatter
 from metatrain.utils.data.dataset import DatasetInfo
 
 from ..utils.additive import ZBL, CompositionModel
+from ..utils.metadata import append_metadata_references
 
 
 class GAP(torch.nn.Module):
@@ -291,7 +292,12 @@ class GAP(torch.nn.Module):
             self._subset_of_regressors.export_torch_script_model()
         )
 
-        return MetatensorAtomisticModel(self.eval(), self.__metadata__, capabilities)
+        if metadata is None:
+            metadata = self.__metadata__
+        else:
+            append_metadata_references(metadata, self.__metadata__)
+
+        return MetatensorAtomisticModel(self.eval(), metadata, capabilities)
 
 
 ########################################################################################

--- a/src/metatrain/gap/model.py
+++ b/src/metatrain/gap/model.py
@@ -22,13 +22,12 @@ from skmatter._selection import _FPS as _FPS_skmatter
 from metatrain.utils.data.dataset import DatasetInfo
 
 from ..utils.additive import ZBL, CompositionModel
-from ..utils.metadata import append_metadata_references
 
 
 class GAP(torch.nn.Module):
     __supported_devices__ = ["cpu"]
     __supported_dtypes__ = [torch.float64]
-    __default_metadata__ = ModelMetadata(
+    __metadata__ = ModelMetadata(
         references={
             "implementation": [
                 "featomic: https://github.com/metatensor/featomic",
@@ -292,12 +291,7 @@ class GAP(torch.nn.Module):
             self._subset_of_regressors.export_torch_script_model()
         )
 
-        if metadata is None:
-            metadata = ModelMetadata()
-
-        append_metadata_references(metadata, self.__default_metadata__)
-
-        return MetatensorAtomisticModel(self.eval(), metadata, capabilities)
+        return MetatensorAtomisticModel(self.eval(), self.__metadata__, capabilities)
 
 
 ########################################################################################

--- a/src/metatrain/pet/model.py
+++ b/src/metatrain/pet/model.py
@@ -674,10 +674,6 @@ class PET(torch.nn.Module):
         # Create the model
         model = cls(**model_data)
 
-        metadata = checkpoint.get("metadata", None)
-        if metadata is not None:
-            model.__metadata__ = metadata
-
         if finetune_config:
             # Apply the finetuning strategy
             model = apply_finetuning_strategy(model, finetune_config)
@@ -686,6 +682,11 @@ class PET(torch.nn.Module):
         dtype = next(state_dict_iter).dtype
         model.to(dtype).load_state_dict(model_state_dict)
         model.additive_models[0].sync_tensor_maps()
+
+        # Loading the metadata from the checkpoint
+        metadata = checkpoint.get("metadata", None)
+        if metadata is not None:
+            model.__metadata__ = metadata
 
         return model
 

--- a/src/metatrain/pet/model.py
+++ b/src/metatrain/pet/model.py
@@ -19,6 +19,7 @@ from ..utils.additive import ZBL, CompositionModel
 from ..utils.data import DatasetInfo, TargetInfo
 from ..utils.dtype import dtype_to_str
 from ..utils.long_range import DummyLongRangeFeaturizer, LongRangeFeaturizer
+from ..utils.metadata import append_metadata_references
 from ..utils.scaler import Scaler
 from ..utils.sum_over_atoms import sum_over_atoms
 from .modules.finetuning import apply_finetuning_strategy
@@ -690,7 +691,9 @@ class PET(torch.nn.Module):
 
         return model
 
-    def export(self) -> MetatensorAtomisticModel:
+    def export(
+        self, metadata: Optional[ModelMetadata] = None
+    ) -> MetatensorAtomisticModel:
         dtype = next(self.parameters()).dtype
         if dtype not in self.__supported_dtypes__:
             raise ValueError(f"unsupported dtype {dtype} for PET")
@@ -721,7 +724,12 @@ class PET(torch.nn.Module):
             dtype=dtype_to_str(dtype),
         )
 
-        return MetatensorAtomisticModel(self.eval(), self.__metadata__, capabilities)
+        if metadata is None:
+            metadata = self.__metadata__
+        else:
+            append_metadata_references(metadata, self.__metadata__)
+
+        return MetatensorAtomisticModel(self.eval(), metadata, capabilities)
 
     def _add_output(self, target_name: str, target_info: TargetInfo) -> None:
         # warn that, for Cartesian tensors, we assume that they are symmetric

--- a/src/metatrain/pet/trainer.py
+++ b/src/metatrain/pet/trainer.py
@@ -491,6 +491,7 @@ class Trainer:
     def save_checkpoint(self, model, path: Union[str, Path]):
         checkpoint = {
             "architecture_name": "pet",
+            "metadata": model.__metadata__,
             "model_data": {
                 "model_hypers": model.hypers,
                 "dataset_info": model.dataset_info,

--- a/src/metatrain/soap_bpnn/model.py
+++ b/src/metatrain/soap_bpnn/model.py
@@ -21,6 +21,7 @@ from metatrain.utils.data.dataset import DatasetInfo
 from ..utils.additive import ZBL, CompositionModel
 from ..utils.dtype import dtype_to_str
 from ..utils.long_range import DummyLongRangeFeaturizer, LongRangeFeaturizer
+from ..utils.metadata import append_metadata_references
 from ..utils.scaler import Scaler
 from ..utils.sum_over_atoms import sum_over_atoms
 from .spherical import TensorBasis
@@ -703,7 +704,12 @@ class SoapBpnn(torch.nn.Module):
             dtype=dtype_to_str(dtype),
         )
 
-        return MetatensorAtomisticModel(self.eval(), self.__metadata__, capabilities)
+        if metadata is None:
+            metadata = self.__metadata__
+        else:
+            append_metadata_references(metadata, self.__metadata__)
+
+        return MetatensorAtomisticModel(self.eval(), metadata, capabilities)
 
     def _add_output(self, target_name: str, target: TargetInfo) -> None:
         # register bases of spherical tensors (TensorBasis)

--- a/src/metatrain/soap_bpnn/trainer.py
+++ b/src/metatrain/soap_bpnn/trainer.py
@@ -464,6 +464,7 @@ class Trainer:
     def save_checkpoint(self, model, path: Union[str, Path]):
         checkpoint = {
             "architecture_name": "soap_bpnn",
+            "metadata": model.__metadata__,
             "model_data": {
                 "model_hypers": model.hypers,
                 "dataset_info": model.dataset_info,

--- a/src/metatrain/utils/metadata.py
+++ b/src/metatrain/utils/metadata.py
@@ -3,7 +3,7 @@ import json
 from metatensor.torch.atomistic import ModelMetadata
 
 
-def update_metadata_references(self: ModelMetadata, other: ModelMetadata) -> None:
+def append_metadata_references(self: ModelMetadata, other: ModelMetadata) -> None:
     """Append ``references`` to an existing ModelMetadata object.
 
     :param self: The metadata object to be appeneded.
@@ -12,6 +12,13 @@ def update_metadata_references(self: ModelMetadata, other: ModelMetadata) -> Non
 
     self_dict = json.loads(self._get_method("__getstate__")())
     other_dict = json.loads(other._get_method("__getstate__")())
-    self_dict["references"].update(other_dict["references"])
+
+    for key, values in other_dict["references"].items():
+        if key not in self_dict["references"]:
+            self_dict["references"][key] = values
+        else:
+            self_dict["references"][key] = list(
+                set(self_dict["references"][key] + values)
+            )
 
     self._get_method("__setstate__")(json.dumps(self_dict))

--- a/src/metatrain/utils/metadata.py
+++ b/src/metatrain/utils/metadata.py
@@ -17,8 +17,8 @@ def append_metadata_references(self: ModelMetadata, other: ModelMetadata) -> Non
         if key not in self_dict["references"]:
             self_dict["references"][key] = values
         else:
-            self_dict["references"][key] = list(
-                set(self_dict["references"][key] + values)
-            )
+            for item in values:
+                if item not in self_dict["references"][key]:
+                    self_dict["references"][key].append(item)
 
     self._get_method("__setstate__")(json.dumps(self_dict))

--- a/src/metatrain/utils/metadata.py
+++ b/src/metatrain/utils/metadata.py
@@ -3,7 +3,7 @@ import json
 from metatensor.torch.atomistic import ModelMetadata
 
 
-def append_metadata_references(self: ModelMetadata, other: ModelMetadata) -> None:
+def update_metadata_references(self: ModelMetadata, other: ModelMetadata) -> None:
     """Append ``references`` to an existing ModelMetadata object.
 
     :param self: The metadata object to be appeneded.
@@ -12,11 +12,6 @@ def append_metadata_references(self: ModelMetadata, other: ModelMetadata) -> Non
 
     self_dict = json.loads(self._get_method("__getstate__")())
     other_dict = json.loads(other._get_method("__getstate__")())
-
-    for key, values in other_dict["references"].items():
-        if key not in self_dict["references"]:
-            self_dict["references"][key] = values
-        else:
-            self_dict["references"][key] += values
+    self_dict["references"].update(other_dict["references"])
 
     self._get_method("__setstate__")(json.dumps(self_dict))

--- a/tests/cli/test_export_model.py
+++ b/tests/cli/test_export_model.py
@@ -15,13 +15,10 @@ import torch
 from omegaconf import OmegaConf
 
 from metatrain.cli.export import export_model
-from metatrain.soap_bpnn import __model__
 from metatrain.utils.architectures import find_all_architectures
-from metatrain.utils.data import DatasetInfo
-from metatrain.utils.data.target_info import get_energy_target_info
 from metatrain.utils.io import load_model
 
-from . import MODEL_HYPERS, RESOURCES_PATH
+from . import RESOURCES_PATH
 
 
 @pytest.mark.parametrize("path", [Path("exported.pt"), "exported.pt"])
@@ -30,13 +27,8 @@ def test_export(monkeypatch, tmp_path, path, caplog):
     monkeypatch.chdir(tmp_path)
     caplog.set_level(logging.INFO)
 
-    dataset_info = DatasetInfo(
-        length_unit="angstrom",
-        atomic_types={1},
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
-    )
-    model = __model__(model_hypers=MODEL_HYPERS, dataset_info=dataset_info)
-    export_model(model, path)
+    checkpoint_path = RESOURCES_PATH / "model-64-bit.ckpt"
+    export_model(checkpoint_path, path)
 
     # Test if extensions are saved
     extensions_glob = glob.glob("extensions/")
@@ -123,17 +115,9 @@ def test_reexport(monkeypatch, tmp_path):
     """Test that an already exported model can be loaded and again exported."""
     monkeypatch.chdir(tmp_path)
 
-    dataset_info = DatasetInfo(
-        length_unit="angstrom",
-        atomic_types={1, 6, 7, 8},
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
-    )
-    model = __model__(model_hypers=MODEL_HYPERS, dataset_info=dataset_info)
-
-    export_model(model, "exported.pt")
-
-    model_loaded = load_model("exported.pt")
-    export_model(model_loaded, "exported_new.pt")
+    checkpoint_path = RESOURCES_PATH / "model-64-bit.ckpt"
+    export_model(checkpoint_path, "exported.pt")
+    export_model("exported.pt", "exported_new.pt")
 
     assert Path("exported_new.pt").is_file()
 


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

As the title suggests, this PR adds the functionality to store the `ModelMetadata` objects inside the model checkpoints, and allows to run `mtt export model.ckpt -o model-with-metadata.ckpt -m metadata.yaml` as a valid command to attach the metadata to the existing `.ckpt` file.

# Contributor (creator of pull-request) checklist
 - [ ] Metadata attachment to the checkpoint works 
 - [ ] `mtt export` still works properly for exporting in `.pt` file
 - [ ] `Model.load_checkpoint()` properly stores the metadata that was read from file
 - [ ] `Trainer.save_checkpoint()` saves the `model.__metadata__`
 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
