### PR TITLE
Add linter/formatter for `json` and `yaml` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,8 @@ extensions/
 docs/src/examples
 *execution_times*
 qm9_reduced_100.zip
+
+# JavaScript
+node_modules/
+package-lock.json
+package.json

--- a/examples/programmatic/llpr/options.yaml
+++ b/examples/programmatic/llpr/options.yaml
@@ -15,7 +15,7 @@ training_set:
   targets:
     energy:
       key: "U0"
-      unit: "hartree"  # very important to run simulations
+      unit: "hartree" # very important to run simulations
 
 validation_set: 0.1
 test_set: 0.0

--- a/src/metatrain/deprecated/pet/default-hypers.yaml
+++ b/src/metatrain/deprecated/pet/default-hypers.yaml
@@ -1,5 +1,4 @@
 architecture:
-
   name: deprecated.pet
 
   model:
@@ -37,7 +36,7 @@ architecture:
     USE_ZBL: False
 
   training:
-    USE_LORA_PEFT: False 
+    USE_LORA_PEFT: False
     LORA_RANK: 4
     LORA_ALPHA: 0.5
     INITIAL_LR: 1e-4

--- a/src/metatrain/deprecated/pet/schema-hypers.json
+++ b/src/metatrain/deprecated/pet/schema-hypers.json
@@ -4,9 +4,7 @@
   "properties": {
     "name": {
       "type": "string",
-      "enum": [
-        "deprecated.pet"
-      ]
+      "enum": ["deprecated.pet"]
     },
     "model": {
       "type": "object",
@@ -115,11 +113,7 @@
         },
         "DTYPE": {
           "type": "string",
-          "enum": [
-            "float32",
-            "float64",
-            "bfloat16"
-          ]
+          "enum": ["float32", "float64", "bfloat16"]
         },
         "N_TARGETS": {
           "type": "integer"
@@ -253,10 +247,7 @@
         },
         "ENERGIES_LOSS": {
           "type": "string",
-          "enum": [
-            "per_structure",
-            "per_atom"
-          ]
+          "enum": ["per_structure", "per_atom"]
         },
         "BALANCED_DATA_LOADER": {
           "type": "boolean"
@@ -269,34 +260,22 @@
       "allOf": [
         {
           "not": {
-            "required": [
-              "SCHEDULER_STEP_SIZE",
-              "SCHEDULER_STEP_SIZE_ATOMIC"
-            ]
+            "required": ["SCHEDULER_STEP_SIZE", "SCHEDULER_STEP_SIZE_ATOMIC"]
           }
         },
         {
           "not": {
-            "required": [
-              "EPOCH_NUM",
-              "EPOCH_NUM_ATOMIC"
-            ]
+            "required": ["EPOCH_NUM", "EPOCH_NUM_ATOMIC"]
           }
         },
         {
           "not": {
-            "required": [
-              "STRUCTURAL_BATCH_SIZE",
-              "ATOMIC_BATCH_SIZE"
-            ]
+            "required": ["STRUCTURAL_BATCH_SIZE", "ATOMIC_BATCH_SIZE"]
           }
         },
         {
           "not": {
-            "required": [
-              "EPOCHS_WARMUP",
-              "EPOCHS_WARMUP_ATOMIC"
-            ]
+            "required": ["EPOCHS_WARMUP", "EPOCHS_WARMUP_ATOMIC"]
           }
         }
       ]

--- a/src/metatrain/experimental/nanopet/default-hypers.yaml
+++ b/src/metatrain/experimental/nanopet/default-hypers.yaml
@@ -1,5 +1,4 @@
 architecture:
-
   name: experimental.nanopet
 
   model:
@@ -11,7 +10,7 @@ architecture:
     num_gnn_layers: 2
     heads: {}
     zbl: False
-    long_range: 
+    long_range:
       enable: false
       use_ewald: false
       smearing: 1.4

--- a/src/metatrain/gap/default-hypers.yaml
+++ b/src/metatrain/gap/default-hypers.yaml
@@ -5,7 +5,7 @@ architecture:
     soap:
       cutoff:
         radius: 5.0
-        smoothing: 
+        smoothing:
           type: ShiftedCosine
           width: 1.0
       density:

--- a/src/metatrain/gap/tests/options-gap.yaml
+++ b/src/metatrain/gap/tests/options-gap.yaml
@@ -5,7 +5,7 @@ architecture:
     soap:
       cutoff:
         radius: 5.5
-        smoothing: 
+        smoothing:
           type: ShiftedCosine
           width: 1.0
       density:
@@ -22,7 +22,7 @@ architecture:
         max_angular: 6
         radial:
           type: Gto
-          max_radial: 7  # now exclusive
+          max_radial: 7 # now exclusive
     krr:
       degree: 2
       num_sparse_points: 900

--- a/src/metatrain/pet/default-hypers.yaml
+++ b/src/metatrain/pet/default-hypers.yaml
@@ -1,5 +1,4 @@
 architecture:
-
   name: pet
 
   model:
@@ -12,7 +11,7 @@ architecture:
     num_attention_layers: 2
     num_gnn_layers: 2
     zbl: false
-    long_range: 
+    long_range:
       enable: false
       use_ewald: false
       smearing: 1.4

--- a/src/metatrain/soap_bpnn/default-hypers.yaml
+++ b/src/metatrain/soap_bpnn/default-hypers.yaml
@@ -15,7 +15,7 @@ architecture:
     add_lambda_basis: true
     heads: {}
     zbl: false
-    long_range: 
+    long_range:
       enable: false
       use_ewald: false
       smearing: 1.4

--- a/tox.ini
+++ b/tox.ini
@@ -24,14 +24,21 @@ lint_folders =
 [testenv:lint]
 description = Run linters and type checks
 package = skip
+allowlist_externals = 
+    npm
+    npx
 deps =
     ruff
     mypy
+    nodeenv
     sphinx-lint
+commands_pre =
+    npm install prettier
 commands =
     ruff format --diff {[testenv]lint_folders}
     ruff check {[testenv]lint_folders}
     mypy {[testenv]lint_folders}
+    npx prettier --check {[testenv]lint_folders}
     sphinx-lint \
         --enable all \
         --disable line-too-long \
@@ -41,10 +48,18 @@ commands =
 [testenv:format]
 description = Abuse tox to do actual formatting on all files.
 package = skip
-deps = ruff
+allowlist_externals = 
+    npm
+    npx
+deps =
+    ruff
+    nodeenv
+commands_pre =
+    npm install prettier
 commands =
     ruff format {[testenv]lint_folders}
     ruff check --fix-only {[testenv]lint_folders} "{toxinidir}/README.rst" {posargs}
+    npx prettier --write {[testenv]lint_folders}
 
 [testenv:tests]
 description = Run basic package tests with pytest (not the architectures)


### PR DESCRIPTION
Should avoid noise by changing these file types in the future.

I applied the de facto standard formatter Prettier.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--615.org.readthedocs.build/en/615/

<!-- readthedocs-preview metatrain end -->