### PR TITLE
Add docstring for random functions

### DIFF
--- a/src/metatrain/utils/augmentation.py
+++ b/src/metatrain/utils/augmentation.py
@@ -13,10 +13,12 @@ from .data import TargetInfo
 
 
 def get_random_rotation():
+    """Random 3D rotation that is Haar uniformly distributed over SO(3)."""
     return Rotation.random()
 
 
 def get_random_inversion():
+    """Randomly choose an inversion factor -1 or 1."""
     return random.choice([1, -1])
 
 


### PR DESCRIPTION
From the docs of [scipy.spatial.transform.Rotation](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.transform.Rotation.random.html#scipy.spatial.transform.Rotation.random) it is not clear if the random orientation is really Haar uniformly distributed over SO(3) [uniform on a sphere].

It is, but to avoid that this question that might come up again in the future, I added a docstring.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--747.org.readthedocs.build/en/747/

<!-- readthedocs-preview metatrain end -->