### PR TITLE
Make DatasetInfo and TargetInfo torchscript compatible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "ase",
     "huggingface_hub",
     "metatensor-learn >=0.3.2,<0.4",
-    "metatensor-operations >=0.3.3,<0.4",
+    "metatensor-operations >=0.3.4,<0.4",
     "metatensor-torch >=0.7.6,<0.8",
     "metatomic-torch >=0.1.2,<0.2",
     "jsonschema",

--- a/src/metatrain/experimental/nanopet/model.py
+++ b/src/metatrain/experimental/nanopet/model.py
@@ -119,10 +119,6 @@ class NanoPET(ModelInterface):
         self.heads = torch.nn.ModuleDict()
         self.head_types = self.hypers["heads"]
         self.last_layers = torch.nn.ModuleDict()
-        self.output_shapes: Dict[str, Dict[str, List[int]]] = {}
-        self.key_labels: Dict[str, Labels] = {}
-        self.component_labels: Dict[str, List[List[Labels]]] = {}
-        self.property_labels: Dict[str, List[Labels]] = {}
         for target_name, target_info in dataset_info.targets.items():
             self._add_output(target_name, target_info)
 
@@ -242,21 +238,7 @@ class NanoPET(ModelInterface):
 
         if self.single_label.values.device != device:
             self.single_label = self.single_label.to(device)
-            self.key_labels = {
-                output_name: label.to(device)
-                for output_name, label in self.key_labels.items()
-            }
-            self.component_labels = {
-                output_name: [
-                    [labels.to(device) for labels in components_block]
-                    for components_block in components_tmap
-                ]
-                for output_name, components_tmap in self.component_labels.items()
-            }
-            self.property_labels = {
-                output_name: [labels.to(device) for labels in properties_tmap]
-                for output_name, properties_tmap in self.property_labels.items()
-            }
+            self.dataset_info = self.dataset_info.to(device)
 
         system_indices = torch.concatenate(
             [
@@ -466,6 +448,8 @@ class NanoPET(ModelInterface):
 
         atomic_properties_tmap_dict: Dict[str, TensorMap] = {}
         for output_name, last_layer in self.last_layers.items():
+            target_info = self.dataset_info.targets[output_name]
+
             if output_name in outputs:
                 atomic_features = atomic_features_dict[output_name]
                 atomic_properties_by_block = []
@@ -473,13 +457,13 @@ class NanoPET(ModelInterface):
                     atomic_properties_by_block.append(
                         last_layer_by_block(atomic_features)
                     )
-                all_components = self.component_labels[output_name]
+                all_components = target_info.component_labels
                 if len(all_components[0]) == 2 and all(
                     "xyz" in comp.names[0] for comp in all_components[0]
                 ):
                     # rank-2 Cartesian tensor, symmetrize
                     tensor_as_three_by_three = atomic_properties_by_block[0].reshape(
-                        -1, 3, 3, list(self.output_shapes[output_name].values())[0][-1]
+                        -1, 3, 3, list(target_info.blocks_shape.values())[0][-1]
                     )
                     volumes = torch.stack(
                         [torch.abs(torch.det(system.cell)) for system in systems]
@@ -505,13 +489,13 @@ class NanoPET(ModelInterface):
                     )
                     for atomic_property, shape, components, properties in zip(
                         atomic_properties_by_block,
-                        self.output_shapes[output_name].values(),
-                        self.component_labels[output_name],
-                        self.property_labels[output_name],
+                        target_info.blocks_shape.values(),
+                        target_info.component_labels,
+                        target_info.property_labels,
                     )
                 ]
                 atomic_properties_tmap_dict[output_name] = TensorMap(
-                    keys=self.key_labels[output_name],
+                    keys=target_info.layout.keys,
                     blocks=blocks,
                 )
 
@@ -638,16 +622,6 @@ class NanoPET(ModelInterface):
                     "NanoPET does not support Cartesian tensors with rank > 2."
                 )
 
