### PR TITLE
Allow DiskDataset samples to be pre-loaded into memory

### DIFF
--- a/docs/src/getting-started/custom_dataset_conf.rst
+++ b/docs/src/getting-started/custom_dataset_conf.rst
@@ -235,3 +235,51 @@ section to your ``options.yaml`` file:
    While the ``extra_data`` section can always be present, it will typically be ignored
    unless using specific loss functions. If the loss function you picked does not
    support the extra data, it will be ignored.
+
+
+Disk Datasets
+-------------
+
+For large datasets, it is often impractical to load all data into memory. In such cases,
+you can use the ``DiskDataset`` class to handle datasets stored on disk. This class
+allows you to work with datasets that are too large to fit into memory by loading only
+the necessary parts of the dataset when needed. For an example of how to generate a disk
+dataset, refer to the programmatic examples.
+
+Training data can then be specified in the ``options.yaml`` file as follows:
+
+.. code-block:: yaml
+
+    training_set:
+        systems:
+            read_from: disk_dataset.zip
+            length_unit: angstrom
+        targets:
+            mtt::polarization:
+                read_from: disk_dataset.zip
+
+Optionally, pre-loading of the dataset into memory can be controlled with the
+``preload_disk_dataset`` option. If set to ``true``, the dataset will be loaded into
+memory when the ``DiskDataset`` object is first constructed, prior to running the
+training loop. If unspecified or set to false (the default behaviour), data will be
+loaded directly from disk whenever requested (i.e. upon calls to the dataloader during
+batching).
+
+While the former can speed up training, the latter is the desired choice for large
+datasets that do not fit into memory. For electronic structure data that may already be
+stored as per-system TensorMaps on disk, it is usually best to use a ``DiskDataset`` and
+control the preloading behaviour with the ``preload_disk_dataset`` option depending on
+the size of dataset and available memory.
+
+.. code-block:: yaml
+
+    training_set:
+        preload_disk_dataset: true
+        systems:
+            read_from: disk_dataset.zip
+            length_unit: angstrom
+        targets:
+            mtt::electron_density_basis:
+                read_from: disk_dataset.zip
+            mtt::hamiltonian:
+                read_from: disk_dataset.zip

--- a/src/metatrain/share/schema-dataset.json
+++ b/src/metatrain/share/schema-dataset.json
@@ -85,6 +85,9 @@
                   "type": "string"
                 }
               ]
+            },
+            "preload": {
+              "type": "boolean"
             }
           },
           "additionalProperties": false

--- a/src/metatrain/share/schema-dataset.json
+++ b/src/metatrain/share/schema-dataset.json
@@ -85,9 +85,6 @@
                   "type": "string"
                 }
               ]
-            },
-            "preload": {
-              "type": "boolean"
             }
           },
           "additionalProperties": false
@@ -310,6 +307,10 @@
         }
       },
       "additionalProperties": false
+    },
+    "preload_disk_dataset": {
+      "type": "boolean",
+      "default": false
     }
   },
   "additionalProperties": false

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -425,7 +425,7 @@ class DiskDataset(torch.utils.data.Dataset):
     :param path: Path to the zip file containing the dataset.
     """
 
-    def __init__(self, path: Union[str, Path], in_memory: Optional[bool] = None):
+    def __init__(self, path: Union[str, Path], preload_disk_dataset: bool = False):
         self.zip_file = zipfile.ZipFile(path, "r")
         self._field_names = ["system"]
         # check that we have at least one sample:
@@ -442,9 +442,7 @@ class DiskDataset(torch.utils.data.Dataset):
         self._len = len([f for f in self.zip_file.namelist() if f.endswith(".mta")])
         self._preloaded = False
         self._data = {}
-        if in_memory is None:
-            in_memory = False
-        if in_memory:  # pre-load into memory
+        if preload_disk_dataset:  # pre-load into memory
             for index in range(self._len):
                 self._data[index] = self.__getitem__(index)
             self._preloaded = True

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -425,7 +425,7 @@ class DiskDataset(torch.utils.data.Dataset):
     :param path: Path to the zip file containing the dataset.
     """
 
-    def __init__(self, path: Union[str, Path], in_memory: bool = False):
+    def __init__(self, path: Union[str, Path], in_memory: Optional[bool] = None):
         self.zip_file = zipfile.ZipFile(path, "r")
         self._field_names = ["system"]
         # check that we have at least one sample:
@@ -442,6 +442,8 @@ class DiskDataset(torch.utils.data.Dataset):
         self._len = len([f for f in self.zip_file.namelist() if f.endswith(".mta")])
         self._preloaded = False
         self._data = {}
+        if in_memory is None:
+            in_memory = False
         if in_memory:  # pre-load into memory
             for index in range(self._len):
                 self._data[index] = self.__getitem__(index)

