### PR TITLE
Replace prettier by `yamlfix` and `jsonfix`

### DIFF
--- a/developer/jsonfix.py
+++ b/developer/jsonfix.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+JsonFix: Lint and format JSON files.
+
+Recursively traverses given files and directories, validates JSON syntax, and reformats
+files with consistent indentation.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    """
+    Parse command-line arguments.
+
+    :returns: Parsed arguments
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        help="Files or directories to process (.json files only)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Only check if files are valid and properly formatted (no changes made)",
+    )
+    return parser.parse_args()
+
+
+def collect_json_files(paths: list[str]) -> list[Path]:
+    """
+    Recursively collect all .json files from the given paths.
+
+    :param paths: List of file and directory paths
+    :returns: List of resolved JSON file paths
+    """
+    json_files: list[Path] = []
+
+    for entry in paths:
+        path = Path(entry)
+
+        if path.is_file() and path.suffix == ".json":
+            json_files.append(path.resolve())
+        elif path.is_dir():
+            json_files.extend(f.resolve() for f in path.rglob("*.json") if f.is_file())
+
+    return json_files
+
+
+def check_and_format_file(path: Path, check_only: bool = False) -> tuple[bool, bool]:
+    """
+    Check and (optionally) format a single JSON file.
+
+    :param path: Path to the JSON file.
+    :param check_only: If True, only check; otherwise, reformat if needed.
+    :returns: is_valid and was_changed
+    """
+    try:
+        original = path.read_text(encoding="utf-8")
+        data = json.loads(original)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return False, False
+
+    formatted = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+
+    if original != formatted:
+        if not check_only:
+            path.write_text(formatted, encoding="utf-8")
+        return True, True
+
+    return True, False
+
+
+def main() -> None:
+    """Main function coordinating JSON file checking and formatting."""
+    args = parse_args()
+    json_files = collect_json_files(args.paths)
+
+    print("JsonFix: Checking files" if args.check else "JsonFix: Fixing files")
+
+    total = 0
+    changed = 0
+    had_invalid = False
+
+    for file_path in json_files:
+        is_valid, was_changed = check_and_format_file(file_path, check_only=args.check)
+        total += 1
+
+        if not is_valid:
+            print(f"✘ Invalid JSON: {file_path}")
+            had_invalid = True
+            continue
+
+        if was_changed:
+            action = "Would fix" if args.check else "Fixed"
+            print(f"{action} {file_path}")
+            changed += 1
+
+    print(f"Checked {total} files: {changed} fixed, {total - changed} left unchanged")
+
+    if had_invalid or (args.check and changed > 0):
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/static/qm9/eval.yaml
+++ b/docs/static/qm9/eval.yaml
@@ -1,5 +1,6 @@
-systems: "qm9_reduced_100.xyz"
+systems: qm9_reduced_100.xyz
+
 targets:
   energy:
-    key: "U0"
-    unit: "eV"
+    key: U0
+    unit: eV

--- a/docs/static/qm9/options.yaml
+++ b/docs/static/qm9/options.yaml
@@ -2,17 +2,17 @@
 architecture:
   name: soap_bpnn
   training:
-    num_epochs: 5 # a very short training run
+    num_epochs: 5  # a very short training run
     batch_size: 10
 
 # Mandatory section defining the parameters for system and target data of the
 # training set
 training_set:
-  systems: "qm9_reduced_100.xyz" # file where the positions are stored
+  systems: qm9_reduced_100.xyz  # file where the positions are stored
   targets:
     energy:
-      key: "U0" # name of the target value
-      unit: "eV" # unit of the target value
+      key: U0  # name of the target value
+      unit: eV  # unit of the target value
 
-test_set: 0.1 # 10 % of the training_set are randomly split and taken for test set
-validation_set: 0.1 # 10 % of the training_set are randomly split and for validation
+test_set: 0.1  # 10 % of the training_set are randomly split and taken for test set
+validation_set: 0.1  # 10 % of the training_set are randomly split and for validation

--- a/examples/ase/options.yaml
+++ b/examples/ase/options.yaml
@@ -5,11 +5,11 @@ architecture:
 
 # training set section
 training_set:
-  systems: "ethanol_reduced_100.xyz"
+  systems: ethanol_reduced_100.xyz
   targets:
     energy:
-      key: "energy"
-      unit: "kcal/mol" # very important to run simulations
+      key: energy
+      unit: kcal/mol  # very important to run simulations
 
 validation_set: 0.1
 test_set: 0.0

--- a/examples/programmatic/llpr/options.yaml
+++ b/examples/programmatic/llpr/options.yaml
@@ -11,11 +11,11 @@ architecture:
 
 # Section defining the parameters for system and target data
 training_set:
-  systems: "qm9_reduced_100.xyz"
+  systems: qm9_reduced_100.xyz
   targets:
     energy:
-      key: "U0"
-      unit: "hartree" # very important to run simulations
+      key: U0
+      unit: hartree  # very important to run simulations
 
 validation_set: 0.1
 test_set: 0.0

--- a/examples/zbl/options_no_zbl.yaml
+++ b/examples/zbl/options_no_zbl.yaml
@@ -15,8 +15,8 @@ training_set:
     length_unit: angstrom
   targets:
     energy:
-      key: "energy"
-      unit: "eV" # very important to run simulations
+      key: energy
+      unit: eV  # very important to run simulations
 
 validation_set: 0.1
 test_set: 0.0

--- a/examples/zbl/options_zbl.yaml
+++ b/examples/zbl/options_zbl.yaml
@@ -15,8 +15,8 @@ training_set:
     length_unit: angstrom
   targets:
     energy:
-      key: "energy"
-      unit: "eV" # very important to run simulations
+      key: energy
+      unit: eV  # very important to run simulations
 
 validation_set: 0.1
 test_set: 0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,3 +144,9 @@ filterwarnings = [
     # OldCompositionModel deprecation warning
     "ignore:`OldCompositionModel` composition model is deprecated. Please use `CompositionModel` instead."
 ]
+
+[tool.yamlfix]
+line_length = 88
+explicit_start = false
+section_whitelines = 1
+none_representation = "null"

--- a/src/metatrain/deprecated/pet/default-hypers.yaml
+++ b/src/metatrain/deprecated/pet/default-hypers.yaml
@@ -1,13 +1,12 @@
 architecture:
   name: deprecated.pet
-
   model:
     CUTOFF_DELTA: 0.2
-    AVERAGE_POOLING: False
-    TRANSFORMERS_CENTRAL_SPECIFIC: False
-    HEADS_CENTRAL_SPECIFIC: False
-    ADD_TOKEN_FIRST: True
-    ADD_TOKEN_SECOND: True
+    AVERAGE_POOLING: false
+    TRANSFORMERS_CENTRAL_SPECIFIC: false
+    HEADS_CENTRAL_SPECIFIC: false
+    ADD_TOKEN_FIRST: true
+    ADD_TOKEN_SECOND: true
     N_GNN_LAYERS: 3
     TRANSFORMER_D_MODEL: 128
     TRANSFORMER_N_HEAD: 4
@@ -15,51 +14,50 @@ architecture:
     HEAD_N_NEURONS: 128
     N_TRANS_LAYERS: 3
     ACTIVATION: silu
-    USE_LENGTH: True
-    USE_ONLY_LENGTH: False
+    USE_LENGTH: true
+    USE_ONLY_LENGTH: false
     R_CUT: 5.0
-    R_EMBEDDING_ACTIVATION: False
+    R_EMBEDDING_ACTIVATION: false
     COMPRESS_MODE: mlp
-    BLEND_NEIGHBOR_SPECIES: False
-    AVERAGE_BOND_ENERGIES: False
-    USE_BOND_ENERGIES: True
-    USE_ADDITIONAL_SCALAR_ATTRIBUTES: False
+    BLEND_NEIGHBOR_SPECIES: false
+    AVERAGE_BOND_ENERGIES: false
+    USE_BOND_ENERGIES: true
+    USE_ADDITIONAL_SCALAR_ATTRIBUTES: false
     SCALAR_ATTRIBUTES_SIZE: null
-    TRANSFORMER_TYPE: PostLN # PostLN or PreLN
-    USE_LONG_RANGE: False
-    K_CUT: null # should be float; only used when USE_LONG_RANGE is True
+    TRANSFORMER_TYPE: PostLN  # PostLN or PreLN
+    USE_LONG_RANGE: false
+    K_CUT: null  # should be float; only used when USE_LONG_RANGE is True
     K_CUT_DELTA: null
-    DTYPE: float32 # float32 or float16 or bfloat16
+    DTYPE: float32  # float32 or float16 or bfloat16
     N_TARGETS: 1
     TARGET_INDEX_KEY: target_index
     RESIDUAL_FACTOR: 0.5
-    USE_ZBL: False
-
+    USE_ZBL: false
   training:
-    USE_LORA_PEFT: False
+    USE_LORA_PEFT: false
     LORA_RANK: 4
     LORA_ALPHA: 0.5
     INITIAL_LR: 1e-4
     EPOCH_NUM_ATOMIC: 1000000000
     EPOCHS_WARMUP_ATOMIC: 100000000
     SCHEDULER_STEP_SIZE_ATOMIC: 500000000 # structural version is called "SCHEDULER_STEP_SIZE"
-    GLOBAL_AUG: True
+    GLOBAL_AUG: true
     SLIDING_FACTOR: 0.7
     ATOMIC_BATCH_SIZE: 850 # structural version is called "STRUCTURAL_BATCH_SIZE"
-    BALANCED_DATA_LOADER: False # if True, use DynamicBatchSampler from torch_geometric
+    BALANCED_DATA_LOADER: false  # if True, use DynamicBatchSampler from torch_geometric
     MAX_TIME: 234000
-    ENERGY_WEIGHT: 0.1 # only used when fitting MLIP
-    MULTI_GPU: False
+    ENERGY_WEIGHT: 0.1  # only used when fitting MLIP
+    MULTI_GPU: false
     RANDOM_SEED: 0
-    CUDA_DETERMINISTIC: False
+    CUDA_DETERMINISTIC: false
     MODEL_TO_START_WITH: null
     ALL_SPECIES_PATH: null
     SELF_CONTRIBUTIONS_PATH: null
-    SUPPORT_MISSING_VALUES: False
-    USE_WEIGHT_DECAY: False
+    SUPPORT_MISSING_VALUES: false
+    USE_WEIGHT_DECAY: false
     WEIGHT_DECAY: 0.0
-    DO_GRADIENT_CLIPPING: False
-    GRADIENT_CLIPPING_MAX_NORM: null # must be overwritten if DO_GRADIENT_CLIPPING is True
-    USE_SHIFT_AGNOSTIC_LOSS: False # only used when fitting general target. Primary use case: EDOS
-    ENERGIES_LOSS: per_structure # per_structure or per_atom
+    DO_GRADIENT_CLIPPING: false
+    GRADIENT_CLIPPING_MAX_NORM: null  # must be overwritten if DO_GRADIENT_CLIPPING is True
+    USE_SHIFT_AGNOSTIC_LOSS: false  # only used when fitting general target. Primary use case: EDOS
+    ENERGIES_LOSS: per_structure  # per_structure or per_atom
     CHECKPOINT_INTERVAL: 100

--- a/src/metatrain/deprecated/pet/schema-hypers.json
+++ b/src/metatrain/deprecated/pet/schema-hypers.json
@@ -4,7 +4,9 @@
   "properties": {
     "name": {
       "type": "string",
-      "enum": ["deprecated.pet"]
+      "enum": [
+        "deprecated.pet"
+      ]
     },
     "model": {
       "type": "object",
@@ -113,7 +115,11 @@
         },
         "DTYPE": {
           "type": "string",
-          "enum": ["float32", "float64", "bfloat16"]
+          "enum": [
+            "float32",
+            "float64",
+            "bfloat16"
+          ]
         },
         "N_TARGETS": {
           "type": "integer"
@@ -247,7 +253,10 @@
         },
         "ENERGIES_LOSS": {
           "type": "string",
-          "enum": ["per_structure", "per_atom"]
+          "enum": [
+            "per_structure",
+            "per_atom"
+          ]
         },
         "BALANCED_DATA_LOADER": {
           "type": "boolean"
@@ -260,22 +269,34 @@
       "allOf": [
         {
           "not": {
-            "required": ["SCHEDULER_STEP_SIZE", "SCHEDULER_STEP_SIZE_ATOMIC"]
+            "required": [
+              "SCHEDULER_STEP_SIZE",
+              "SCHEDULER_STEP_SIZE_ATOMIC"
+            ]
           }
         },
         {
           "not": {
-            "required": ["EPOCH_NUM", "EPOCH_NUM_ATOMIC"]
+            "required": [
+              "EPOCH_NUM",
+              "EPOCH_NUM_ATOMIC"
+            ]
           }
         },
         {
           "not": {
-            "required": ["STRUCTURAL_BATCH_SIZE", "ATOMIC_BATCH_SIZE"]
+            "required": [
+              "STRUCTURAL_BATCH_SIZE",
+              "ATOMIC_BATCH_SIZE"
+            ]
           }
         },
         {
           "not": {
-            "required": ["EPOCHS_WARMUP", "EPOCHS_WARMUP_ATOMIC"]
+            "required": [
+              "EPOCHS_WARMUP",
+              "EPOCHS_WARMUP_ATOMIC"
+            ]
           }
         }
       ]

--- a/src/metatrain/experimental/nanopet/default-hypers.yaml
+++ b/src/metatrain/experimental/nanopet/default-hypers.yaml
@@ -1,6 +1,5 @@
 architecture:
   name: experimental.nanopet
-
   model:
     cutoff: 5.0
     cutoff_width: 0.5
@@ -9,16 +8,15 @@ architecture:
     num_attention_layers: 2
     num_gnn_layers: 2
     heads: {}
-    zbl: False
+    zbl: false
     long_range:
       enable: false
       use_ewald: false
       smearing: 1.4
       kspace_resolution: 1.33
       interpolation_nodes: 5
-
   training:
-    distributed: False
+    distributed: false
     distributed_port: 39591
     batch_size: 16
     num_epochs: 10000
@@ -30,7 +28,7 @@ architecture:
     scale_targets: true
     fixed_composition_weights: {}
     per_structure_targets: []
-    log_mae: False
+    log_mae: false
     log_separate_blocks: false
     best_model_metric: rmse_prod
     loss:

--- a/src/metatrain/experimental/nanopet/schema-hypers.json
+++ b/src/metatrain/experimental/nanopet/schema-hypers.json
@@ -4,7 +4,9 @@
   "properties": {
     "name": {
       "type": "string",
-      "enum": ["experimental.nanopet"]
+      "enum": [
+        "experimental.nanopet"
+      ]
     },
     "model": {
       "type": "object",
@@ -32,7 +34,10 @@
           "patternProperties": {
             ".*": {
               "type": "string",
-              "enum": ["linear", "mlp"]
+              "enum": [
+                "linear",
+                "mlp"
+              ]
             }
           },
           "additionalProperties": false
@@ -125,7 +130,11 @@
         },
         "best_model_metric": {
           "type": "string",
-          "enum": ["rmse_prod", "mae_prod", "loss"]
+          "enum": [
+            "rmse_prod",
+            "mae_prod",
+            "loss"
+          ]
         },
         "loss": {
           "type": "object",
@@ -141,13 +150,20 @@
             },
             "reduction": {
               "type": "string",
-              "enum": ["sum", "mean", "none"]
+              "enum": [
+                "sum",
+                "mean",
+                "none"
+              ]
             },
             "type": {
               "oneOf": [
                 {
                   "type": "string",
-                  "enum": ["mse", "mae"]
+                  "enum": [
+                    "mse",
+                    "mae"
+                  ]
                 },
                 {
                   "type": "object",
@@ -165,7 +181,9 @@
                           "additionalProperties": false
                         }
                       },
-                      "required": ["deltas"],
+                      "required": [
+                        "deltas"
+                      ],
                       "additionalProperties": false
                     }
                   },
@@ -181,7 +199,10 @@
     },
     "atomic_types": {
       "type": "array",
-      "items": { "type": "integer", "minimum": 1 },
+      "items": {
+        "type": "integer",
+        "minimum": 1
+      },
       "uniqueItems": true
     }
   },

--- a/src/metatrain/gap/default-hypers.yaml
+++ b/src/metatrain/gap/default-hypers.yaml
@@ -1,6 +1,5 @@
 architecture:
   name: gap
-
   model:
     soap:
       cutoff:
@@ -27,7 +26,6 @@ architecture:
       degree: 2
       num_sparse_points: 500
     zbl: false
-
   training:
     regularizer: 0.001
     regularizer_forces: null

--- a/src/metatrain/gap/schema-hypers.json
+++ b/src/metatrain/gap/schema-hypers.json
@@ -4,7 +4,9 @@
   "properties": {
     "name": {
       "type": "string",
-      "enum": ["gap"]
+      "enum": [
+        "gap"
+      ]
     },
     "model": {
       "type": "object",
@@ -23,7 +25,9 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["ShiftedCosine"]
+                      "enum": [
+                        "ShiftedCosine"
+                      ]
                     },
                     "width": {
                       "type": "number"
@@ -39,7 +43,9 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["Gaussian"]
+                  "enum": [
+                    "Gaussian"
+                  ]
                 },
                 "center_atom_weight": {
                   "type": "number"
@@ -52,7 +58,9 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["Willatt2018"]
+                      "enum": [
+                        "Willatt2018"
+                      ]
                     },
                     "rate": {
                       "type": "number"
@@ -74,7 +82,9 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["TensorProduct"]
+                  "enum": [
+                    "TensorProduct"
+                  ]
                 },
                 "max_angular": {
                   "type": "integer"
@@ -84,7 +94,9 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["Gto"]
+                      "enum": [
+                        "Gto"
+                      ]
                     },
                     "max_radial": {
                       "type": "integer"
@@ -137,7 +149,10 @@
     },
     "atomic_types": {
       "type": "array",
-      "items": { "type": "integer", "minimum": 1 },
+      "items": {
+        "type": "integer",
+        "minimum": 1
+      },
       "uniqueItems": true
     }
   },

--- a/src/metatrain/gap/tests/options-gap.yaml
+++ b/src/metatrain/gap/tests/options-gap.yaml
@@ -1,6 +1,5 @@
 architecture:
   name: gap
-
   model:
     soap:
       cutoff:
@@ -22,33 +21,32 @@ architecture:
         max_angular: 6
         radial:
           type: Gto
-          max_radial: 7 # now exclusive
+          max_radial: 7  # now exclusive
     krr:
       degree: 2
       num_sparse_points: 900
     zbl: false
-
   training:
     regularizer: 0.00005
     regularizer_forces: 0.001
 
 training_set:
-  systems: "ethanol_reduced_100.xyz" # file where the positions are stored
+  systems: ethanol_reduced_100.xyz  # file where the positions are stored
   targets:
     energy:
-      key: "energy" # name of the target value
-      unit: "eV" # unit of the target value
+      key: energy  # name of the target value
+      unit: eV  # unit of the target value
 
 test_set:
-  systems: "ethanol_reduced_100.xyz" # file where the positions are stored
+  systems: ethanol_reduced_100.xyz  # file where the positions are stored
   targets:
     energy:
-      key: "energy" # name of the target value
-      unit: "eV" # unit of the target value
+      key: energy  # name of the target value
+      unit: eV  # unit of the target value
 
 validation_set:
-  systems: "ethanol_reduced_100.xyz" # file where the positions are stored
+  systems: ethanol_reduced_100.xyz  # file where the positions are stored
   targets:
     energy:
-      key: "energy" # name of the target value
-      unit: "eV" # unit of the target value
+      key: energy  # name of the target value
+      unit: eV  # unit of the target value

--- a/src/metatrain/pet/default-hypers.yaml
+++ b/src/metatrain/pet/default-hypers.yaml
@@ -1,6 +1,5 @@
 architecture:
   name: pet
-
   model:
     cutoff: 4.5
     cutoff_width: 0.2
@@ -17,7 +16,6 @@ architecture:
       smearing: 1.4
       kspace_resolution: 1.33
       interpolation_nodes: 5
-
   training:
     distributed: false
     distributed_port: 39591

--- a/src/metatrain/pet/schema-hypers.json
+++ b/src/metatrain/pet/schema-hypers.json
@@ -4,7 +4,9 @@
   "properties": {
     "name": {
       "type": "string",
-      "enum": ["pet"]
+      "enum": [
+        "pet"
+      ]
     },
     "model": {
       "type": "object",
@@ -81,7 +83,10 @@
           "type": "number"
         },
         "weight_decay": {
-          "type": ["number", "null"]
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "scheduler_patience": {
           "type": "integer"
@@ -124,7 +129,11 @@
         },
         "best_model_metric": {
           "type": "string",
-          "enum": ["rmse_prod", "mae_prod", "loss"]
+          "enum": [
+            "rmse_prod",
+            "mae_prod",
+            "loss"
+          ]
         },
         "finetune": {
           "type": "object",
@@ -135,7 +144,11 @@
             },
             "method": {
               "type": "string",
-              "enum": ["full", "lora", "heads"]
+              "enum": [
+                "full",
+                "lora",
+                "heads"
+              ]
             },
             "config": {
               "type": "object",
@@ -149,7 +162,10 @@
                       "type": "integer"
                     }
                   },
-                  "required": ["alpha", "rank"],
+                  "required": [
+                    "alpha",
+                    "rank"
+                  ],
                   "additionalProperties": false
                 },
                 {
@@ -167,7 +183,10 @@
                       }
                     }
                   },
-                  "required": ["head_modules", "last_layer_modules"],
+                  "required": [
+                    "head_modules",
+                    "last_layer_modules"
+                  ],
                   "additionalProperties": false
                 }
               ]
@@ -192,13 +211,20 @@
             },
             "reduction": {
               "type": "string",
-              "enum": ["sum", "mean", "none"]
+              "enum": [
+                "sum",
+                "mean",
+                "none"
+              ]
             },
             "type": {
               "oneOf": [
                 {
                   "type": "string",
-                  "enum": ["mse", "mae"]
+                  "enum": [
+                    "mse",
+                    "mae"
+                  ]
                 },
                 {
                   "type": "object",
@@ -216,7 +242,9 @@
                           "additionalProperties": false
                         }
                       },
-                      "required": ["deltas"],
+                      "required": [
+                        "deltas"
+                      ],
                       "additionalProperties": false
                     }
                   },
@@ -225,7 +253,10 @@
               ]
             },
             "sliding_factor": {
-              "type": ["number", "null"]
+              "type": [
+                "number",
+                "null"
+              ]
             }
           },
           "additionalProperties": false

--- a/src/metatrain/share/schema-base.json
+++ b/src/metatrain/share/schema-base.json
@@ -24,7 +24,11 @@
     },
     "base_precision": {
       "type": "integer",
-      "enum": [16, 32, 64]
+      "enum": [
+        16,
+        32,
+        64
+      ]
     },
     "seed": {
       "type": "integer",
@@ -40,26 +44,44 @@
       },
       "allOf": [
         {
-          "if": { "required": ["entity"] },
+          "if": {
+            "required": [
+              "entity"
+            ]
+          },
           "then": {
             "properties": {
-              "entity": { "type": "string" }
+              "entity": {
+                "type": "string"
+              }
             }
           }
         },
         {
-          "if": { "required": ["project"] },
+          "if": {
+            "required": [
+              "project"
+            ]
+          },
           "then": {
             "properties": {
-              "project": { "type": "string" }
+              "project": {
+                "type": "string"
+              }
             }
           }
         },
         {
-          "if": { "required": ["name"] },
+          "if": {
+            "required": [
+              "name"
+            ]
+          },
           "then": {
             "properties": {
-              "name": { "type": "string" }
+              "name": {
+                "type": "string"
+              }
             }
           }
         }
@@ -72,7 +94,9 @@
           "type": "string"
         }
       },
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "additionalProperties": true
     },
     "training_set": {
@@ -125,6 +149,11 @@
       ]
     }
   },
-  "required": ["architecture", "training_set", "test_set", "validation_set"],
+  "required": [
+    "architecture",
+    "training_set",
+    "test_set",
+    "validation_set"
+  ],
   "additionalProperties": false
 }

--- a/src/metatrain/share/schema-dataset.json
+++ b/src/metatrain/share/schema-dataset.json
@@ -142,7 +142,9 @@
                   "oneOf": [
                     {
                       "type": "string",
-                      "enum": ["scalar"]
+                      "enum": [
+                        "scalar"
+                      ]
                     },
                     {
                       "type": "object",
@@ -150,13 +152,19 @@
                         "cartesian": {
                           "type": "object",
                           "properties": {
-                            "rank": { "type": "integer" }
+                            "rank": {
+                              "type": "integer"
+                            }
                           },
-                          "required": ["rank"],
+                          "required": [
+                            "rank"
+                          ],
                           "additionalProperties": false
                         }
                       },
-                      "required": ["cartesian"],
+                      "required": [
+                        "cartesian"
+                      ],
                       "additionalProperties": false
                     },
                     {
@@ -170,19 +178,30 @@
                               "items": {
                                 "type": "object",
                                 "properties": {
-                                  "o3_lambda": { "type": "integer" },
-                                  "o3_sigma": { "type": "number" }
+                                  "o3_lambda": {
+                                    "type": "integer"
+                                  },
+                                  "o3_sigma": {
+                                    "type": "number"
+                                  }
                                 },
-                                "required": ["o3_lambda", "o3_sigma"],
+                                "required": [
+                                  "o3_lambda",
+                                  "o3_sigma"
+                                ],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": ["irreps"],
+                          "required": [
+                            "irreps"
+                          ],
                           "additionalProperties": false
                         }
                       },
-                      "required": ["spherical"],
+                      "required": [
+                        "spherical"
+                      ],
                       "additionalProperties": false
                     }
                   ]
@@ -255,7 +274,9 @@
                   "oneOf": [
                     {
                       "type": "string",
-                      "enum": ["scalar"]
+                      "enum": [
+                        "scalar"
+                      ]
                     },
                     {
                       "type": "object",
@@ -263,13 +284,19 @@
                         "cartesian": {
                           "type": "object",
                           "properties": {
-                            "rank": { "type": "integer" }
+                            "rank": {
+                              "type": "integer"
+                            }
                           },
-                          "required": ["rank"],
+                          "required": [
+                            "rank"
+                          ],
                           "additionalProperties": false
                         }
                       },
-                      "required": ["cartesian"],
+                      "required": [
+                        "cartesian"
+                      ],
                       "additionalProperties": false
                     },
                     {
@@ -283,19 +310,30 @@
                               "items": {
                                 "type": "object",
                                 "properties": {
-                                  "o3_lambda": { "type": "integer" },
-                                  "o3_sigma": { "type": "number" }
+                                  "o3_lambda": {
+                                    "type": "integer"
+                                  },
+                                  "o3_sigma": {
+                                    "type": "number"
+                                  }
                                 },
-                                "required": ["o3_lambda", "o3_sigma"],
+                                "required": [
+                                  "o3_lambda",
+                                  "o3_sigma"
+                                ],
                                 "additionalProperties": false
                               }
                             }
                           },
-                          "required": ["irreps"],
+                          "required": [
+                            "irreps"
+                          ],
                           "additionalProperties": false
                         }
                       },
-                      "required": ["spherical"],
+                      "required": [
+                        "spherical"
+                      ],
                       "additionalProperties": false
                     }
                   ]

--- a/src/metatrain/soap_bpnn/default-hypers.yaml
+++ b/src/metatrain/soap_bpnn/default-hypers.yaml
@@ -1,6 +1,5 @@
 architecture:
   name: soap_bpnn
-
   model:
     soap:
       max_angular: 6
@@ -21,9 +20,8 @@ architecture:
       smearing: 1.4
       kspace_resolution: 1.33
       interpolation_nodes: 5
-
   training:
-    distributed: False
+    distributed: false
     distributed_port: 39591
     batch_size: 8
     num_epochs: 100
@@ -36,7 +34,7 @@ architecture:
     scale_targets: true
     fixed_composition_weights: {}
     per_structure_targets: []
-    log_mae: False
+    log_mae: false
     log_separate_blocks: false
     best_model_metric: rmse_prod
     loss:

--- a/src/metatrain/soap_bpnn/schema-hypers.json
+++ b/src/metatrain/soap_bpnn/schema-hypers.json
@@ -4,7 +4,9 @@
   "properties": {
     "name": {
       "type": "string",
-      "enum": ["soap_bpnn"]
+      "enum": [
+        "soap_bpnn"
+      ]
     },
     "model": {
       "type": "object",
@@ -53,7 +55,10 @@
           "patternProperties": {
             ".*": {
               "type": "string",
-              "enum": ["linear", "mlp"]
+              "enum": [
+                "linear",
+                "mlp"
+              ]
             }
           },
           "additionalProperties": false
@@ -152,7 +157,11 @@
         },
         "best_model_metric": {
           "type": "string",
-          "enum": ["rmse_prod", "mae_prod", "loss"]
+          "enum": [
+            "rmse_prod",
+            "mae_prod",
+            "loss"
+          ]
         },
         "loss": {
           "type": "object",
@@ -168,13 +177,20 @@
             },
             "reduction": {
               "type": "string",
-              "enum": ["sum", "mean", "none"]
+              "enum": [
+                "sum",
+                "mean",
+                "none"
+              ]
             },
             "type": {
               "oneOf": [
                 {
                   "type": "string",
-                  "enum": ["mse", "mae"]
+                  "enum": [
+                    "mse",
+                    "mae"
+                  ]
                 },
                 {
                   "type": "object",
@@ -207,7 +223,10 @@
     },
     "atomic_types": {
       "type": "array",
-      "items": { "type": "integer", "minimum": 1 },
+      "items": {
+        "type": "integer",
+        "minimum": 1
+      },
       "uniqueItems": true
     }
   },

--- a/tests/distributed/options-distributed.yaml
+++ b/tests/distributed/options-distributed.yaml
@@ -4,7 +4,7 @@ device: cuda
 architecture:
   name: soap_bpnn
   training:
-    distributed: True
+    distributed: true
     batch_size: 25
     num_epochs: 100
 
@@ -16,7 +16,7 @@ training_set:
     energy:
       key: energy
       unit: eV
-      forces: on
+      forces: true
 
 test_set: 0.0
 validation_set: 0.5

--- a/tests/distributed/options.yaml
+++ b/tests/distributed/options.yaml
@@ -15,7 +15,7 @@ training_set:
     energy:
       key: energy
       unit: eV
-      forces: on
+      forces: true
 
 test_set: 0.0
 validation_set: 0.5

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ envlist =
 package = editable
 passenv = *
 lint_folders =
+    "{toxinidir}/developer/" \
     "{toxinidir}/examples/" \
     "{toxinidir}/src/" \
     "{toxinidir}/tests/" \
@@ -24,21 +25,17 @@ lint_folders =
 [testenv:lint]
 description = Run linters and type checks
 package = skip
-allowlist_externals =
-    npm
-    npx
 deps =
     ruff
     mypy
-    nodeenv
     sphinx-lint
-commands_pre =
-    npm install prettier
+    yamlfix
 commands =
     ruff format --diff {[testenv]lint_folders}
     ruff check {[testenv]lint_folders}
+    python {toxinidir}/developer/jsonfix.py --check {[testenv]lint_folders}
+    yamlfix --check {[testenv]lint_folders}
     mypy {[testenv]lint_folders}
-    npx prettier --check {[testenv]lint_folders}
     sphinx-lint \
         --enable all \
         --disable line-too-long \
@@ -48,18 +45,14 @@ commands =
 [testenv:format]
 description = Abuse tox to do actual formatting on all files.
 package = skip
-allowlist_externals =
-    npm
-    npx
 deps =
     ruff
-    nodeenv
-commands_pre =
-    npm install prettier
+    yamlfix
 commands =
     ruff format {[testenv]lint_folders}
     ruff check --fix-only {[testenv]lint_folders} "{toxinidir}/README.md" {posargs}
-    npx prettier --write {[testenv]lint_folders}
+    python {toxinidir}/developer/jsonfix.py {[testenv]lint_folders}
+    yamlfix {[testenv]lint_folders}
 
 [testenv:tests]
 description = Run basic package tests with pytest (not the architectures)


### PR DESCRIPTION
Fixes #646 

Replaces the JS library `prettier` by Python alternatives. For yaml files I use `yamlfix`. And inspired by this library and the lack of alternatives I vibecoded our own called `jsonfix`.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--665.org.readthedocs.build/en/665/

<!-- readthedocs-preview metatrain end -->