### PR TITLE
Small fix of rst link

### DIFF
--- a/docs/src/advanced-concepts/output-naming.rst
+++ b/docs/src/advanced-concepts/output-naming.rst
@@ -2,7 +2,7 @@ Output naming
 =============
 
 The name and format of the outputs in ``metatrain`` are based on those of the
-`<metatomic https://docs.metatensor.org/metatomic/latest/outputs/index.html>`_
+`metatomic <https://docs.metatensor.org/metatomic/latest/outputs/index.html>`_
 package. An immediate example is given by the ``energy`` output.
 
 Any additional outputs present within the library are denoted by the


### PR DESCRIPTION
Small typo of the link 

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--624.org.readthedocs.build/en/624/

<!-- readthedocs-preview metatrain end -->