### PR TITLE
 Set the seed for regression tests inside the functions

### DIFF
--- a/src/metatrain/experimental/nanopet/tests/test_regression.py
+++ b/src/metatrain/experimental/nanopet/tests/test_regression.py
@@ -14,14 +14,11 @@ from metatrain.utils.neighbor_lists import get_system_with_neighbor_lists
 from . import DATASET_PATH, DEFAULT_HYPERS, MODEL_HYPERS
 
 
-# reproducibility
-random.seed(0)
-np.random.seed(0)
-torch.manual_seed(0)
-
-
 def test_regression_init():
     """Perform a regression test on the model at initialization"""
+    random.seed(0)
+    np.random.seed(0)
+    torch.manual_seed(0)
 
     targets = {}
     targets["mtt::U0"] = get_energy_target_info({"quantity": "energy", "unit": "eV"})
@@ -44,11 +41,11 @@ def test_regression_init():
 
     expected_output = torch.tensor(
         [
-            [-0.361842244864],
-            [-0.222126781940],
-            [-0.145303070545],
-            [-0.189965277910],
-            [-0.048939596862],
+            [0.163995444775],
+            [0.068577021360],
+            [-0.003538529389],
+            [0.049175731838],
+            [0.044154867530],
         ]
     )
 
@@ -60,8 +57,10 @@ def test_regression_init():
 
 
 def test_regression_train():
-    """Perform a regression test on the model when
-    trained for 2 epoch on a small dataset"""
+    """Regression test for the model when trained for 2 epoch on a small dataset"""
+    random.seed(0)
+    np.random.seed(0)
+    torch.manual_seed(0)
 
     systems = read_systems(DATASET_PATH)
 
@@ -113,16 +112,16 @@ def test_regression_train():
 
     expected_output = torch.tensor(
         [
-            [0.675404727459],
-            [0.414229094982],
-            [0.305283188820],
-            [0.677668213844],
-            [0.318834125996],
+            [0.260419785976],
+            [0.258879989386],
+            [0.127974838018],
+            [0.177975922823],
+            [0.136635094881],
         ]
     )
 
     # if you need to change the hardcoded values:
-    torch.set_printoptions(precision=12)
-    print(output["mtt::U0"].block().values)
+    # torch.set_printoptions(precision=12)
+    # print(output["mtt::U0"].block().values)
 
     torch.testing.assert_close(output["mtt::U0"].block().values, expected_output)

--- a/src/metatrain/gap/tests/test_errors.py
+++ b/src/metatrain/gap/tests/test_errors.py
@@ -26,7 +26,7 @@ np.random.seed(0)
 torch.manual_seed(0)
 
 
-def test_ethanol_regression_train_and_invariance():
+def test_more_sparse_points_than_envs():
     """test the error if the number of sparse point
     is bigger than the number of environments
     """

--- a/src/metatrain/gap/tests/test_regression.py
+++ b/src/metatrain/gap/tests/test_regression.py
@@ -18,28 +18,11 @@ from . import DATASET_ETHANOL_PATH, DATASET_PATH, DEFAULT_HYPERS
 torch.set_default_dtype(torch.float64)  # GAP only supports float64
 
 
-# reproducibility
-random.seed(0)
-np.random.seed(0)
-torch.manual_seed(0)
-
-
-def test_regression_init():
-    """Perform a regression test on the model at initialization"""
-    targets = {}
-    targets["mtt::U0"] = get_energy_target_info({"unit": "eV"})
-
-    dataset_info = DatasetInfo(
-        length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=targets
-    )
-    GAP(DEFAULT_HYPERS["model"], dataset_info)
-
-
-def test_regression_train_and_invariance():
-    """Perform a regression test on the model when trained for 2 epoch on a small
-    dataset.  We perform also the invariance test here because one needs a trained model
-    for this.
-    """
+def test_regression_train():
+    """Regression test on the model when trained for 2 epoch on a small dataset"""
+    random.seed(0)
+    np.random.seed(0)
+    torch.manual_seed(0)
 
     systems = read_systems(DATASET_PATH)
 
