### PR TITLE
Fix bug when log_separate_blocks is True

### DIFF
--- a/src/metatrain/pet/trainer.py
+++ b/src/metatrain/pet/trainer.py
@@ -433,6 +433,7 @@ class Trainer(TrainerInterface):
                 scaler_scales = (
                     model.module if is_distributed else model
                 ).scaler.get_scales_dict()
+
                 metric_logger = MetricLogger(
                     log_obj=ROOT_LOGGER,
                     dataset_info=(

--- a/src/metatrain/utils/metrics.py
+++ b/src/metatrain/utils/metrics.py
@@ -36,7 +36,7 @@ class RMSEAccumulator:
 
                 key_to_write = copy.deepcopy(key)
                 if self.separate_blocks:
-                    key_to_write += "("
+                    key_to_write += " ("
                     for name, value in zip(block_key.names, block_key.values):
                         key_to_write += f"{name}={int(value)},"
                     key_to_write = key_to_write[:-1]
@@ -141,7 +141,7 @@ class MAEAccumulator:
 
                 key_to_write = copy.deepcopy(key)
                 if self.separate_blocks:
-                    key_to_write += "("
+                    key_to_write += " ("
                     for name, value in zip(block_key.names, block_key.values):
                         key_to_write += f"{name}={int(value)},"
                     key_to_write = key_to_write[:-1]

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -102,18 +102,18 @@ def test_per_block(accumulator_class, tensor_map_with_grad_1, tensor_map_with_gr
 
     print(accumulator.information)
 
-    assert accumulator.information["energy(label_name=0)"][1] == 30
-    assert accumulator.information["energy(label_name=1)"][1] == 30
-    assert accumulator.information["energy(label_name=0)_gradient_gradients"][1] == 30
-    assert accumulator.information["energy(label_name=1)_gradient_gradients"][1] == 30
+    assert accumulator.information["energy (label_name=0)"][1] == 30
+    assert accumulator.information["energy (label_name=1)"][1] == 30
+    assert accumulator.information["energy (label_name=0)_gradient_gradients"][1] == 30
+    assert accumulator.information["energy (label_name=1)_gradient_gradients"][1] == 30
 
     metrics = accumulator.finalize(not_per_atom=["gradient_gradients"])
 
     rmse_or_mae = "RMSE" if accumulator_class == RMSEAccumulator else "MAE"
-    assert f"energy(label_name=0) {rmse_or_mae} (per atom)" in metrics
-    assert f"energy(label_name=0)_gradient_gradients {rmse_or_mae}" in metrics
-    assert f"energy(label_name=1) {rmse_or_mae} (per atom)" in metrics
-    assert f"energy(label_name=1)_gradient_gradients {rmse_or_mae}" in metrics
+    assert f"energy (label_name=0) {rmse_or_mae} (per atom)" in metrics
+    assert f"energy (label_name=0)_gradient_gradients {rmse_or_mae}" in metrics
+    assert f"energy (label_name=1) {rmse_or_mae} (per atom)" in metrics
+    assert f"energy (label_name=1)_gradient_gradients {rmse_or_mae}" in metrics
 
 
 def test_get_selected_metric():


### PR DESCRIPTION
The code was crashing when `log_separate_blocks` is `True` due to a missing space between the target name and the block labels.


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--626.org.readthedocs.build/en/626/

<!-- readthedocs-preview metatrain end -->