### PR TITLE
Setup merge queue to run tests on GPU once per PR

### DIFF
--- a/.github/workflows/merge-tests.yml
+++ b/.github/workflows/merge-tests.yml
@@ -1,0 +1,35 @@
+name: Merge queue tests
+
+# This file defines tests that will run once per PR, before merging it. We use it to run
+# expensive tests before merging code while not running them on every single commit.
+on:
+  merge_group:
+
+jobs:
+  merge-queue-tests:
+    name: ${{ matrix.test-name }}
+    strategy:
+      matrix:
+        test-name:
+          - tests
+          - gap-tests
+          - soap-bpnn-tests
+          - pet-tests
+          - nanopet-tests
+          - deprecated-pet-tests
+
+    runs-on: ubuntu-22.04 # TODO replace with a GPU-enabled runner
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+
+      - run: pip install tox
+
+      - name: run Python tests
+        run: |
+          tox -e ${{ matrix.test-name }}


### PR DESCRIPTION
This PR adds an additional CI job that runs the test suite on a GPU-capable runner. The job will be triggered in two cases:

1. Weekly schedule – once every Monday.
2. Just before a PR is merged – using GitHub’s [merge_group](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) trigger. While this feature is designed for managing queues of PRs with many commits, it serves our purpose well for running final checks before merge.

At this stage, the logic still needs testing. For now, the job runs on a standard runner. Once everything works as expected, we’ll switch to a GPU runner (which incurs additional cost 💸) and enable the full architecture tests on GPU.