--- a/src/metatrain/utils/data/get_dataset.py
+++ b/src/metatrain/utils/data/get_dataset.py
@@ -31,7 +31,7 @@ def get_dataset(
     if options["systems"]["read_from"].endswith(".zip"):  # disk dataset
         dataset = DiskDataset(
             options["systems"]["read_from"],
-            options["systems"]["preload"],
+            options["preload_disk_dataset"],
         )
         target_info_dictionary = dataset.get_target_info(options["targets"])
         if "extra_data" in options:

--- a/src/metatrain/utils/data/get_dataset.py
+++ b/src/metatrain/utils/data/get_dataset.py
@@ -29,7 +29,10 @@ def get_dataset(
     extra_data_info_dictionary = {}
 
     if options["systems"]["read_from"].endswith(".zip"):  # disk dataset
-        dataset = DiskDataset(options["systems"]["read_from"])
+        dataset = DiskDataset(
+            options["systems"]["read_from"],
+            options["systems"]["preload"],
+        )
         target_info_dictionary = dataset.get_target_info(options["targets"])
         if "extra_data" in options:
             extra_data_info_dictionary = dataset.get_target_info(options["extra_data"])

--- a/src/metatrain/utils/omegaconf.py
+++ b/src/metatrain/utils/omegaconf.py
@@ -86,7 +86,6 @@ CONF_SYSTEMS = OmegaConf.create(
         "read_from": "${..read_from}",
         "reader": None,
         "length_unit": None,
-        "preload": None,
     }
 )
 

--- a/src/metatrain/utils/omegaconf.py
+++ b/src/metatrain/utils/omegaconf.py
@@ -86,6 +86,7 @@ CONF_SYSTEMS = OmegaConf.create(
         "read_from": "${..read_from}",
         "reader": None,
         "length_unit": None,
+        "preload": None,
     }
 )
 

--- a/tests/cli/test_eval_model.py
+++ b/tests/cli/test_eval_model.py
@@ -193,6 +193,7 @@ def test_eval_disk_dataset(monkeypatch, tmp_path, caplog, suffix, preload):
         {
             "systems": {"read_from": "qm9_reduced_100.zip"},
             "targets": {"energy": {"read_from": "qm9_reduced_100.zip"}},
+            "preload_disk_dataset": preload,
         }
     )
 

--- a/tests/cli/test_eval_model.py
+++ b/tests/cli/test_eval_model.py
@@ -179,7 +179,8 @@ def test_eval_no_targets(monkeypatch, tmp_path, model, options):
 
 
 @pytest.mark.parametrize("suffix", [".zip", ".mts"])
-def test_eval_disk_dataset(monkeypatch, tmp_path, caplog, suffix):
+@pytest.mark.parametrize("preload", [True, False])
+def test_eval_disk_dataset(monkeypatch, tmp_path, caplog, suffix, preload):
     """Test that eval via python API runs without an error raise."""
     monkeypatch.chdir(tmp_path)
     caplog.set_level(logging.INFO)

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -846,7 +846,8 @@ def test_train_generic_target_metatensor(monkeypatch, tmp_path, with_scalar_part
     train_model(options)
 
 
-def test_train_disk_dataset(monkeypatch, tmp_path, options):
+@pytest.mark.parametrize("preload", [True, False])
+def test_train_disk_dataset(monkeypatch, tmp_path, options, preload):
     """Test that training via the training cli runs without an error raise
     when learning from a `DiskDataset`."""
     monkeypatch.chdir(tmp_path)
@@ -880,10 +881,12 @@ def test_train_disk_dataset(monkeypatch, tmp_path, options):
 
     options["training_set"]["systems"]["read_from"] = "qm9_reduced_100.zip"
     options["training_set"]["targets"]["energy"]["read_from"] = "qm9_reduced_100.zip"
+    options["training_set"]["preload_disk_dataset"] = preload
     train_model(options)
 
 
-def test_train_disk_dataset_splits_issue_601(monkeypatch, tmp_path, options):
+@pytest.mark.parametrize("preload", [True, False])
+def test_train_disk_dataset_splits_issue_601(monkeypatch, tmp_path, options, preload):
     """Test that training via the training cli runs without an error raise
     when learning from multiple `DiskDataset` objects for training and test datasets, as
     per issue https://github.com/metatensor/metatrain/issues/601."""
@@ -930,6 +933,7 @@ def test_train_disk_dataset_splits_issue_601(monkeypatch, tmp_path, options):
                 }
             },
         }
+        options[f"{subset_name}_set"]["preload_disk_dataset"] = preload
     train_model(options)
 
 


### PR DESCRIPTION
This PR allows the samples of a DiskDataset to be loaded upon construction of the class, thereby avoiding loading from disk every time the `__getitem__` method is called (i.e. on batching). The option to preload, or not, is introduced as a option to the user.

The modus operandi of metatrain **not** using DiskDatasets is to store all targets in a single TensorMap. Under-the-hood, when creating internal `Dataset` objects for training, these target TensorMaps have to be split by system ID. For large targets, this splitting is a costly procedure and is often un-necessary: usually the target data lives on disk as a single TensorMap for each system, so is joined (also not for free) just to be split again. `DiskDataset` offers a means of work-around for this, as targets are stored as one TensorMap per sample, and no splitting needs to occur to create the training datasets.

This of course doesn't offer a complete solution, as by definition the `DiskDataset` loads samples directly from disk. This PR therefore generalizes further allowing either on-disk or in-memory versions of the zip dataset depending on RAM contraints.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--656.org.readthedocs.build/en/656/

<!-- readthedocs-preview metatrain end -->