### PR TITLE
Fix automatic training restart after moving outputs directory

### DIFF
--- a/src/metatrain/cli/train.py
+++ b/src/metatrain/cli/train.py
@@ -125,7 +125,7 @@ def _process_restart_from(restart_from: str) -> Optional[Union[str, Path]]:
     pattern = re.compile(r".*\d{4}-\d{2}-\d{2}/\d{2}-\d{2}-\d{2}/*")
     checkpoints = sorted(
         (f for f in Path("outputs").glob("*/*/*.ckpt") if pattern.match(str(f))),
-        key=lambda f: f.stat().st_ctime,
+        key=lambda f: f.stat().st_mtime,
         reverse=True,
     )
 


### PR DESCRIPTION
Implements the fix discussed in #720 

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - ~[ ] Documentation updated (for new features)?~
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?
 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--722.org.readthedocs.build/en/722/

<!-- readthedocs-preview metatrain end -->