-        # one output shape for each tensor block, grouped by target (i.e. tensormap)
-        self.output_shapes[target_name] = {}
-        for key, block in target_info.layout.items():
-            dict_key = target_name
-            for n, k in zip(key.names, key.values):
-                dict_key += f"_{n}_{int(k)}"
-            self.output_shapes[target_name][dict_key] = [
-                len(comp.values) for comp in block.components
-            ] + [len(block.properties.values)]
-
         self.outputs[target_name] = ModelOutput(
             quantity=target_info.quantity,
             unit=target_info.unit,
@@ -687,17 +661,9 @@ class NanoPET(ModelInterface):
                     prod(shape),
                     bias=False,
                 )
-                for key, shape in self.output_shapes[target_name].items()
+                for key, shape in target_info.blocks_shape.items()
             }
         )
-
-        self.key_labels[target_name] = target_info.layout.keys
-        self.component_labels[target_name] = [
-            block.components for block in target_info.layout.blocks()
-        ]
-        self.property_labels[target_name] = [
-            block.properties for block in target_info.layout.blocks()
-        ]
 
     @staticmethod
     def upgrade_checkpoint(checkpoint: Dict) -> Dict:

--- a/src/metatrain/experimental/nanopet/model.py
+++ b/src/metatrain/experimental/nanopet/model.py
@@ -59,8 +59,6 @@ class NanoPET(ModelInterface):
         references={"architecture": ["https://arxiv.org/abs/2305.19302v3"]}
     )
 
-    component_labels: Dict[str, List[List[Labels]]]
-
     def __init__(self, hypers: Dict, dataset_info: DatasetInfo) -> None:
         super().__init__(hypers, dataset_info, self.__default_metadata__)
 

--- a/src/metatrain/experimental/nanopet/model.py
+++ b/src/metatrain/experimental/nanopet/model.py
@@ -676,7 +676,7 @@ class NanoPET(ModelInterface):
             "metadata": self.metadata,
             "model_data": {
                 "model_hypers": self.hypers,
-                "dataset_info": self.dataset_info.to_device("cpu"),
+                "dataset_info": self.dataset_info.to(device="cpu"),
             },
             "model_state_dict": self.state_dict(),
             "best_model_state_dict": None,

--- a/src/metatrain/experimental/nanopet/model.py
+++ b/src/metatrain/experimental/nanopet/model.py
@@ -676,7 +676,7 @@ class NanoPET(ModelInterface):
             "metadata": self.metadata,
             "model_data": {
                 "model_hypers": self.hypers,
-                "dataset_info": self.dataset_info,
+                "dataset_info": self.dataset_info.to_device("cpu"),
             },
             "model_state_dict": self.state_dict(),
             "best_model_state_dict": None,

--- a/src/metatrain/experimental/nanopet/model.py
+++ b/src/metatrain/experimental/nanopet/model.py
@@ -236,12 +236,8 @@ class NanoPET(ModelInterface):
 
         device = systems[0].device
 
