### PR TITLE
Allow explicit specification of atomic types in `options.yaml`

### DIFF
--- a/docs/src/getting-started/custom_dataset_conf.rst
+++ b/docs/src/getting-started/custom_dataset_conf.rst
@@ -181,25 +181,15 @@ first element of the list.
 
 Typically the global atomic types the the model is defined for are inferred from the
 training and validation datasets. Sometimes, due to shuffling of datasets with low
-representation of some types, these datasets may not contain all atomic types that
-you want to use in your model. In this case, you can specify the atomic types
-explicitly in the ``options.yaml`` file, in the ``training_set`` section with the
-``atomic_types`` key:
+representation of some types, these datasets may not contain all atomic types that you
+want to use in your model. To explicitly control the atomic types the model is defined
+for, specify the ``atomic_types`` key in the ``architecture`` section of the options
+file:
 
 .. code-block:: yaml
 
-    training_set:
+    architecture:
         atomic_types: [1, 6, 7, 8, 16]  # i.e. for H, C, N, O, S
-        systems:
-            read_from: dataset_0.xyz
-            length_unit: angstrom
-        targets:
-            energy:
-                quantity: energy
-                key: my_energy_label0
-                unit: eV
-    test_set: 0.1
-    validation_set: 0.1
 
 .. warning::
 

--- a/docs/src/getting-started/custom_dataset_conf.rst
+++ b/docs/src/getting-started/custom_dataset_conf.rst
@@ -189,6 +189,12 @@ file:
 .. code-block:: yaml
 
     architecture:
+        name: pet
+        model:
+            cutoff: 5.0
+        training:
+            batch_size: 32
+            epochs: 100
         atomic_types: [1, 6, 7, 8, 16]  # i.e. for H, C, N, O, S
 
 .. warning::

--- a/docs/src/getting-started/custom_dataset_conf.rst
+++ b/docs/src/getting-started/custom_dataset_conf.rst
@@ -179,6 +179,28 @@ elements and therefore has the the same unit ``eV``. The target section ``free-e
 only exists in the second element and its unit does not have to be the same as in the
 first element of the list.
 
+Typically the global atomic types the the model is defined for are inferred from the
+training and validation datasets. Sometimes, due to shuffling of datasets with low
+representation of some types, these datasets may not contain all atomic types that
+you want to use in your model. In this case, you can specify the atomic types
+explicitly in the ``options.yaml`` file, in the ``training_set`` section with the
+``atomic_types`` key:
+
+.. code-block:: yaml
+
+    training_set:
+        atomic_types: [1, 6, 7, 8, 16]  # i.e. for H, C, N, O, S
+        systems:
+            read_from: dataset_0.xyz
+            length_unit: angstrom
+        targets:
+            energy:
+                quantity: energy
+                key: my_energy_label0
+                unit: eV
+    test_set: 0.1
+    validation_set: 0.1
+
 .. warning::
 
    Even though parsing several datasets is supported by the library, it may not

--- a/src/metatrain/cli/train.py
+++ b/src/metatrain/cli/train.py
@@ -384,10 +384,10 @@ def train_model(
     ###########################
     # CREATE DATASET_INFO #####
     ###########################
-    if options["training_set"][0].get("atomic_types") is None:
+    if options["architecture"].get("atomic_types") is None:  # infer from datasets
         atomic_types = get_atomic_types(train_datasets + val_datasets)
-    else:
-        atomic_types = sorted(options["training_set"][0]["atomic_types"])
+    else:  # use explicitly defined atomic types
+        atomic_types = sorted(options["architecture"]["atomic_types"])
 
     dataset_info = DatasetInfo(
         length_unit=options["training_set"][0]["systems"]["length_unit"],

--- a/src/metatrain/cli/train.py
+++ b/src/metatrain/cli/train.py
@@ -384,8 +384,10 @@ def train_model(
     ###########################
     # CREATE DATASET_INFO #####
     ###########################
-
-    atomic_types = get_atomic_types(train_datasets + val_datasets)
+    if options["training_set"][0].get("atomic_types") is None:
+        atomic_types = get_atomic_types(train_datasets + val_datasets)
+    else:
+        atomic_types = options["training_set"][0]["atomic_types"]
 
     dataset_info = DatasetInfo(
         length_unit=options["training_set"][0]["systems"]["length_unit"],

--- a/src/metatrain/cli/train.py
+++ b/src/metatrain/cli/train.py
@@ -387,7 +387,7 @@ def train_model(
     if options["training_set"][0].get("atomic_types") is None:
         atomic_types = get_atomic_types(train_datasets + val_datasets)
     else:
-        atomic_types = options["training_set"][0]["atomic_types"]
+        atomic_types = sorted(options["training_set"][0]["atomic_types"])
 
     dataset_info = DatasetInfo(
         length_unit=options["training_set"][0]["systems"]["length_unit"],

--- a/src/metatrain/experimental/nanopet/schema-hypers.json
+++ b/src/metatrain/experimental/nanopet/schema-hypers.json
@@ -178,6 +178,11 @@
         }
       },
       "additionalProperties": false
+    },
+    "atomic_types": {
+      "type": "array",
+      "items": { "type": "integer", "minimum": 1 },
+      "uniqueItems": true
     }
   },
   "additionalProperties": false

--- a/src/metatrain/gap/schema-hypers.json
+++ b/src/metatrain/gap/schema-hypers.json
@@ -134,6 +134,11 @@
         }
       },
       "additionalProperties": false
