### PR TITLE
Automatically generate tests for checkpoint versionning

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_new-architecture.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_new-architecture.md
@@ -4,16 +4,19 @@
 
 # Contributor (creator of pull-request) checklist
 
-- [ ] Add your architecture to the experimental/stable folder. See the
-  [docs/src/dev-docs/architecture-life-cycle.rst](Architecture life cycle) document for
-  requirements.
-  `src/metatrain/experimental/<architecture_name>`
+- [ ] Add your architecture to the `experimental` or `stable` folder. See the
+  [docs/src/dev-docs/architecture-life-cycle.rst](Architecture life cycle)
+  document for requirements. `src/metatrain/experimental/<architecture_name>`
 - [ ] Add default hyperparameter file to
   `src/metatrain/experimental/<architecture_name>/default-hypers.yml`
-- [ ] Add a `.yml` file into github workflows `.github/workflow/<architecture_name>.yml`
-- [ ] Architecture dependencies entry in the `optional-dependencies` section in the
+- [ ] Add your architecture to the CI in `.github/workflow/architecture-tests.yml`
+- [ ] Add a new dependencies entry in the `optional-dependencies` section in the
   `pyproject.toml`
-- [ ] Tests: torch-scriptability, basic functionality (invariance, fitting, prediction)
+- [ ] Add tests:
+  - [ ] checking that the code is compatible with TorchScript
+  - [ ] checking the basic functionality (invariance, fitting, prediction)
+  - [ ] checking that the checkpoints are properly versionned (see the existing
+    `test_checkpoint.py` in other architectures)
 - [ ] Add maintainers as codeowners in [CODEOWNERS](CODEOWNERS)
 
 # Reviewer checklist

--- a/src/metatrain/experimental/nanopet/tests/test_checkpoints.py
+++ b/src/metatrain/experimental/nanopet/tests/test_checkpoints.py
@@ -1,12 +1,14 @@
 import copy
-import glob
-import gzip
 
 import pytest
 import torch
 
 from metatrain.experimental.nanopet import NanoPET, Trainer
 from metatrain.utils.data import DatasetInfo, get_atomic_types, get_dataset
+from metatrain.utils.testing.checkpoints import (
+    checkpoint_did_not_change,
+    make_checkpoint_load_tests,
+)
 
 from . import DATASET_PATH, DEFAULT_HYPERS, MODEL_HYPERS
 
@@ -70,60 +72,6 @@ def model_trainer():
     return model, trainer
 
 
-def check_same_checkpoint_structure(checkpoint, reference, prefix=""):
-    assert isinstance(checkpoint, dict)
-    assert isinstance(reference, dict)
+test_checkpoint_did_not_change = checkpoint_did_not_change
 
-    for key in reference:
-        if key not in checkpoint:
-            raise KeyError(f"missing key from checkpoint: {prefix}.{key}")
-
-    for key in checkpoint:
-        if key not in reference:
-            raise KeyError(f"new key in checkpoint: {prefix}.{key}")
-
-    for key in reference:
-        if isinstance(reference[key], dict):
-            check_same_checkpoint_structure(
-                checkpoint[key], reference[key], prefix=prefix + "." + str(key)
-            )
-
-
-def test_checkpoint_did_not_change(monkeypatch, tmp_path, model_trainer):
-    model, trainer = model_trainer
-    version = model.__checkpoint_version__
-    with gzip.open(f"checkpoints/v{version}.ckpt.gz", "rb") as fd:
-        reference = torch.load(fd, weights_only=False)
-
-    monkeypatch.chdir(tmp_path)
-    trainer.save_checkpoint(model, "checkpoint.ckpt")
-
-    checkpoint = torch.load("checkpoint.ckpt", weights_only=False)
-
-    try:
-        check_same_checkpoint_structure(checkpoint, reference)
-    except KeyError as e:
-        raise ValueError(
-            "checkpoint structure changed. Please increase the checkpoint "
-            "version and implement checkpoint update"
-        ) from e
-
-
-@pytest.mark.parametrize("context", ["restart", "finetune", "export"])
-def test_loading_old_checkpoints(model_trainer, context):
-    model, trainer = model_trainer
-
-    for path in glob.glob("checkpoints/*.ckpt.gz"):
-        with gzip.open(path, "rb") as fd:
-            checkpoint = torch.load(fd, weights_only=False)
-
-        if checkpoint["model_ckpt_version"] != model.__checkpoint_version__:
-            checkpoint = model.__class__.upgrade_checkpoint(checkpoint)
-
-        model.load_checkpoint(checkpoint, context)
-
-        if context != "export":
-            if checkpoint["trainer_ckpt_version"] != trainer.__checkpoint_version__:
-                checkpoint = trainer.__class__.upgrade_checkpoint(checkpoint)
-
-            trainer.load_checkpoint(checkpoint, DEFAULT_HYPERS, context)
+test_loading_old_checkpoints = make_checkpoint_load_tests(DEFAULT_HYPERS)

