### PR TITLE
Getting only requested fields from DiskDataset

### DIFF
--- a/src/metatrain/utils/data/get_dataset.py
+++ b/src/metatrain/utils/data/get_dataset.py
@@ -29,7 +29,10 @@ def get_dataset(
     extra_data_info_dictionary = {}
 
     if options["systems"]["read_from"].endswith(".zip"):  # disk dataset
-        dataset = DiskDataset(options["systems"]["read_from"])
+        dataset = DiskDataset(
+            options["systems"]["read_from"],
+            fields=[*options["targets"], *options.get("extra_data", {})],
+        )
         target_info_dictionary = dataset.get_target_info(options["targets"])
         if "extra_data" in options:
             extra_data_info_dictionary = dataset.get_target_info(options["extra_data"])


### PR DESCRIPTION
It was a bit of a pain that with the disk dataset you had to train on all of the properties contained in the dataset (or most recently include the ones that you didn't want as extra_data).

This PR makes metatrain use only the fields of the disk dataset that were asked by the user either as targets or extra data.


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--681.org.readthedocs.build/en/681/

<!-- readthedocs-preview metatrain end -->