### PR TITLE
Fixed typo in PET train dataloder

### DIFF
--- a/src/metatrain/pet/trainer.py
+++ b/src/metatrain/pet/trainer.py
@@ -190,7 +190,7 @@ class Trainer(TrainerInterface):
         for train_dataset, train_sampler in zip(train_datasets, train_samplers):
             train_dataloaders.append(
                 DataLoader(
-                    dataset=dataset,
+                    dataset=train_dataset,
                     batch_size=self.hypers["batch_size"],
                     sampler=train_sampler,
                     shuffle=(


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

This PR fixes a typo left after #589 , where `dateset` variable was used instead of `train_dataset` while creating the train_dataloader in PET trainer. As a consequence, the train dataloader was eventually initialized with val dataset.

# Contributor (creator of pull-request) checklist

 - [ ] ~~Tests updated (for new features and bugfixes)?~~
 - [ ] ~~Documentation updated (for new features)?~~
 - [ ] ~~Issue referenced (for PRs that solve an issue)?~~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--613.org.readthedocs.build/en/613/

<!-- readthedocs-preview metatrain end -->