@@ -89,34 +72,9 @@ def test_regression_train_and_invariance():
 
     assert torch.allclose(output["mtt::U0"].block().values, expected_output, rtol=0.3)
 
-    # Tests that the model is rotationally invariant
-    system = read(DATASET_PATH)
-    system.numbers = np.ones(len(system.numbers))
 
-    original_system = copy.deepcopy(system)
-    system.rotate(48, "y")
-
-    original_output = gap(
-        [metatomic.torch.systems_to_torch(original_system)],
-        {"mtt::U0": gap.outputs["mtt::U0"]},
-    )
-    rotated_output = gap(
-        [metatomic.torch.systems_to_torch(system)],
-        {"mtt::U0": gap.outputs["mtt::U0"]},
-    )
-
-    assert torch.allclose(
-        original_output["mtt::U0"].block().values,
-        rotated_output["mtt::U0"].block().values,
-    )
-
-
-def test_ethanol_regression_train_and_invariance():
-    """Perform a regression test on the model when trained for 2 epoch on a small
-    dataset.  We perform also the invariance test here because one needs a trained model
-    for this.
-    """
-
+def test_invariance():
+    """Check that GAP is rotationally invariant"""
     systems = read_systems(DATASET_ETHANOL_PATH)
 
     conf = {

--- a/src/metatrain/pet/tests/test_regression.py
+++ b/src/metatrain/pet/tests/test_regression.py
@@ -19,9 +19,7 @@ from . import DATASET_PATH, DATASET_WITH_FORCES_PATH, DEFAULT_HYPERS, MODEL_HYPE
 
 
 def test_regression_init():
-    """Perform a regression test on the model at initialization"""
-
-    # reproducibility
+    """Regression test for the model at initialization"""
     random.seed(0)
     np.random.seed(0)
     torch.manual_seed(0)
@@ -63,10 +61,7 @@ def test_regression_init():
 
 
 def test_regression_energies_forces_train():
-    """Perform a regression test on the model when trained for 2 epoch on a small "
-    "dataset with energies and forces"""
-
-    # reproducibility
+    """Regression test for the model when trained for 2 epoch on a small dataset"""
     random.seed(0)
     np.random.seed(0)
     torch.manual_seed(0)

--- a/src/metatrain/soap_bpnn/tests/test_regression.py
+++ b/src/metatrain/soap_bpnn/tests/test_regression.py
@@ -17,14 +17,11 @@ from metatrain.utils.neighbor_lists import (
 from . import DATASET_PATH, DEFAULT_HYPERS, MODEL_HYPERS
 
 
-# reproducibility
-random.seed(0)
-np.random.seed(0)
-torch.manual_seed(0)
-
-
 def test_regression_init():
     """Perform a regression test on the model at initialization"""
+    random.seed(0)
+    np.random.seed(0)
+    torch.manual_seed(0)
 
     targets = {}
     targets["mtt::U0"] = get_energy_target_info({"unit": "eV"})
@@ -50,11 +47,11 @@ def test_regression_init():
 
     expected_output = torch.tensor(
         [
-            [-0.101833008230],
-            [-0.072022750974],
-            [0.049263622612],
-            [-0.041890706867],
-            [-0.038003440946],
+            [0.115978844464],
+            [0.074449732900],
+            [-0.024028975517],
+            [0.192573457956],
+            [-0.221303701401],
         ]
     )
 
@@ -66,8 +63,10 @@ def test_regression_init():
 
 
 def test_regression_train():
-    """Perform a regression test on the model when
-    trained for 2 epoch on a small dataset"""
+    """Regression test for the model when trained for 2 epoch on a small dataset"""
+    random.seed(0)
+    np.random.seed(0)
+    torch.manual_seed(0)
 
     systems = read_systems(DATASET_PATH)
 
@@ -122,11 +121,11 @@ def test_regression_train():
 
     expected_output = torch.tensor(
         [
-            [1.620890259743],
-            [5.662323951721],
-            [9.532886505127],
-            [4.712886810303],
-            [2.171051025391],
+            [1.643912792206],
+            [1.634970188141],
+            [5.043813705444],
+            [10.300852775574],
+            [2.965628623962],
         ]
     )
 

--- a/tests/cli/test_export_model.py
+++ b/tests/cli/test_export_model.py
@@ -129,16 +129,15 @@ def test_huggingface(monkeypatch, tmp_path):
     model from HuggingFace."""
     monkeypatch.chdir(tmp_path)
 
-    HF_TOKEN = os.getenv("HUGGINGFACE_TOKEN_METATRAIN")
-    if HF_TOKEN is None:
+    hf_token = os.getenv("HUGGINGFACE_TOKEN_METATRAIN")
+    if hf_token is None or len(hf_token) == 0:
         pytest.skip("HuggingFace token not found in environment.")
-    assert len(HF_TOKEN) > 0
 
     command = [
         "mtt",
         "export",
         "https://huggingface.co/metatensor/metatrain-test/resolve/main/model.ckpt",
-        f"--token={HF_TOKEN}",
+        f"--token={hf_token}",
     ]
 
     output = "model.pt"
@@ -157,13 +156,13 @@ def test_huggingface(monkeypatch, tmp_path):
 def test_huggingface_env(monkeypatch, tmp_path):
     """Test that huggingphase export works with env variable."""
 
-    token = os.getenv("HUGGINGFACE_TOKEN_METATRAIN")
-    if token is None:
+    hf_token = os.getenv("HUGGINGFACE_TOKEN_METATRAIN")
+    if hf_token is None or len(hf_token) == 0:
         pytest.skip("HuggingFace token not found in environment.")
 
     monkeypatch.chdir(tmp_path)
     env = os.environ.copy()
-    env["HF_TOKEN"] = token
+    env["HF_TOKEN"] = hf_token
 
     assert len(env["HF_TOKEN"]) > 0
 

--- a/tests/resources/generate-outputs.sh
+++ b/tests/resources/generate-outputs.sh
@@ -5,18 +5,18 @@ echo "Generating data for testing..."
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-cd $ROOT_DIR
+cd "$ROOT_DIR"
 
 mtt train options.yaml -o model-32-bit.pt -r base_precision=32
 mtt train options.yaml -o model-64-bit.pt -r base_precision=64
 mtt train options-pet.yaml -o model-pet.pt
 
 # upload results to private HF repo if token is set
-if [ -n "${HUGGINGFACE_TOKEN_METATRAIN:-}" ]; then
+if [[ "${HUGGINGFACE_TOKEN_METATRAIN+}" != "" ]]; then
     huggingface-cli upload \
         "metatensor/metatrain-test" \
         "model-32-bit.ckpt" \
         "model.ckpt" \
         --commit-message="Overwrite test model with new version" \
-        --token=$HUGGINGFACE_TOKEN_METATRAIN
+        --token="$HUGGINGFACE_TOKEN_METATRAIN"
 fi

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -79,9 +79,8 @@ def test_load_model_token():
     model from HuggingFace."""
 
     hf_token = os.getenv("HUGGINGFACE_TOKEN_METATRAIN")
-    if hf_token is None:
+    if hf_token is None or len(hf_token) == 0:
         pytest.skip("HuggingFace token not found in environment.")
-    assert len(hf_token) > 0
 
     path = "https://huggingface.co/metatensor/metatrain-test/resolve/main/model.ckpt"
     load_model(path, hf_token=hf_token)
@@ -89,9 +88,8 @@ def test_load_model_token():
 
 def test_load_model_token_invalid_url_style():
     hf_token = os.getenv("HUGGINGFACE_TOKEN_METATRAIN")
-    if hf_token is None:
+    if hf_token is None or len(hf_token) == 0:
         pytest.skip("HuggingFace token not found in environment.")
-    assert len(hf_token) > 0
 
     # change `resolve` to ``foo`` to make the URL scheme invalid
     path = "https://huggingface.co/metatensor/metatrain-test/foo/main/model.ckpt"


### PR DESCRIPTION
Re-opening #631 as a PR from a branch on this repo until codecov get fixed.

----

Setting them at the module level means they are set when pytest performs test discovery. If more tests are added, the regression tests will start with a different RNG state than expected and fail.



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--632.org.readthedocs.build/en/632/

<!-- readthedocs-preview metatrain end -->