### PR TITLE
Don't re-create the Systems while remapping NLs in PET

### DIFF
--- a/src/metatrain/pet/model.py
+++ b/src/metatrain/pet/model.py
@@ -852,40 +852,6 @@ class PET(ModelInterface):
             block.properties for block in target_info.layout.blocks()
         ]
 
-    def _get_system_indices_and_labels(
-        self,
-        systems: List[System],
-        device: torch.device,
-        selected_atoms: Optional[Labels] = None,
-    ):
-        system_indices_list = []
-        atom_indices_list = []
-        for i, system in enumerate(systems):
-            if selected_atoms is not None:
-                selected_atoms_index = selected_atoms.values[:, 1][
-                    selected_atoms.values[:, 0] == i
-                ]
-            else:
-                selected_atoms_index = torch.arange(len(system), device=device)
-            system_indices_list.append(
-                torch.full((len(selected_atoms_index),), i, device=device)
-            )
-            atom_indices_list.append(
-                torch.arange(len(selected_atoms_index), device=device)
-            )
-        system_indices = torch.concatenate(system_indices_list)
-        atom_indices = torch.concatenate(atom_indices_list)
-
-        sample_values = torch.stack(
-            [system_indices, atom_indices],
-            dim=1,
-        )
-        sample_labels = Labels(
-            names=["system", "atom"],
-            values=sample_values,
-        )
-        return system_indices, sample_labels
-
     @classmethod
     def upgrade_checkpoint(cls, checkpoint: Dict) -> Dict:
         for v in range(1, cls.__checkpoint_version__):

--- a/src/metatrain/pet/modules/structures.py
+++ b/src/metatrain/pet/modules/structures.py
@@ -110,28 +110,6 @@ def concatenate_structures(
     )
 
 
-def save_system(
-    system: System,
-    neighbor_list_options: NeighborListOptions,
-    selected_atoms: Optional[Labels] = None,
-):
-    positions = system.positions
-    types = system.types
-    cell = system.cell
-    pbc = system.pbc
-    system_data = {
-        "positions": positions,
-        "types": types,
-        "cell": cell,
-        "pbc": pbc,
-    }
-    nl = system.get_neighbor_list(neighbor_list_options)
-    nl.to(dtype=torch.float64).save("nl.mta")
-    torch.save(system_data, "system.pt")
-    if selected_atoms is not None:
-        selected_atoms.to("cpu").save("selected_atoms.mta")
-
-
 def systems_to_batch(
     systems: List[System],
     options: NeighborListOptions,


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->
This PR implements a cleaner version of the neighborlist (NL) indices remapping technique, that doesn't re-create systems and therefore doesn't loose additional NLs data. It also makes the overall computational graph in the forward pass more transparent and efficient. 

The origin of the remapping comes from the difference in the NL format between ASE and LAMMPS. While running calculations that involve domain decomposition, LAMMPS-metatomic interface by default adds all the _ghost_ atoms to the list of `positions` and `types`. Therefore, even for tiny structures of a few atoms, one can get a thousand of atoms in the returned `System` instance. This adds a significant overhead during inference, as one needs to calculate the forward pass for all real and all ghost atoms.

This should be relatively easy solvable with pre-selecting only the `selected_atoms`, that are real atoms associated with a current domain. However, due to the presence of message-passing (MP)  in the model, one needs to consider messages exchange between all types of atoms in the system --- real-real, real-ghost, ghost-ghost --- in order to get the proper messages coming to the real atoms on each MP step. This can be achieved by introducing MPI calls for other domains on every MP step, or by considering a large domain with a lot of neighbors. Currently, the second technique is used. 

# Contributor (creator of pull-request) checklist

 - ~~[ ] Tests updated (for new features and bugfixes)?~~
 - ~~[ ] Documentation updated (for new features)?~~
 - [ ] Issue referenced (for PRs that solve an issue)?

# Maintainer/Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?
