### PR TITLE
Add caching for model downloading

### DIFF
--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -27,6 +27,8 @@ Unreleased
 Added
 #####
 
+- Added caching for ``load_model`` when downloading from URLs. Models will be stored in
+  a cache directory, which is logged when the model is loaded.
 - ``extra_data`` is now a valid section in the ``options.yaml`` file, allowing users to
   add custom data to the training set. The data is contained in the dataloader and can
   be used in custom loss functions or models.

--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -27,8 +27,7 @@ Unreleased
 Added
 #####
 
-- Added caching for ``load_model`` when downloading from URLs. Models will be stored in
-  a cache directory, which is logged when the model is loaded.
+- Added caching ``load_model`` when downloading from Hugging Face.
 - ``extra_data`` is now a valid section in the ``options.yaml`` file, allowing users to
   add custom data to the training set. The data is contained in the dataloader and can
   be used in custom loss functions or models.

--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -27,7 +27,7 @@ Unreleased
 Added
 #####
 
-- Added caching ``load_model`` when downloading from Hugging Face.
+- When downloading checkpoints and models from Hugging Face, the files will be cached locally and re-used.
 - ``extra_data`` is now a valid section in the ``options.yaml`` file, allowing users to
   add custom data to the training set. The data is contained in the dataloader and can
   be used in custom loss functions or models.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [{name = "metatrain developers"}]
 # Strict version pinning to avoid regression test failing on new versions
 dependencies = [
     "ase",
+    "huggingface_hub",
     "metatensor-learn >=0.3.2,<0.4",
     "metatensor-operations >=0.3.3,<0.4",
     "metatensor-torch >=0.7.6,<0.8",

--- a/src/metatrain/utils/io.py
+++ b/src/metatrain/utils/io.py
@@ -123,9 +123,7 @@ def load_model(
 ) -> Any:
     """Load checkpoints and exported models from an URL or a local file for inference.
 
-    Remote models are downloaded to a local cache directory, with hashed filenames to
-    avoid common name collisions. The cache directory path is logged during the loading
-    process.
+    Remote models from Hugging Face are downloaded to a local cache directory.
 
     If an exported model should be loaded and requires compiled extensions, their
     location should be passed using the ``extensions_directory`` parameter.

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ commands =
     ruff format {[testenv]lint_folders}
     ruff check --fix-only {[testenv]lint_folders} "{toxinidir}/README.md" {posargs}
     python {toxinidir}/developer/jsonfix.py {[testenv]lint_folders}
-    yamlfix {[testenv]lint_folders}
+    yamlfix {[testenv]lint_folders} -e "**/outputs/**"
 
 [testenv:tests]
 description = Run basic package tests with pytest (not the architectures)

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,6 @@ deps =
     pytest
     pytest-cov
     pytest-xdist
-    huggingface_hub
     spherical  # for nanoPET spherical target
     torch-pme  # for long-range tests
     wandb


### PR DESCRIPTION
Fixes #525

Speedup for power model loaders 🚀

Should we add an option like `force_download` that will download the model even if it already exists in the local cache?

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--685.org.readthedocs.build/en/685/

<!-- readthedocs-preview metatrain end -->