--- a/src/metatrain/pet/tests/test_checkpoints.py
+++ b/src/metatrain/pet/tests/test_checkpoints.py
@@ -1,12 +1,14 @@
 import copy
-import glob
-import gzip
 
 import pytest
 import torch
 
 from metatrain.pet import PET, Trainer
 from metatrain.utils.data import DatasetInfo, get_atomic_types, get_dataset
+from metatrain.utils.testing.checkpoints import (
+    checkpoint_did_not_change,
+    make_checkpoint_load_tests,
+)
 
 from . import DATASET_PATH, DEFAULT_HYPERS, MODEL_HYPERS
 
@@ -72,60 +74,6 @@ def model_trainer():
     return model, trainer
 
 
-def check_same_checkpoint_structure(checkpoint, reference, prefix=""):
-    assert isinstance(checkpoint, dict)
-    assert isinstance(reference, dict)
+test_checkpoint_did_not_change = checkpoint_did_not_change
 
-    for key in reference:
-        if key not in checkpoint:
-            raise KeyError(f"missing key from checkpoint: {prefix}.{key}")
-
-    for key in checkpoint:
-        if key not in reference:
-            raise KeyError(f"new key in checkpoint: {prefix}.{key}")
-
-    for key in reference:
-        if isinstance(reference[key], dict):
-            check_same_checkpoint_structure(
-                checkpoint[key], reference[key], prefix=prefix + "." + str(key)
-            )
-
-
-def test_checkpoint_did_not_change(monkeypatch, tmp_path, model_trainer):
-    model, trainer = model_trainer
-    version = model.__checkpoint_version__
-    with gzip.open(f"checkpoints/v{version}.ckpt.gz", "rb") as fd:
-        reference = torch.load(fd, weights_only=False)
-
-    monkeypatch.chdir(tmp_path)
-    trainer.save_checkpoint(model, "checkpoint.ckpt")
-
-    checkpoint = torch.load("checkpoint.ckpt", weights_only=False)
-
-    try:
-        check_same_checkpoint_structure(checkpoint, reference)
-    except KeyError as e:
-        raise ValueError(
-            "checkpoint structure changed. Please increase the checkpoint "
-            "version and implement checkpoint update"
-        ) from e
-
-
-@pytest.mark.parametrize("context", ["restart", "finetune", "export"])
-def test_loading_old_checkpoints(model_trainer, context):
-    model, trainer = model_trainer
-
-    for path in glob.glob("checkpoints/*.ckpt.gz"):
-        with gzip.open(path, "rb") as fd:
-            checkpoint = torch.load(fd, weights_only=False)
-
-        if checkpoint["model_ckpt_version"] != model.__checkpoint_version__:
-            checkpoint = model.__class__.upgrade_checkpoint(checkpoint)
-
-        model.load_checkpoint(checkpoint, context)
-
-        if context != "export":
-            if checkpoint["trainer_ckpt_version"] != trainer.__checkpoint_version__:
-                checkpoint = trainer.__class__.upgrade_checkpoint(checkpoint)
-
-            trainer.load_checkpoint(checkpoint, DEFAULT_HYPERS, context)
+test_loading_old_checkpoints = make_checkpoint_load_tests(DEFAULT_HYPERS)

--- a/src/metatrain/soap_bpnn/tests/test_checkpoints.py
+++ b/src/metatrain/soap_bpnn/tests/test_checkpoints.py
@@ -1,12 +1,14 @@
 import copy
-import glob
-import gzip
 
 import pytest
 import torch
 
 from metatrain.soap_bpnn import SoapBpnn, Trainer
 from metatrain.utils.data import DatasetInfo, get_atomic_types, get_dataset
+from metatrain.utils.testing.checkpoints import (
+    checkpoint_did_not_change,
+    make_checkpoint_load_tests,
+)
 
 from . import DATASET_PATH, DEFAULT_HYPERS, MODEL_HYPERS
 
@@ -70,60 +72,6 @@ def model_trainer():
     return model, trainer
 
 
-def check_same_checkpoint_structure(checkpoint, reference, prefix=""):
-    assert isinstance(checkpoint, dict)
-    assert isinstance(reference, dict)
+test_checkpoint_did_not_change = checkpoint_did_not_change
 
