### PR TITLE
Fix distributed training

### DIFF
--- a/src/metatrain/utils/distributed/distributed_data_parallel.py
+++ b/src/metatrain/utils/distributed/distributed_data_parallel.py
@@ -7,5 +7,6 @@ class DistributedDataParallel(torch.nn.parallel.DistributedDataParallel):
     :py:class`torch.nn.parallel.DistributedDataParallel`
     and adds a function to retrieve the supported outputs of the module.
     """
+
     def supported_outputs(self):
         return self.module.supported_outputs()

--- a/src/metatrain/utils/distributed/distributed_data_parallel.py
+++ b/src/metatrain/utils/distributed/distributed_data_parallel.py
@@ -5,13 +5,7 @@ class DistributedDataParallel(torch.nn.parallel.DistributedDataParallel):
     """
     DistributedDataParallel wrapper that inherits from
     :py:class`torch.nn.parallel.DistributedDataParallel`
-    and adds the capabilities attribute to it.
-
-    :param module: The module to be parallelized.
-    :param args: Arguments to be passed to the parent class.
-    :param kwargs: Keyword arguments to be passed to the parent class
+    and adds a function to retrieve the supported outputs of the module.
     """
-
-    def __init__(self, module: torch.nn.Module, *args, **kwargs):
-        super(DistributedDataParallel, self).__init__(module, *args, **kwargs)
-        self.outputs = module.outputs
+    def supported_outputs(self):
+        return self.module.supported_outputs()


### PR DESCRIPTION
A follow-up to #588, fixing distributed training

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--600.org.readthedocs.build/en/600/

<!-- readthedocs-preview metatrain end -->