### PR TITLE
Add progress bar to `mtt eval`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "jsonschema",
     "omegaconf >= 2.3.0",
     "python-hostlist",
+    "tqdm",
     "vesin",
 ]
 

--- a/src/metatrain/cli/eval.py
+++ b/src/metatrain/cli/eval.py
@@ -7,6 +7,7 @@ from typing import Dict, Optional, Union
 
 import numpy as np
 import torch
+import tqdm
 from metatensor.torch import Labels, TensorBlock, TensorMap
 from metatomic.torch import AtomisticModel
 from omegaconf import DictConfig, OmegaConf
@@ -182,7 +183,7 @@ def _eval_targets(
     timings_per_atom = []
 
     # Main evaluation loop
-    for batch in dataloader:
+    for batch in tqdm.tqdm(dataloader):
         systems, batch_targets, _ = batch
         systems = [system.to(dtype=dtype, device=device) for system in systems]
         batch_targets = {


### PR DESCRIPTION
As in the title. For now, it looks like this:

`mtt train`
```
[2025-08-20 09:17:36][INFO] - Evaluating training dataset
[2025-08-20 09:17:36][INFO] - Running on device cuda with dtype torch.float64
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:00<00:00, 33.08it/s]
[2025-08-20 09:17:39][INFO] - energy RMSE (per atom): 1.8946 meV | energy MAE (per atom): 1.4322 meV
[2025-08-20 09:17:39][INFO] - Evaluation time: 0.22 s [0.5496 ± 0.0914 ms per atom]
[2025-08-20 09:17:39][INFO] - Evaluating validation dataset
[2025-08-20 09:17:39][INFO] - Running on device cuda with dtype torch.float64
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 31.43it/s]
[2025-08-20 09:17:40][INFO] - energy RMSE (per atom): 2.5541 meV | energy MAE (per atom): 1.9596 meV
[2025-08-20 09:17:40][INFO] - Evaluation time: 0.06 s [0.4749 ± 0.0178 ms per atom]
[2025-08-20 09:17:40][INFO] - Evaluating test dataset
[2025-08-20 09:17:40][INFO] - Running on device cuda with dtype torch.float64
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 31.69it/s]
[2025-08-20 09:17:40][INFO] - energy RMSE (per atom): 3.4242 meV | energy MAE (per atom): 2.5042 meV
```

`mtt eval`
```
[2025-08-20 09:18:39][INFO] - Evaluating dataset
[2025-08-20 09:18:39][WARNING] - No forces found in section 'U0'.
[2025-08-20 09:18:39][WARNING] - No stress found in section 'U0'.
[2025-08-20 09:18:39][INFO] - Running on device cuda with dtype torch.float64
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:02<00:00, 46.80it/s]
[2025-08-20 09:18:45][INFO] - energy RMSE (per atom): 2.8197 meV | energy MAE (per atom): 2.0209 meV
[2025-08-20 09:18:45][INFO] - Evaluation time: 1.89 s [2.1129 ± 0.9017 ms per atom]
```

I'm wondering if we should disable it for `mtt train` and only keep it for `mtt eval`

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--727.org.readthedocs.build/en/727/

<!-- readthedocs-preview metatrain end -->