-    for key in reference:
-        if key not in checkpoint:
-            raise KeyError(f"missing key from checkpoint: {prefix}.{key}")
-
-    for key in checkpoint:
-        if key not in reference:
-            raise KeyError(f"new key in checkpoint: {prefix}.{key}")
-
-    for key in reference:
-        if isinstance(reference[key], dict):
-            check_same_checkpoint_structure(
-                checkpoint[key], reference[key], prefix=prefix + "." + str(key)
-            )
-
-
-def test_checkpoint_did_not_change(monkeypatch, tmp_path, model_trainer):
-    model, trainer = model_trainer
-    version = model.__checkpoint_version__
-    with gzip.open(f"checkpoints/v{version}.ckpt.gz", "rb") as fd:
-        reference = torch.load(fd, weights_only=False)
-
-    monkeypatch.chdir(tmp_path)
-    trainer.save_checkpoint(model, "checkpoint.ckpt")
-
-    checkpoint = torch.load("checkpoint.ckpt", weights_only=False)
-
-    try:
-        check_same_checkpoint_structure(checkpoint, reference)
-    except KeyError as e:
-        raise ValueError(
-            "checkpoint structure changed. Please increase the checkpoint "
-            "version and implement checkpoint update"
-        ) from e
-
-
-@pytest.mark.parametrize("context", ["restart", "finetune", "export"])
-def test_loading_old_checkpoints(model_trainer, context):
-    model, trainer = model_trainer
-
-    for path in glob.glob("checkpoints/*.ckpt.gz"):
-        with gzip.open(path, "rb") as fd:
-            checkpoint = torch.load(fd, weights_only=False)
-
-        if checkpoint["model_ckpt_version"] != model.__checkpoint_version__:
-            checkpoint = model.__class__.upgrade_checkpoint(checkpoint)
-
-        model.load_checkpoint(checkpoint, context)
-
-        if context != "export":
-            if checkpoint["trainer_ckpt_version"] != trainer.__checkpoint_version__:
-                checkpoint = trainer.__class__.upgrade_checkpoint(checkpoint)
-
-            trainer.load_checkpoint(checkpoint, DEFAULT_HYPERS, context)
+test_loading_old_checkpoints = make_checkpoint_load_tests(DEFAULT_HYPERS)

--- a/src/metatrain/utils/testing/checkpoints.py
+++ b/src/metatrain/utils/testing/checkpoints.py
@@ -1,0 +1,83 @@
+import glob
+import gzip
+import os
+
+import pytest
+import torch
+
+
+def check_same_checkpoint_structure(checkpoint, reference, prefix=""):
+    assert isinstance(checkpoint, dict)
+    assert isinstance(reference, dict)
+
+    for key in reference:
+        if key not in checkpoint:
+            raise KeyError(f"missing key from checkpoint: {prefix}.{key}")
+
+    for key in checkpoint:
+        if key not in reference:
+            raise KeyError(f"new key in checkpoint: {prefix}.{key}")
+
+    for key in reference:
+        if isinstance(reference[key], dict):
+            check_same_checkpoint_structure(
+                checkpoint[key], reference[key], prefix=prefix + "." + str(key)
+            )
+
+
+def checkpoint_did_not_change(monkeypatch, tmp_path, model_trainer):
+    model, trainer = model_trainer
+
+    cwd = os.getcwd()
+    monkeypatch.chdir(tmp_path)
+    trainer.save_checkpoint(model, "checkpoint.ckpt")
+    checkpoint = torch.load("checkpoint.ckpt", weights_only=False)
+    monkeypatch.chdir(cwd)
+
+    version = model.__checkpoint_version__
+    if not os.path.exists(f"checkpoints/v{version}.ckpt.gz"):
+        with gzip.open(f"v{version}.ckpt.gz", "wb") as output:
+            with open(os.path.join(tmp_path, "checkpoint.ckpt"), "rb") as input:
+                output.write(input.read())
+
+        raise ValueError(
+            f"missing reference checkpoint for v{version}, "
+            "we created one for you with the current state of the code. "
+            f"Please move it to `checkpoints/v{version}.ckpt.gz` if you "
+            "have no other changes to do"
+        )
+
+    else:
+        with gzip.open(f"checkpoints/v{version}.ckpt.gz", "rb") as fd:
+            reference = torch.load(fd, weights_only=False)
+
+        try:
+            check_same_checkpoint_structure(checkpoint, reference)
+        except KeyError as e:
+            raise ValueError(
+                "checkpoint structure changed. Please increase the checkpoint "
+                "version and implement checkpoint update"
+            ) from e
+
+
+def make_checkpoint_load_tests(DEFAULT_HYPERS):
+    @pytest.mark.parametrize("context", ["restart", "finetune", "export"])
+    def test_loading_old_checkpoints(model_trainer, context):
+        model, trainer = model_trainer
+
+        for path in glob.glob("checkpoints/*.ckpt.gz"):
+            with gzip.open(path, "rb") as fd:
+                checkpoint = torch.load(fd, weights_only=False)
+
+            if checkpoint["model_ckpt_version"] != model.__checkpoint_version__:
+                checkpoint = model.__class__.upgrade_checkpoint(checkpoint)
+
+            model.load_checkpoint(checkpoint, context)
+
+            if context != "export":
+                if checkpoint["trainer_ckpt_version"] != trainer.__checkpoint_version__:
+                    checkpoint = trainer.__class__.upgrade_checkpoint(checkpoint)
+
+                trainer.load_checkpoint(checkpoint, DEFAULT_HYPERS, context)
+
+    return test_loading_old_checkpoints


### PR DESCRIPTION
Follow up to #580, now using the same code to define the checkpoint tests for all architectures.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
