### PR TITLE
Fix bug in the distributed training of `CompositionModel`

### DIFF
--- a/src/metatrain/pet/trainer.py
+++ b/src/metatrain/pet/trainer.py
@@ -142,6 +142,22 @@ class Trainer(TrainerInterface):
         for additive_model in model.additive_models:
             additive_model.to(dtype=torch.float64)
 
+        logging.info("Calculating composition weights")
+
+        model.additive_models[0].train_model(  # this is the composition model
+            train_datasets,
+            model.additive_models[1:],
+            self.hypers["batch_size"],
+            is_distributed,
+            self.hypers["fixed_composition_weights"],
+        )
+
+        if self.hypers["scale_targets"]:
+            logging.info("Calculating scaling weights")
+            model.scaler.train_model(
+                train_datasets, model.additive_models, treat_as_additive=True
+            )
+
         logging.info("Setting up data loaders")
 
         if is_distributed:
@@ -222,19 +238,6 @@ class Trainer(TrainerInterface):
                 )
             )
         val_dataloader = CombinedDataLoader(val_dataloaders, shuffle=False)
-
-        logging.info("Calculating composition weights")
-        model.additive_models[0].train_model(  # this is the composition model
-            train_dataloader,
-            model.additive_models[1:],
-            self.hypers["fixed_composition_weights"],
-        )
-
-        if self.hypers["scale_targets"]:
-            logging.info("Calculating scaling weights")
-            model.scaler.train_model(
-                train_datasets, model.additive_models, treat_as_additive=True
-            )
 
         if is_distributed:
             model = DistributedDataParallel(model, device_ids=[device])

--- a/src/metatrain/utils/additive/_base_composition.py
+++ b/src/metatrain/utils/additive/_base_composition.py
@@ -80,17 +80,25 @@ class BaseCompositionModel(torch.nn.Module):
 
         self.target_names.append(target_name)
         self.is_fitted[target_name] = False
-        if layout.sample_names == ["system"]:
+        valid_sample_names = [
+            ["system"],
+            [
+                "system",
+                "atom",
+            ],
+        ]
+
+        if layout.sample_names == valid_sample_names[0]:
             self.sample_kinds[target_name] = "per_structure"
 
-        elif layout.sample_names == ["system", "atom"]:
+        elif layout.sample_names == valid_sample_names[1]:
             self.sample_kinds[target_name] = "per_atom"
 
         else:
             raise ValueError(
                 "unknown sample kind. TensorMap has sample names"
-                f" {layout.sample_names} but expected either"
-                "['system'], or ['system', 'atom']"
+                f" {layout.sample_names} but expected one of "
+                f"{valid_sample_names}."
             )
 
         # First slice the layout to only include the keys that the composition
@@ -207,9 +215,7 @@ class BaseCompositionModel(torch.nn.Module):
                     X = self._compute_X_per_structure(systems)
 
                 elif self.sample_kinds[target_name] == "per_atom":