+    },
+    "atomic_types": {
+      "type": "array",
+      "items": { "type": "integer", "minimum": 1 },
+      "uniqueItems": true
     }
   },
   "additionalProperties": false

--- a/src/metatrain/pet/schema-hypers.json
+++ b/src/metatrain/pet/schema-hypers.json
@@ -258,6 +258,11 @@
         }
       },
       "additionalProperties": false
+    },
+    "atomic_types": {
+      "type": "array",
+      "items": { "type": "integer", "minimum": 1 },
+      "uniqueItems": true
     }
   },
   "additionalProperties": false

--- a/src/metatrain/share/schema-dataset.json
+++ b/src/metatrain/share/schema-dataset.json
@@ -62,12 +62,6 @@
   },
   "type": "object",
   "properties": {
-    "atomic_types": {
-      "type": "array",
-      "items": {
-        "type": "integer"
-      }
-    },
     "systems": {
       "oneOf": [
         {

--- a/src/metatrain/share/schema-dataset.json
+++ b/src/metatrain/share/schema-dataset.json
@@ -62,6 +62,12 @@
   },
   "type": "object",
   "properties": {
+    "atomic_types": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      }
+    },
     "systems": {
       "oneOf": [
         {

--- a/src/metatrain/soap_bpnn/schema-hypers.json
+++ b/src/metatrain/soap_bpnn/schema-hypers.json
@@ -204,6 +204,11 @@
         }
       },
       "additionalProperties": false
+    },
+    "atomic_types": {
+      "type": "array",
+      "items": { "type": "integer", "minimum": 1 },
+      "uniqueItems": true
     }
   },
   "additionalProperties": false

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -619,8 +619,7 @@ def test_train_atomic_types(options, monkeypatch, tmp_path, atomic_types):
     list of atomic types works."""
     monkeypatch.chdir(tmp_path)
     shutil.copy(DATASET_PATH_QM9, "qm9_reduced_100.xyz")
-    options["training_set"]["atomic_types"] = atomic_types
-    print(options["training_set"]["atomic_types"])
+    options["architecture"]["atomic_types"] = atomic_types
     train_model(options)
 
 

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -612,9 +612,10 @@ def test_train_issue_290(monkeypatch, tmp_path):
 
     train_model(options)
 
+
 @pytest.mark.parametrize("atomic_types", [[1, 6, 7, 8], [1, 6, 7, 8, 100]])
 def test_train_atomic_types(options, monkeypatch, tmp_path, atomic_types):
-    """Tests that passing a complete and an over-complete 
+    """Tests that passing a complete and an over-complete
     list of atomic types works."""
     monkeypatch.chdir(tmp_path)
     shutil.copy(DATASET_PATH_QM9, "qm9_reduced_100.xyz")

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -612,6 +612,16 @@ def test_train_issue_290(monkeypatch, tmp_path):
 
     train_model(options)
 
+@pytest.mark.parametrize("atomic_types", [[1, 6, 7, 8], [1, 6, 7, 8, 100]])
+def test_train_atomic_types(options, monkeypatch, tmp_path, atomic_types):
+    """Tests that passing a complete and an over-complete 
+    list of atomic types works."""
+    monkeypatch.chdir(tmp_path)
+    shutil.copy(DATASET_PATH_QM9, "qm9_reduced_100.xyz")
+    options["training_set"]["atomic_types"] = atomic_types
+    print(options["training_set"]["atomic_types"])
+    train_model(options)
+
 
 def test_train_log_order(caplog, monkeypatch, tmp_path, options):
     """Tests that the log is always printed in the same order for forces


### PR DESCRIPTION
Currently metatrain infers the global atom types from the training and validation sets. As in the title, this lets the global types be passed explicitly by the user. 

This is useful when the training and validation sets don't contain the global atom types, which can be the case when creating subsets of a dataset for a learning exercise where certain atom types may be poorly represented and get missed in the shuffle.

In `options.yaml` one can now specify, for example:
```yaml
...
architecture:
    atomic_types: [1, 6, 7, 8]
...
```
with the default (i.e. no specification) being the current behaviour - inferring from the training and validation sets.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - ~[ ] Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - ~[ ] CHANGELOG updated with public API or any other important changes?~


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--602.org.readthedocs.build/en/602/

<!-- readthedocs-preview metatrain end -->