### PR TITLE
Move CSCS CI out of the contributor checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -7,8 +7,8 @@
  - [ ] Tests updated (for new features and bugfixes)?
  - [ ] Documentation updated (for new features)?
  - [ ] Issue referenced (for PRs that solve an issue)?
- - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?
 
-# Reviewer checklist
+# Maintainer/Reviewer checklist
 
  - [ ] CHANGELOG updated with public API or any other important changes?
+ - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


### PR DESCRIPTION
Less scary for occasional contributors

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--723.org.readthedocs.build/en/723/

<!-- readthedocs-preview metatrain end -->