### PR TITLE
Fix the human readable parameter counter

### DIFF
--- a/src/metatrain/cli/train.py
+++ b/src/metatrain/cli/train.py
@@ -705,7 +705,7 @@ def _human_readable(n):
     x = float(n)
 
     while abs(x) >= 1000 and idx < len(suffixes) - 1:
-        x /= 1000.0
+        x /= 1000
         idx += 1
 
     if abs(x) < 100:

--- a/src/metatrain/cli/train.py
+++ b/src/metatrain/cli/train.py
@@ -38,7 +38,7 @@ from ..utils.io import (
     trainer_from_checkpoint,
 )
 from ..utils.jsonschema import validate
-from ..utils.logging import ROOT_LOGGER, WandbHandler
+from ..utils.logging import ROOT_LOGGER, WandbHandler, human_readable
 from ..utils.omegaconf import BASE_OPTIONS, check_units, expand_dataset_config
 from .eval import _eval_targets
 from .export import _has_extensions
@@ -528,7 +528,7 @@ def train_model(
     n_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
     logging.info(
         (
-            f"The model has {_human_readable(n_params)} parameters "
+            f"The model has {human_readable(n_params)} parameters "
             f"(actual number: {n_params})."
         )
     )
@@ -676,20 +676,3 @@ def _get_batch_size_from_hypers(hypers: Union[Dict, DictConfig]) -> Optional[int
         ):
             return value
     return None
-
-
-def _human_readable(n):
-    suffixes = ["", "K", "M", "B", "T"]
-    idx = 0
-    x = float(n)
-
-    while abs(x) >= 1000 and idx < len(suffixes) - 1:
-        x /= 1000
-        idx += 1
-
-    if abs(x) < 100:
-        s = f"{x:.1f}".rstrip("0").rstrip(".")
-    else:
-        s = f"{x:.0f}"
-
-    return f"{s}{suffixes[idx]}"

--- a/src/metatrain/cli/train.py
+++ b/src/metatrain/cli/train.py
@@ -700,20 +700,17 @@ def _get_batch_size_from_hypers(hypers: Union[Dict, DictConfig]) -> Optional[int
 
 
 def _human_readable(n):
-    """
-    Turn a number into a human-friendly string
-    """
     suffixes = ["", "K", "M", "B", "T"]
-    if n == 0:
-        return "0"
-    # figure out which suffix to use
-    idx = min(int(np.log10(abs(n)) // 3), len(suffixes) - 1)
-    value = n / (1000**idx)
-    # pick formatting: one decimal if <10, otherwise integer with commas
-    if value < 10:
-        s = f"{value:.1f}"
+    idx = 0
+    x = float(n)
+
+    while abs(x) >= 1000 and idx < len(suffixes) - 1:
+        x /= 1000.0
+        idx += 1
+
+    if abs(x) < 100:
+        s = f"{x:.1f}".rstrip("0").rstrip(".")
     else:
-        s = f"{int(value):,d}"
-    # drop any trailing ".0"
-    s = s.rstrip(".0")
+        s = f"{x:.0f}"
+
     return f"{s}{suffixes[idx]}"

--- a/src/metatrain/utils/logging.py
+++ b/src/metatrain/utils/logging.py
@@ -440,23 +440,14 @@ def _sort_metric_names(name_list):
     return sorted_name_list
 
 
-def human_readable(n):
+def human_readable(n: Union[int, float]) -> str:
     """Convert a number to a human-readable format with suffixes.
 
     This function takes a number and formats it into a string with metric
     suffixes (K for thousands, M for millions, B for billions, T for trillions).
 
-    - Numbers less than 1000 are returned as is.
-    - Numbers between 1,000 and 99,999 are formatted with one decimal place and a "K"
-        suffix (e.g., 1234 becomes "1.2K").
-    - Numbers from 100,000 up to 999,999 are formatted as an integer with a "K"
-        suffix (e.g., 123456 becomes "123K").
-    - This pattern continues for millions (M), billions (B), and trillions (T).
-
     :param n: The number to be converted.
-    :type n: int or float
     :return: The human-readable string representation of the number.
-    :rtype: str
 
     """
     suffixes = ["", "K", "M", "B", "T"]

--- a/src/metatrain/utils/logging.py
+++ b/src/metatrain/utils/logging.py
@@ -438,3 +438,45 @@ def _sort_metric_names(name_list):
     # add the rest
     sorted_name_list.extend(sorted_remaining_name_list)
     return sorted_name_list
+
+
+def human_readable(n):
+    """Convert a number to a human-readable format with suffixes.
+
+    This function takes a number and formats it into a string with metric
+    suffixes (K for thousands, M for millions, B for billions, T for trillions).
+
+    - Numbers less than 1000 are returned as is.
+    - Numbers between 1,000 and 99,999 are formatted with one decimal place and a "K"
+        suffix (e.g., 1234 becomes "1.2K").
+    - Numbers from 100,000 up to 999,999 are formatted as an integer with a "K"
+        suffix (e.g., 123456 becomes "123K").
+    - This pattern continues for millions (M), billions (B), and trillions (T).
+
+    :param n: The number to be converted.
+    :type n: int or float
+    :return: The human-readable string representation of the number.
+    :rtype: str
+
+    """
+    suffixes = ["", "K", "M", "B", "T"]
+    idx = 0
+    x = float(n)
+
+    # repeatedly divide by 1000 to find the right suffix
+    while abs(x) >= 1000 and idx < len(suffixes) - 1:
+        x /= 1000
+        idx += 1
+
+    # one decimal if the reduced value is under 100, else integer
+    if abs(x) < 100:
+        s = f"{x:.1f}".rstrip("0").rstrip(".")
+    else:
+        s = f"{int(round(x))}"
+
+    # handle cases like 999999 so it does not become "1000K"
+    if s == "1000" and idx < len(suffixes) - 1:
+        s = "1"
+        idx += 1
+
+    return f"{s}{suffixes[idx]}"

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -16,7 +16,7 @@ from metatomic.torch import NeighborListOptions, systems_to_torch
 from omegaconf import OmegaConf
 
 from metatrain import RANDOM_SEED
-from metatrain.cli.train import _process_restart_from, train_model
+from metatrain.cli.train import _human_readable, _process_restart_from, train_model
 from metatrain.utils.data.readers.ase import read
 from metatrain.utils.data.writers import DiskDatasetWriter
 from metatrain.utils.errors import ArchitectureError
@@ -970,3 +970,23 @@ def test_train_wandb_logger(monkeypatch, tmp_path):
 
     assert "'base_precision': 64" in file_log
     assert "'seed': 42" in file_log
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0, "0"),
+        (999, "999"),
+        (1000, "1K"),
+        (1234, "1.2K"),
+        (1254, "1.3K"),
+        (20454, "20.5K"),
+        (306945, "307K"),
+        (1000000, "1M"),
+        (1500000000, "1.5B"),
+        (1865039582492, "1.9T"),
+        (1835039582492, "1.8T"),
+    ],
+)
+def test_human_readable_parameter_counter(value, expected):
+    assert _human_readable(value) == expected

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -16,7 +16,7 @@ from metatomic.torch import NeighborListOptions, systems_to_torch
 from omegaconf import OmegaConf
 
 from metatrain import RANDOM_SEED
-from metatrain.cli.train import _human_readable, _process_restart_from, train_model
+from metatrain.cli.train import _process_restart_from, train_model
 from metatrain.utils.data.readers.ase import read
 from metatrain.utils.data.writers import DiskDatasetWriter
 from metatrain.utils.errors import ArchitectureError
@@ -963,23 +963,3 @@ def test_train_wandb_logger(monkeypatch, tmp_path):
 
     assert "'base_precision': 64" in file_log
     assert "'seed': 42" in file_log
-
-
-@pytest.mark.parametrize(
-    "value, expected",
-    [
-        (0, "0"),
-        (999, "999"),
-        (1000, "1K"),
-        (1234, "1.2K"),
-        (1254, "1.3K"),
-        (20454, "20.5K"),
-        (306945, "307K"),
-        (1000000, "1M"),
-        (1500000000, "1.5B"),
-        (1865039582492, "1.9T"),
-        (1835039582492, "1.8T"),
-    ],
-)
-def test_human_readable_parameter_counter(value, expected):
-    assert _human_readable(value) == expected

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -17,6 +17,7 @@ from metatrain.utils.logging import (
     MetricLogger,
     WandbHandler,
     get_cli_input,
+    human_readable,
     setup_logging,
 )
 
@@ -391,3 +392,37 @@ def test_get_cli_input_sys(monkeypatch):
     argv, argv_str = get_argv()
     monkeypatch.setattr(sys, "argv", argv)
     assert get_cli_input() == argv_str
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (0, "0"),
+        (123, "123"),
+        (999, "999"),
+        (1000, "1K"),
+        (1049, "1K"),
+        (1050, "1.1K"),
+        (1234, "1.2K"),
+        (9999, "10K"),
+        (20454, "20.5K"),
+        (99499, "99.5K"),
+        (99500, "99.5K"),
+        (100000, "100K"),
+        # Edge case around 1 million
+        (999499, "999K"),
+        (999500, "1M"),
+        (999999, "1M"),
+        (1000000, "1M"),
+        (1049999, "1M"),
+        (1050000, "1.1M"),
+        # Larger numbers
+        (123456789, "123M"),
+        (999999999999, "1T"),
+        # Max suffix
+        (1230000000000000, "1230T"),
+        (1230000000000000000, "1230000T"),
+    ],
+)
+def test_human_readable_parameter_counter(value, expected):
+    assert human_readable(value) == expected


### PR DESCRIPTION
Fix a but for which a number of parameters like x0yzw  would result in xK instead of x0K. 


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--697.org.readthedocs.build/en/697/

<!-- readthedocs-preview metatrain end -->