### PR TITLE
Enable distributed training test with NCCL on ALPS (GH200)

### DIFF
--- a/ci/containers/Containerfile.base
+++ b/ci/containers/Containerfile.base
@@ -1,0 +1,11 @@
+FROM docker://nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04
+
+# FFTW library required by spinfast: https://github.com/moble/spinsfast?tab=readme-ov-file#pip
+RUN apt update && \
+	apt install -y libfftw3-dev python3 python3-pip python3-venv git && \
+	apt clean
+
+RUN python3 -m pip install --break-system-packages tox
+
+ENV PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu128
+ENV CUDA_HOME="/usr/local/cuda"

--- a/ci/containers/Containerfile.mtt
+++ b/ci/containers/Containerfile.mtt
@@ -1,0 +1,8 @@
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
+COPY . /mtt-repo/
+
+RUN python3 -m venv --system-site-packages /mtt-venv && \
+	. /mtt-venv/bin/activate && \
+	python -m pip install /mtt-repo[soap-bpnn]

--- a/ci/cscs.yml
+++ b/ci/cscs.yml
@@ -2,28 +2,69 @@ include:
   - remote: 'https://gitlab.com/cscs-ci/recipes/-/raw/master/templates/v2/.ci-ext.yml'
 
 stages:
+  - build_base
   - build
   - test
 
-variables:
-  PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/metatrain:$CI_COMMIT_SHORT_SHA
+# Build base image from Containerfile.base
+# The base image is re-built whenever Containerfile.base changes
+build base:
+  stage: build_base
+  extends: .container-builder-cscs-gh200
+  before_script:
+    - TAG_DOCKERFILE=`sha256sum $DOCKERFILE | head -c 8`
+    - TAG=${TAG_DOCKERFILE}
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/mtt-base:$TAG
+    - echo "BASE_IMAGE=$PERSIST_IMAGE_NAME" > build.env
+    - 'echo "INFO: Bulidning image $PERSIST_IMAGE_NAME"'
+  artifacts:
+    reports:
+      dotenv: build.env
+  variables:
+    DOCKERFILE: ci/containers/Containerfile.base
 
-build_job:
+# Build image with metatrain
+build mtt:
   stage: build
   extends: .container-builder-cscs-gh200
+  before_script:
+    - 'echo "INFO: Building image $PERSIST_IMAGE_NAME"'
   variables:
-    DOCKERFILE: ci/containers/Containerfile
+    GIT_STRATEGY: clone
+    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/base/mtt:$CI_COMMIT_SHORT_SHA
+    DOCKERFILE: ci/containers/Containerfile.mtt
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE"]'
 
-test_job:
+# Run tox tests (single GPU)
+test tox:
   stage: test
   extends: .container-runner-daint-gh200
-  image: $PERSIST_IMAGE_NAME
-  timeout: 2h
+  image: $BASE_IMAGE
+  timeout: 1h
   script:
     - tox -r
   variables:
     SLURM_JOB_NUM_NODES: 1
     SLURM_PARTITION: normal
     SLURM_NTASKS: 1
-    SLURM_TIMELIMIT: '00:45:00'
+    SLURM_TIMELIMIT: '00:40:00'
     GIT_STRATEGY: fetch
+
+# Run distributed training (single node, multiple GPUs)
+test distributed:
+  stage: test
+  extends: .container-runner-daint-gh200
+  image: $CSCS_REGISTRY_PATH/base/mtt:$CI_COMMIT_SHORT_SHA
+  timeout: 1h
+  script:
+    - . /mtt-venv/bin/activate
+    - cd /mtt-repo/tests/distributed
+    - mtt train options-distributed.yaml
+  variables:
+    SLURM_JOB_NUM_NODES: 1
+    SLURM_PARTITION: normal
+    SLURM_NTASKS: 4
+    SLURM_GPUS_PER_TASK: 1
+    SLURM_CPUS_PER_TASK: 16
+    SLURM_TIMELIMIT: '00:10:00'
+    USE_NCCL: 'cuda12'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.9"
 readme = "README.md"
 license = "BSD-3-Clause"
 description = "Training and evaluating machine learning models for atomistic systems."
