### PR TITLE
Fix `.rst` title in disk dataset example

### DIFF
--- a/examples/programmatic/disk_dataset/README.rst
+++ b/examples/programmatic/disk_dataset/README.rst
@@ -1,2 +1,2 @@
-Using metatrain architectures outside of metatrain
-==================================================
+Saving a disk dataset
+=====================


### PR DESCRIPTION
Fix .rst title in disk dataset example

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--657.org.readthedocs.build/en/657/

<!-- readthedocs-preview metatrain end -->