### PR TITLE
Update codecov setup to exclude testing code inside metatrain

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,15 +7,17 @@ coverage:
       default:
         informational: true
   ignore:
+    # no need to report coverage of the test code themself
     - "tests/.*"
     - "examples/.*"
+    - "src/metatrain/utils/testing/.*"
+    # we don't check coverage for the architectures
     - "src/metatrain/deprecated/.*"
     - "src/metatrain/experimental/.*"
     - "src/metatrain/gap/.*"
     - "src/metatrain/pet/.*"
     - "src/metatrain/soap_bpnn/.*"
+    # we don't currently run distributed tests on CI
     - "src/metatrain/utils/distributed/.*"
-    - "src/metatrain/utils/sum_over_atoms.py"
-    - "src/metatrain/utils/augmentation.py"
 
 comment: false


### PR DESCRIPTION
We have code inside `metatrain.utils.testing` that is only used for architecture tests and thus should be excluded from the main coverage.


# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