-        if self.single_label.values.device != device:
-            self.single_label = self.single_label.to(device)
-        
-        info_device = self.dataset_info.device
-        if info_device is not None and info_device != device:
-            self.dataset_info = self.dataset_info.to(device)
+        self.single_label = self.single_label.to(device)
+        self.dataset_info = self.dataset_info.to(device)
 
         system_indices = torch.concatenate(
             [

--- a/src/metatrain/experimental/nanopet/model.py
+++ b/src/metatrain/experimental/nanopet/model.py
@@ -238,6 +238,7 @@ class NanoPET(ModelInterface):
 
         if self.single_label.values.device != device:
             self.single_label = self.single_label.to(device)
+        if self.dataset_info.device != device:
             self.dataset_info = self.dataset_info.to(device)
 
         system_indices = torch.concatenate(
@@ -579,6 +580,9 @@ class NanoPET(ModelInterface):
         # For example, after training, the additive models could still be in
         # float64
         self.to(dtype)
+
+        # Move dataset info to CPU so that it can be saved
+        self.dataset_info = self.dataset_info.to(device="cpu")
 
         # Additionally, the composition model contains some `TensorMap`s that cannot
         # be registered correctly with Pytorch. This funciton moves them:

--- a/src/metatrain/experimental/nanopet/model.py
+++ b/src/metatrain/experimental/nanopet/model.py
@@ -238,7 +238,9 @@ class NanoPET(ModelInterface):
 
         if self.single_label.values.device != device:
             self.single_label = self.single_label.to(device)
-        if self.dataset_info.device != device:
+        
+        info_device = self.dataset_info.device
+        if info_device is not None and info_device != device:
             self.dataset_info = self.dataset_info.to(device)
 
         system_indices = torch.concatenate(

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -12,6 +12,10 @@ from metatensor.learn.data._namedtuple import namedtuple
 from metatensor.torch import TensorMap, load_buffer
 from metatomic.torch import load_system
 from omegaconf import DictConfig
+
+# We explicitly import device because otherwise torch.jit.script doesn't
+# recognize the torch.device type
+from torch import device as _torch_device
 from torch.utils.data import Subset
 
 from metatrain.utils.data.readers.metatensor import (
@@ -83,6 +87,18 @@ class DatasetInfo:
     @atomic_types.setter
     def atomic_types(self, value: List[int]):
         self._atomic_types = _set(value)
+
+    @property
+    def device(self) -> _torch_device:
+        """Return the device where the tensors of DatasetInfo are located.
+
+        This function only checks the device of the first target
+        and assumes that all targets and extra data are on the same device.
+        This is guaranteed if the ``to()`` method has been used to move
+        the DatasetInfo to a specific device.
+        """
+        first_target = list(self.targets.values())[0]
+        return first_target.device
 
     def to(
         self, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -87,7 +87,7 @@ class DatasetInfo:
     def to(
         self, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None
     ) -> "DatasetInfo":
-        """Return a copy of this instance with all tensors moved to the specified device."""
+        """Return a copy with all tensors moved to the device and dtype."""
         new = self.copy()
         for key, target_info in new.targets.items():
             new.targets[key] = target_info.to(device=device, dtype=dtype)

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -12,7 +12,6 @@ from metatensor.learn.data._namedtuple import namedtuple
 from metatensor.torch import TensorMap, load_buffer
 from metatomic.torch import load_system
 from omegaconf import DictConfig
-
 from torch.utils.data import Subset
 
 from metatrain.utils.data.readers.metatensor import (

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -13,9 +13,6 @@ from metatensor.torch import TensorMap, load_buffer
 from metatomic.torch import load_system
 from omegaconf import DictConfig
 
-# We explicitly import device because otherwise torch.jit.script doesn't
-# recognize the torch.device type
-from torch import device as _torch_device
 from torch.utils.data import Subset
 
 from metatrain.utils.data.readers.metatensor import (
@@ -89,7 +86,7 @@ class DatasetInfo:
         self._atomic_types = _set(value)
 
     @property
-    def device(self) -> _torch_device:
+    def device(self) -> Optional[torch.device]:
         """Return the device where the tensors of DatasetInfo are located.
 
         This function only checks the device of the first target
@@ -97,6 +94,8 @@ class DatasetInfo:
         This is guaranteed if the ``to()`` method has been used to move
         the DatasetInfo to a specific device.
         """
+        if len(self.targets) == 0:
+            return None
         first_target = list(self.targets.values())[0]
         return first_target.device
 

--- a/src/metatrain/utils/data/target_info.py
+++ b/src/metatrain/utils/data/target_info.py
@@ -4,6 +4,10 @@ import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap, equal_metadata
 from omegaconf import DictConfig
 
+# We explicitly import device because otherwise torch.jit.script doesn't
+# recognize the torch.device type
+from torch import device as _torch_device
+
 
 class TargetInfo:
     """A class that contains information about a target.
@@ -226,6 +230,11 @@ class TargetInfo:
         if self.unit != other.unit:
             return False
         return equal_metadata(self.layout, other.layout, check_gradients=False)
+
+    @property
+    def device(self) -> _torch_device:
+        """Return the device of the target info's layout."""
+        return self.layout.device
 
     def to(
         self, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None

--- a/src/metatrain/utils/data/target_info.py
+++ b/src/metatrain/utils/data/target_info.py
@@ -230,7 +230,7 @@ class TargetInfo:
     def to(
         self, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None
     ) -> "TargetInfo":
-        """Move the target info to the given device."""
+        """Return a copy with all tensors moved to the device and dtype."""
         new_layout = self.layout.to(device=device, dtype=dtype)
         return TargetInfo(
             quantity=self.quantity,

--- a/tests/resources/generate-outputs.sh
+++ b/tests/resources/generate-outputs.sh
@@ -11,12 +11,20 @@ mtt train options.yaml -o model-32-bit.pt -r base_precision=32
 mtt train options.yaml -o model-64-bit.pt -r base_precision=64
 mtt train options-pet.yaml -o model-pet.pt
 
-# upload results to private HF repo if token is set
-if [[ "${HUGGINGFACE_TOKEN_METATRAIN+}" != "" ]]; then
-    huggingface-cli upload \
+set +x  # disable command echoing for sensitive private token check
+TOKEN_PRESENT=false
+if [[ -n "${HUGGINGFACE_TOKEN_METATRAIN:-}" ]]; then
+    TOKEN_PRESENT=true
+fi
+set -x
+
+if [ $TOKEN_PRESENT = true ]; then
+    hf upload \
         "metatensor/metatrain-test" \
         "model-32-bit.ckpt" \
         "model.ckpt" \
         --commit-message="Overwrite test model with new version" \
         --token="$HUGGINGFACE_TOKEN_METATRAIN"
+else
+    echo "HUGGINGFACE_TOKEN_METATRAIN is not set, skipping upload."
 fi

--- a/tests/utils/data/test_dataset.py
+++ b/tests/utils/data/test_dataset.py
@@ -352,11 +352,16 @@ def test_dataset_info_union(layout_scalar, layout_cartesian):
     assert union.atomic_types == [1, 6]
     assert union.targets == other_targets
 
+
 def test_dataset_info_no_targets():
     """Tests the properties of a DatasetInfo that has no targets."""
-    dataset_info = DatasetInfo(length_unit="angstrom", atomic_types=[1, 2, 3], targets={})
-    
+    dataset_info = DatasetInfo(
+        length_unit="angstrom", atomic_types=[1, 2, 3], targets={}
+    )
+
     assert dataset_info.device is None
+    # Setting the device should not fail:
+    dataset_info.to(device="cpu")
 
 
 def test_dataset():

--- a/tests/utils/data/test_dataset.py
+++ b/tests/utils/data/test_dataset.py
@@ -174,15 +174,10 @@ def test_target_info_eq(layout_scalar):
     assert info1 != info2
 
 
-def test_target_info_eq_error(layout_scalar):
+def test_target_info_eq_other_objects(layout_scalar):
     info = TargetInfo(quantity="energy", unit="eV", layout=layout_scalar)
 
-    match = (
-        "Comparison between a TargetInfo instance and a list instance is not "
-        "implemented."
-    )
-    with pytest.raises(NotImplementedError, match=match):
-        _ = info == [1, 2, 3]
+    assert not info == [1, 2, 3]
 
 
 def test_dataset_info(layout_scalar):
@@ -303,18 +298,13 @@ def test_dataset_info_eq(layout_scalar):
     assert info != info2
 
 
-def test_dataset_info_eq_error(layout_scalar):
+def test_dataset_info_eq_other_objects(layout_scalar):
     targets = {}
     targets["energy"] = TargetInfo(quantity="energy", unit="eV", layout=layout_scalar)
 
     info = DatasetInfo(length_unit="angstrom", atomic_types=[1, 6], targets=targets)
 
-    match = (
-        "Comparison between a DatasetInfo instance and a list instance is not "
-        "implemented."
-    )
-    with pytest.raises(NotImplementedError, match=match):
-        _ = info == [1, 2, 3]
+    assert not info == [1, 2, 3]
 
 
 def test_dataset_info_update_different_target_info(layout_scalar):
@@ -678,3 +668,21 @@ def test_get_stats(layout_scalar):
     assert "stress" not in stats_2
     assert "eV" in stats
     assert "eV" in stats_2
+
+
+def test_instance_torchscript_compatible(layout_scalar):
+    dataset_info = DatasetInfo(
+        length_unit=None,
+        atomic_types=[1, 2, 3],
+        targets={
+            "energy": TargetInfo(
+                quantity="energy", unit="kcal/mol", layout=layout_scalar
+            )
+        },
+    )
+
+    torch.jit.script(dataset_info)
+
+
+def test_class_torchscript_compatible():
+    torch.jit.script(DatasetInfo)

--- a/tests/utils/data/test_dataset.py
+++ b/tests/utils/data/test_dataset.py
@@ -200,6 +200,7 @@ def test_dataset_info(layout_scalar):
     assert dataset_info.targets["energy"].unit == "kcal/mol"
     assert dataset_info.targets["mtt::U0"].quantity == "energy"
     assert dataset_info.targets["mtt::U0"].unit == "kcal/mol"
+    assert dataset_info.device == layout_scalar.device
 
     expected = (
         "DatasetInfo(length_unit='angstrom', atomic_types=[1, 2, 3], "
@@ -350,6 +351,12 @@ def test_dataset_info_union(layout_scalar, layout_cartesian):
     assert union.length_unit == "angstrom"
     assert union.atomic_types == [1, 6]
     assert union.targets == other_targets
+
+def test_dataset_info_no_targets():
+    """Tests the properties of a DatasetInfo that has no targets."""
+    dataset_info = DatasetInfo(length_unit="angstrom", atomic_types=[1, 2, 3], targets={})
+    
+    assert dataset_info.device is None
 
 
 def test_dataset():

--- a/tests/utils/data/test_dataset.py
+++ b/tests/utils/data/test_dataset.py
@@ -694,7 +694,3 @@ def test_instance_torchscript_compatible(layout_scalar):
     )
 
     torch.jit.script(dataset_info)
-
-
-def test_class_torchscript_compatible():
-    torch.jit.script(DatasetInfo)

--- a/tests/utils/data/test_target_info.py
+++ b/tests/utils/data/test_target_info.py
@@ -151,6 +151,7 @@ def test_is_compatible_with(energy_target_config, spherical_target_config):
         energy_target_info_with_forces.is_compatible_with(spherical_target_config)
     )
 
+
 @pytest.mark.parametrize(
     "target_config",
     [

--- a/tests/utils/data/test_target_info.py
+++ b/tests/utils/data/test_target_info.py
@@ -79,6 +79,7 @@ def test_layout_energy(energy_target_config):
     assert target_info.unit == "eV"
     assert target_info.per_atom is False
     assert target_info.gradients == []
+    assert target_info.device == target_info.layout.device
 
     target_info = get_energy_target_info(
         energy_target_config, add_position_gradients=True
@@ -87,6 +88,7 @@ def test_layout_energy(energy_target_config):
     assert target_info.unit == "eV"
     assert target_info.per_atom is False
     assert target_info.gradients == ["positions"]
+    assert target_info.device == target_info.layout.device
 
     target_info = get_energy_target_info(
         energy_target_config, add_position_gradients=True, add_strain_gradients=True
@@ -95,6 +97,7 @@ def test_layout_energy(energy_target_config):
     assert target_info.unit == "eV"
     assert target_info.per_atom is False
     assert target_info.gradients == ["positions", "strain"]
+    assert target_info.device == target_info.layout.device
 
 
 def test_layout_scalar(scalar_target_config):
@@ -103,6 +106,7 @@ def test_layout_scalar(scalar_target_config):
     assert target_info.unit == ""
     assert target_info.per_atom is False
     assert target_info.gradients == []
+    assert target_info.device == target_info.layout.device
 
 
 def test_layout_cartesian(cartesian_target_config):
@@ -111,6 +115,7 @@ def test_layout_cartesian(cartesian_target_config):
     assert target_info.unit == "D"
     assert target_info.per_atom is True
     assert target_info.gradients == []
+    assert target_info.device == target_info.layout.device
 
 
 def test_layout_spherical(spherical_target_config):
@@ -119,6 +124,7 @@ def test_layout_spherical(spherical_target_config):
     assert target_info.unit == ""
     assert target_info.per_atom is False
     assert target_info.gradients == []
+    assert target_info.device == target_info.layout.device
 
 
 def test_is_auxiliary_output():
@@ -144,7 +150,6 @@ def test_is_compatible_with(energy_target_config, spherical_target_config):
     assert not (
         energy_target_info_with_forces.is_compatible_with(spherical_target_config)
     )
-
 
 @pytest.mark.parametrize(
     "target_config",

--- a/tests/utils/data/test_target_info.py
+++ b/tests/utils/data/test_target_info.py
@@ -3,7 +3,6 @@ import torch
 from omegaconf import DictConfig
 
 from metatrain.utils.data.target_info import (
-    TargetInfo,
     get_energy_target_info,
     get_generic_target_info,
     is_auxiliary_output,

--- a/tests/utils/data/test_target_info.py
+++ b/tests/utils/data/test_target_info.py
@@ -164,7 +164,3 @@ def test_is_compatible_with(energy_target_config, spherical_target_config):
 def test_instance_torchscript_compatible(target_config, request):
     target_info = get_generic_target_info(request.getfixturevalue(target_config))
     torch.jit.script(target_info)
-
-
-def test_class_torchscript_compatible():
-    torch.jit.script(TargetInfo)

--- a/tests/utils/data/test_target_info.py
+++ b/tests/utils/data/test_target_info.py
@@ -1,7 +1,9 @@
 import pytest
+import torch
 from omegaconf import DictConfig
 
 from metatrain.utils.data.target_info import (
+    TargetInfo,
     get_energy_target_info,
     get_generic_target_info,
     is_auxiliary_output,
@@ -142,3 +144,21 @@ def test_is_compatible_with(energy_target_config, spherical_target_config):
     assert not (
         energy_target_info_with_forces.is_compatible_with(spherical_target_config)
     )
+
+
+@pytest.mark.parametrize(
+    "target_config",
+    [
+        "energy_target_config",
+        "scalar_target_config",
+        "cartesian_target_config",
+        "spherical_target_config",
+    ],
+)
+def test_instance_torchscript_compatible(target_config, request):
+    target_info = get_generic_target_info(request.getfixturevalue(target_config))
+    torch.jit.script(target_info)
+
+
+def test_class_torchscript_compatible():
+    torch.jit.script(TargetInfo)


### PR DESCRIPTION
I discussed with @frostedoyster that one source of unnecessary confusion for models is all the separate dictionaries that need to be created to use the information of targets in `forward`, e.g. `self.component_labels`, `self.key_labels`, etc.. The management of all these dictionaries certainly doesn't help with readability.

In this PR, I try to solve it by making both `TargetInfo` and `DatasetInfo` torchscript compatible, so that they can be used directly in `forward`. Perhaps the `DatasetInfo` was not so necessary, but while I was at it I thought I'd do it for completeness.

The only changes I introduced regarding functionality are:
- `__eq__` methods now return `False` if compared to other objects. This is because it was much easier to make torchscript compatible, but also because it is what all (most) python objects do. Is there a reason for raising an error instead? Anyway I left the tests unchanged for now and they are failing, I can revert this change in functionality if you want.
- Introduced a `to` method to change the device of `DatasetInfo` and `TargetInfo`, because it helps with reducing the amount of code in the model's `forward`.

I think moving forward this enables further refactoring possibilities like having functions that given the torch tensor outputs for the targets build all the tensormaps. I think this would be huge for people that are not familiar with `metatensor` and want to contribute a model, since the building of the tensor maps involves a lot of lines and is intimidating. I didn't add this in the PR to keep it as simple as possible for now.

As an example, I modified `NanoPET` to showcase the benefits of the PR. I didn't modify `PET` because it will create conflicts with #662 that would not be fun to solve :) 

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--693.org.readthedocs.build/en/693/

<!-- readthedocs-preview metatrain end -->