-                    X = self._compute_X_per_atom(
-                        systems, self._get_sliced_atomic_types(key)
-                    )
+                    X = self._compute_X_per_atom(systems, self.atomic_types)
 
                 else:
                     raise ValueError(
@@ -279,7 +285,7 @@ class BaseCompositionModel(torch.nn.Module):
 
                 blocks.append(
                     TensorBlock(
-                        values=weight_vals,
+                        values=weight_vals.contiguous(),
                         samples=XTY_block.samples.to(device=weight_vals.device),
                         components=XTY_block.components,
                         properties=XTY_block.properties.to(device=weight_vals.device),
@@ -316,12 +322,15 @@ class BaseCompositionModel(torch.nn.Module):
         dtype = systems[0].positions.dtype
         self._sync_device_dtype(device, dtype)
 
-        system_indices, sample_labels_per_atom = _get_system_indices_and_labels(
-            systems, device
-        )
+        # Build the sample labels that are required
+        _, sample_labels = _get_system_indices_and_labels(systems, device)
 
+        # Compute the X tensor
+        X = self._compute_X_per_atom(systems, self.atomic_types)
+
+        # Build the predictions for each output
         predictions: Dict[str, TensorMap] = {}
-        for output_name, model_output in outputs.items():
+        for output_name in outputs:
             if output_name not in self.target_names:
                 raise ValueError(
                     f"output {output_name} is not supported by this composition model."
@@ -331,53 +340,28 @@ class BaseCompositionModel(torch.nn.Module):
             prediction_key_vals = []
             prediction_blocks: List[TensorBlock] = []
             for key, weight_block in weights.items():
-                # Compute X
-                if self.sample_kinds[output_name] == "per_structure":
-                    if model_output.per_atom:
-                        sample_labels = sample_labels_per_atom
-                        X = self._compute_X_per_atom(
-                            systems, self._get_sliced_atomic_types(key)
-                        )
-
-                    else:
-                        sample_labels = Labels(
-                            ["system"],
-                            torch.arange(
-                                len(systems), dtype=torch.int32, device=device
-                            ).reshape(-1, 1),
-                        ).to(device=device)
-                        X = self._compute_X_per_structure(systems)
-
-                # TODO: add support for per_pair. As compositions are only fitted for
-                # on-site blocks this extension is simple, reusing the per_atom code.
-                elif self.sample_kinds[output_name] == "per_atom":
-                    sample_labels = sample_labels_per_atom
-                    X = self._compute_X_per_atom(
-                        systems, self._get_sliced_atomic_types(key)
-                    )
-
-                else:
-                    raise ValueError(
-                        f"unknown sample kind: {self.sample_kinds[output_name]}"
-                        f" for target {output_name}"
-                    )
+                sample_labels_block = sample_labels
 
                 # If selected_atoms is provided, slice the samples labels and the X
                 # tensor
-                if selected_atoms is not None:
-                    sample_indices = sample_labels.select(selected_atoms)
-                    sample_labels = Labels(
-                        sample_labels.names,
-                        sample_labels.values[sample_indices],
+                if selected_atoms is None:
+                    X_block = X
+                else:
+                    sample_indices = sample_labels_block.select(selected_atoms)
+                    sample_labels_block = Labels(
+                        sample_labels_block.names,
+                        sample_labels_block.values[sample_indices],
                     ).to(device=device)
-                    X = X[sample_indices]
+                    X_block = X[sample_indices]
 
                 # Compute X.T @ W
-                out_vals = torch.tensordot(X, weight_block.values, dims=([1], [0]))
+                out_vals = torch.tensordot(
+                    X_block, weight_block.values, dims=([1], [0])
+                )
                 prediction_blocks.append(
                     TensorBlock(
                         values=out_vals,
-                        samples=sample_labels,
+                        samples=sample_labels_block,
                         components=weight_block.components,
                         properties=weight_block.properties,
                     )
@@ -391,32 +375,14 @@ class BaseCompositionModel(torch.nn.Module):
                 ),
                 prediction_blocks,
             )
+
+            # If a per-structure output is requested, sum over the sample dimensions
+            # that aren't "system".
+            if not outputs[output_name].per_atom:
+                prediction = mts.sum_over_samples(prediction, "atom")
             predictions[output_name] = prediction
 
         return predictions
-
-    def _get_sliced_atomic_types(self, key: LabelsEntry) -> torch.Tensor:
-        """
-        Gets the slice of atomic types needed for the block indexed by the input ``key``
-        """
-        center_types = self.atomic_types
-        dtype = torch.int32
-        device = self.atomic_types.device
-
-        if "center_type" in key.names:
-            center_types = torch.tensor(
-                [key["center_type"]], dtype=dtype, device=device
-            )
-
-        if "first_atom_type" in key.names and "second_atom_type" in key.names:
-            assert (
-                key["first_atom_type"] == key["second_atom_type"] and key["s2_pi"] == 0
-            )
-            center_types = torch.tensor(
-                [key["first_atom_type"]], dtype=dtype, device=device
-            )
-
-        return center_types
 
     def _compute_X_per_structure(self, systems: List[System]) -> torch.Tensor:
         """
@@ -508,20 +474,27 @@ def _include_key(key: LabelsEntry) -> bool:
     composition model.
 
     The rules are as follows:
-        - If the key has a single name "_" (indicating a scalar),
-          it is included.
-        - If the key has names "o3_lambda" and "o3_sigma", it is included
-          if values are 0 and 1 respectively (indicating an invariant block of a
-          spherical target).
+        - If the key has a single name "_" (indicating a scalar), it is included.
+        - If the key has names ["o3_lambda", "o3_sigma"] it is included if values are 0
+          and 1 respectively (indicating an invariant block of a spherical target).
     """
+    valid_key_names = [
+        ["_"],  # scalar
+        ["o3_lambda", "o3_sigma"],  # spherical
+    ]
     include_key = False
 
-    if len(key.names) == 1 and key.names[0] == "_":  # scalar
+    if key.names == valid_key_names[0]:
         include_key = True
 
-    if "o3_lambda" in key.names and "o3_sigma" in key.names:
+    elif key.names == valid_key_names[1]:
         if key["o3_lambda"] == 0 and key["o3_sigma"] == 1:
             include_key = True
+
+    else:
+        raise ValueError(
+            f"key names {key.names} not in valid key names {valid_key_names}"
+        )
 
     return include_key
 

--- a/src/metatrain/utils/additive/composition.py
+++ b/src/metatrain/utils/additive/composition.py
@@ -1,16 +1,22 @@
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import metatensor.torch as mts
 import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
-from metatensor.torch.learn.data import DataLoader
 from metatomic.torch import ModelOutput, System
+from torch.utils.data import DataLoader, DistributedSampler
+
+from metatrain.utils.data import (
+    CollateFn,
+    CombinedDataLoader,
+    Dataset,
+)
 
 from ..data import DatasetInfo, TargetInfo
 from ..jsonschema import validate
 from ..transfer import batch_to
-from ._base_composition import BaseCompositionModel
+from ._base_composition import BaseCompositionModel, _include_key
 from .remove import remove_additive
 
 
@@ -69,31 +75,105 @@ class CompositionModel(torch.nn.Module):
         for target_name, target_info in self.dataset_info.targets.items():
             self._add_output(target_name, target_info)
 
+    def _get_dataloader(
+        self,
+        datasets: List[Union[Dataset, torch.utils.data.Subset]],
+        batch_size: int,
+        is_distributed: bool,
+    ) -> DataLoader:
+        """
+        Create a DataLoader for the provided datasets. As the dataloader is only used to
+        accumulate the quanitites needed for fitting the composition weights, there is
+        no need to shuffle or drop the last non-full batch. Distributed sampling can be
+        used or not, based on the `is_distributed` argument, and training with double
+        precision is enforced.
+        """
+        # Create the collate function
+        targets_keys = list(self.dataset_info.targets.keys())
+        collate_fn = CollateFn(target_keys=targets_keys)
+
+        dtype = datasets[0][0]["system"].positions.dtype
+        if dtype != torch.float64:
+            raise ValueError(
+                "The composition model only supports float64 during training. "
+                f"Got dtype: {dtype}."
+            )
+
+        # Build the dataloaders
+        if is_distributed:
+            world_size = torch.distributed.get_world_size()
+            rank = torch.distributed.get_rank()
+            samplers = [
+                DistributedSampler(
+                    dataset,
+                    num_replicas=world_size,
+                    rank=rank,
+                    shuffle=False,
+                    drop_last=False,
+                )
+                for dataset in datasets
+            ]
+        else:
+            samplers = [None] * len(datasets)
+
+        dataloaders = []
+        for dataset, sampler in zip(datasets, samplers):
+            if len(dataset) < batch_size:
+                raise ValueError(
+                    f"A training dataset has fewer samples "
+                    f"({len(dataset)}) than the batch size "
+                    f"({batch_size}). "
+                    "Please reduce the batch size."
+                )
+            dataloaders.append(
+                DataLoader(
+                    dataset=dataset,
+                    batch_size=batch_size,
+                    sampler=sampler,
+                    shuffle=None if sampler else False,
+                    drop_last=False,
+                    collate_fn=collate_fn,
+                )
+            )
+
+        return CombinedDataLoader(dataloaders, shuffle=False)
+
     def train_model(
         self,
-        dataloader: DataLoader,
+        datasets: List[Union[Dataset, torch.utils.data.Subset]],
         additive_models: List[torch.nn.Module],
+        batch_size: int,
+        is_distributed: bool,
         fixed_weights: Optional[Dict[str, Dict[int, float]]] = None,
     ) -> None:
         """
-        Train the composition model on the provided training data in the ``dataloader``.
+        Train the composition model on the provided training data in the ``datasets``.
 
-        Assumes the systems are stored in the ``system`` attribute of the batch. Targets
-        are expected to be in the batch as well, with keys corresponding to the target
+        Assumes the systems are stored in the ``system`` attribute of each sample, with
+        targets expected to be stored as well, with keys corresponding to the target
         names defined in the dataset info.
 
-        Any additive contributions from the provided ``additive_models`` will be
-        removed from the targets before training. The `fixed_weights` argument can be
-        used to specify which targets should be treated as fixed weights during
-        training.
+        Any additive contributions from the provided ``additive_models`` will be removed
+        from the targets before training. The `fixed_weights` argument can be used to
+        specify which targets should be treated as fixed weights during training.
         """
+
+        if not isinstance(datasets, list):
+            datasets = [datasets]
+
         if len(self.target_infos) == 0:  # no (new) targets to fit
             return
+
+        # Create dataloader for the training datasets
+        dataloader = self._get_dataloader(
+            datasets, batch_size, is_distributed=is_distributed
+        )
 
         if fixed_weights is None:
             fixed_weights = {}
 
         device = self.dummy_buffer.device
+
         # accumulate
         for batch in dataloader:
             systems, targets, _ = batch
@@ -101,7 +181,7 @@ class CompositionModel(torch.nn.Module):
             # only accumulate the targets that do not use fixed weights
             targets = {
                 target_name: targets[target_name]
-                for target_name in self.target_infos.keys()
+                for target_name, target in targets.items()
                 if target_name not in fixed_weights
             }
             if len(targets) == 0:
@@ -109,7 +189,7 @@ class CompositionModel(torch.nn.Module):
 
             # remove additive contributions from these targets
             for additive_model in additive_models:
-                targets = remove_additive(  # remove other additive models
+                targets = remove_additive(
                     systems,
                     targets,
                     additive_model,
@@ -120,7 +200,19 @@ class CompositionModel(torch.nn.Module):
                 )
             self.model.accumulate(systems, targets)
 
-        # fit
+        if is_distributed:
+            torch.distributed.barrier()
+            # All-reduce the accumulated TensorMaps across all processes
+            for target_name in self.model.XTX.keys():
+                for XTX_block, XTY_block in zip(
+                    self.model.XTX[target_name],
+                    self.model.XTY[target_name],
+                    strict=True,
+                ):
+                    torch.distributed.all_reduce(XTX_block.values)
+                    torch.distributed.all_reduce(XTY_block.values)
+
+        # Fit the model on all ranks
         self.model.fit(fixed_weights)
 
         # update the buffer weights now they are fitted
@@ -222,8 +314,20 @@ class CompositionModel(torch.nn.Module):
             per_atom=True,
         )
 
+        # Create a fake weights buffer for the target, filtering the blocks that will
+        # not be fitted
+        layout = mts.filter_blocks(
+            target_info.layout,
+            Labels(
+                target_info.layout.keys.names,
+                torch.vstack(
+                    [key.values for key in target_info.layout.keys if _include_key(key)]
+                ),
+            ),
+        )
+
         fake_weights = TensorMap(
-            keys=self.dataset_info.targets[target_name].layout.keys,
+            keys=layout.keys,
             blocks=[
                 TensorBlock(
                     values=torch.zeros(
@@ -239,7 +343,7 @@ class CompositionModel(torch.nn.Module):
                     components=b.components,
                     properties=b.properties,
                 )
-                for b in target_info.layout.blocks()
+                for b in layout.blocks()
             ],
         )
         self.register_buffer(


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Changes the API of the new `CompositionModel` to instead take a dataset as input (like the old one). It then internally creates a dataloader with proper handling of the (non-) distributed cases. If distributed, accumulation of the `XTX` and `XTY` quantities is parallelized across processors then aggregated before fitting.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - ~[ ] Documentation updated (for new features)?~
 - [x] Issue referenced (for PRs that solve an issue)?
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--698.org.readthedocs.build/en/698/

<!-- readthedocs-preview metatrain end -->