-authors = [{name = "metatrain developers"}]
+authors = [{ name = "metatrain developers" }]
 
 # Strict version pinning to avoid regression test failing on new versions
 dependencies = [
@@ -52,18 +52,11 @@ mtt = "metatrain.__main__:main"
 ### ======================================================================== ###
 
 [build-system]
-requires = [
-    "setuptools >= 77",
-    "setuptools_scm>=8",
-    "wheel",
-]
+requires = ["setuptools >= 77", "setuptools_scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
-soap-bpnn = [
-    "torch-spex>=0.1,<0.2",
-    "wigners",
-]
+soap-bpnn = ["torch-spex>=0.1,<0.2", "wigners"]
 deprecated-pet = [
     "pet-neighbors-convert",
     "torch_geometric",
@@ -74,11 +67,7 @@ deprecated-pet = [
 ]
 pet = []
 nanopet = []
-gap = [
-    "featomic-torch >=0.7,<0.8",
-    "skmatter",
-    "scipy",
-]
+gap = ["featomic-torch >=0.7,<0.8", "skmatter", "scipy"]
 
 [tool.check-manifest]
 ignore = ["src/metatrain/_version.py"]
@@ -92,20 +81,15 @@ version_file = "src/metatrain/_version.py"
 [tool.coverage.report]
 skip_covered = true
 show_missing = true
-exclude_lines = [
-    "if __name__ == .__main__.:",
-]
+exclude_lines = ["if __name__ == .__main__.:"]
 omit = [
     "*/site-packages/*",
     "*/metatrain/experimental/*",
-    "*/metatrain/utils/testing/*"
+    "*/metatrain/utils/testing/*",
 ]
 
 [tool.coverage.paths]
-source = [
-    "src/metatrain",
-    ".tox/*/lib/python*/site-packages/metatrain"
-]
+source = ["src/metatrain", ".tox/*/lib/python*/site-packages/metatrain"]
 
 [tool.ruff]
 exclude = ["docs/src/examples/**", "src/metatrain/_version.py"]
@@ -124,9 +108,7 @@ known-third-party = ["torch"]
 docstring-code-format = true
 
 [tool.mypy]
-exclude = [
-    "docs/src/examples"
-]
+exclude = ["docs/src/examples"]
 follow_imports = 'skip'
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.9"
 readme = "README.md"
 license = "BSD-3-Clause"
 description = "Training and evaluating machine learning models for atomistic systems."
-authors = [{ name = "metatrain developers" }]
+authors = [{name = "metatrain developers"}]
 
 # Strict version pinning to avoid regression test failing on new versions
 dependencies = [
@@ -52,11 +52,18 @@ mtt = "metatrain.__main__:main"
 ### ======================================================================== ###
 
 [build-system]
-requires = ["setuptools >= 77", "setuptools_scm>=8", "wheel"]
+requires = [
+    "setuptools >= 77",
+    "setuptools_scm>=8",
+    "wheel",
+]
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
-soap-bpnn = ["torch-spex>=0.1,<0.2", "wigners"]
+soap-bpnn = [
+    "torch-spex>=0.1,<0.2",
+    "wigners",
+]
 deprecated-pet = [
     "pet-neighbors-convert",
     "torch_geometric",
@@ -67,7 +74,11 @@ deprecated-pet = [
 ]
 pet = []
 nanopet = []
-gap = ["featomic-torch >=0.7,<0.8", "skmatter", "scipy"]
+gap = [
+    "featomic-torch >=0.7,<0.8",
+    "skmatter",
+    "scipy",
+]
 
 [tool.check-manifest]
 ignore = ["src/metatrain/_version.py"]
@@ -81,15 +92,20 @@ version_file = "src/metatrain/_version.py"
 [tool.coverage.report]
 skip_covered = true
 show_missing = true
-exclude_lines = ["if __name__ == .__main__.:"]
+exclude_lines = [
+    "if __name__ == .__main__.:",
+]
 omit = [
     "*/site-packages/*",
     "*/metatrain/experimental/*",
-    "*/metatrain/utils/testing/*",
+    "*/metatrain/utils/testing/*"
 ]
 
 [tool.coverage.paths]
-source = ["src/metatrain", ".tox/*/lib/python*/site-packages/metatrain"]
+source = [
+    "src/metatrain",
+    ".tox/*/lib/python*/site-packages/metatrain"
+]
 
 [tool.ruff]
 exclude = ["docs/src/examples/**", "src/metatrain/_version.py"]
@@ -108,7 +124,9 @@ known-third-party = ["torch"]
 docstring-code-format = true
 
 [tool.mypy]
-exclude = ["docs/src/examples"]
+exclude = [
+    "docs/src/examples"
+]
 follow_imports = 'skip'
 ignore_missing_imports = true
 

--- a/src/metatrain/experimental/nanopet/trainer.py
+++ b/src/metatrain/experimental/nanopet/trainer.py
@@ -515,6 +515,9 @@ class Trainer(TrainerInterface):
         self.optimizer_state_dict = optimizer.state_dict()
         self.scheduler_state_dict = lr_scheduler.state_dict()
 
+        if is_distributed:
+            torch.distributed.destroy_process_group()
+
     def save_checkpoint(self, model, path: Union[str, Path]):
         checkpoint = {
             "architecture_name": "experimental.nanopet",

--- a/src/metatrain/pet/trainer.py
+++ b/src/metatrain/pet/trainer.py
@@ -531,6 +531,9 @@ class Trainer(TrainerInterface):
         self.optimizer_state_dict = optimizer.state_dict()
         self.scheduler_state_dict = lr_scheduler.state_dict()
 
+        if is_distributed:
+            torch.distributed.destroy_process_group()
+
     def save_checkpoint(self, model, path: Union[str, Path]):
         checkpoint = {
             "architecture_name": "pet",

--- a/src/metatrain/soap_bpnn/trainer.py
+++ b/src/metatrain/soap_bpnn/trainer.py
@@ -502,6 +502,9 @@ class Trainer(TrainerInterface):
         self.optimizer_state_dict = optimizer.state_dict()
         self.scheduler_state_dict = lr_scheduler.state_dict()
 
+        if is_distributed:
+            torch.distributed.destroy_process_group()
+
     def save_checkpoint(self, model, path: Union[str, Path]):
         checkpoint = {
             "architecture_name": "soap_bpnn",


### PR DESCRIPTION
This PR builds on #687 and runs the distributed training example in `tests/distributed`. The example is run on a single node, with all 4 GPUs.

The CI workflow is now the following:
```
Build base container -> Build MTT container -> Run distributed example
          |
          ------------> Run tox tests
```

The base container (used by the `tox` tests) is now only re-built if the Containerfile changes.

This PR also adds `torch.distributed.destroy_process_group()` to the different trainers to get rid of the corresponding warnings.

This is a starting point, but we should discuss about how to expand the distributed training tests (currently the example only tests SOAP-BPNN).