### PR TITLE
Change llpr architecture name to "llpr" instead of "llpr_wrapper"

### DIFF
--- a/src/metatrain/utils/architectures.py
+++ b/src/metatrain/utils/architectures.py
@@ -24,7 +24,7 @@ def check_architecture_name(name: str) -> None:
     :raises ValueError: if the architecture is not found
     """
     try:
-        if name == "llpr_wrapper":
+        if name == "llpr":
             return
         if find_spec(f"metatrain.{name}") is not None:
             return
@@ -123,7 +123,7 @@ def import_architecture(name: str):
     """
     check_architecture_name(name)
     try:
-        if name == "llpr_wrapper":
+        if name == "llpr":
             return importlib.import_module("metatrain.utils.llpr")
         else:
             return importlib.import_module(f"metatrain.{name}")
@@ -171,7 +171,7 @@ def find_all_architectures() -> List[str]:
     architecture_names = []
     for option_file_path in options_files_path:
         architecture_names.append(get_architecture_name(option_file_path))
-    architecture_names.append("llpr_wrapper")
+    architecture_names.append("llpr")
 
     return architecture_names
 

--- a/src/metatrain/utils/llpr.py
+++ b/src/metatrain/utils/llpr.py
@@ -587,11 +587,15 @@ class LLPRUncertaintyModel(torch.nn.Module):
                 "Trying to save a LLPR checkpoint, but model has not been "
                 "calibrated yet."
             )
+
+        # FIXME: this is very hacky, there should be a way to get the architecture
+        # name from a model instance
         wrapped_architecture_name = self.model.__module__.replace(
             "metatrain.", ""
         ).replace(".model", "")
+
         checkpoint = {
-            "architecture_name": "llpr_wrapper",
+            "architecture_name": "llpr",
             "wrapped_architecture_name": wrapped_architecture_name,
             "wrapped_model_data": {  # necessary to re-instantiate the wrapped model
                 "model_hypers": self.model.hypers,
@@ -609,6 +613,7 @@ class LLPRUncertaintyModel(torch.nn.Module):
         dtype = next(state_dict_iter).dtype
 
         wrapped_model_data = checkpoint["wrapped_model_data"]
+        # FIXME: LLPR should use `model_from_checkpoint` like everyone else
         wrapped_model_class = import_architecture(
             checkpoint["wrapped_architecture_name"]
         ).__model__

--- a/tests/utils/test_architectures.py
+++ b/tests/utils/test_architectures.py
@@ -29,7 +29,7 @@ def test_find_all_architectures():
     assert "soap_bpnn" in all_arches
     assert "experimental.nanopet" in all_arches
     assert "deprecated.pet" in all_arches
-    assert "llpr_wrapper" in all_arches
+    assert "llpr" in all_arches
 
 
 def test_get_architecture_path():
@@ -39,7 +39,7 @@ def test_get_architecture_path():
 @pytest.mark.parametrize("name", find_all_architectures())
 def test_get_default_hypers(name):
     """Test that architecture hypers for all arches can be loaded."""
-    if name == "llpr_wrapper":
+    if name == "llpr":
         # Skip this architecture as it is not a valid architecture but a wrapper
         return
     default_hypers = get_default_hypers(name)
@@ -110,7 +110,7 @@ def test_get_architecture_name_err_no_such_arch():
 @pytest.mark.parametrize("name", find_all_architectures())
 def test_check_valid_default_architecture_options(name):
     """Test that all default hypers are according to the provided schema."""
-    if name == "llpr_wrapper":
+    if name == "llpr":
         # Skip this architecture as it is not a valid architecture but a wrapper
         return
     options = get_default_hypers(name)


### PR DESCRIPTION
This should make the checkpoints a bit more forward-compatible when making LLPR a proper architecture (#663)

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--664.org.readthedocs.build/en/664/

<!-- readthedocs-preview metatrain end -->