### PR TITLE
Add helpful error message when OOM

### DIFF
--- a/src/metatrain/cli/train.py
+++ b/src/metatrain/cli/train.py
@@ -30,7 +30,7 @@ from ..utils.data import (
 from ..utils.data.dataset import _save_indices, _train_test_random_split
 from ..utils.devices import pick_devices
 from ..utils.distributed.logging import is_main_process
-from ..utils.errors import ArchitectureError
+from ..utils.errors import ArchitectureError, OutOfMemoryError
 from ..utils.io import (
     check_file_extension,
     load_model,
@@ -559,6 +559,8 @@ def train_model(
             val_datasets=val_datasets,
             checkpoint_dir=str(checkpoint_dir),
         )
+    except torch.cuda.OutOfMemoryError as e:
+        raise ArchitectureError(OutOfMemoryError(e)) from e
     except Exception as e:
         raise ArchitectureError(e) from e
 

--- a/src/metatrain/utils/errors.py
+++ b/src/metatrain/utils/errors.py
@@ -17,3 +17,24 @@ class ArchitectureError(Exception):
             "If you think this is a bug, please contact its maintainer (see the "
             "architecture's documentation) and include the full traceback error.log."
         )
+
+
+class OutOfMemoryError(Exception):
+    """
+    Exception raised for out of memory errors.
+
+    This exception should be raised when a GPU out of memory error occurs,
+    indicating that the model or batch size is too large for the available GPU memory.
+
+    :param exception: The original exception that was caught, which led to raising this
+        custom exception.
+    """
+
+    def __init__(self, exception):
+        super().__init__(
+            f"{exception}\n\n"
+            "The error above likely means that the model ran out of memory during "
+            "training. You can try to reduce the batch size or reduce the model size "
+            "(e.g., reduce the number of features or layers). If available check the "
+            "architecture's documentation for more suggestions."
+        )

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -16,6 +16,7 @@ from metatensor.torch import Labels, TensorBlock, TensorMap
 from metatomic.torch import NeighborListOptions, systems_to_torch
 from omegaconf import OmegaConf
 
+import metatrain.soap_bpnn
 from metatrain import RANDOM_SEED
 from metatrain.cli.train import _process_restart_from, train_model
 from metatrain.utils.data.readers.ase import read
@@ -798,6 +799,24 @@ def test_architecture_error(options, monkeypatch, tmp_path):
     )
 
     with pytest.raises(ArchitectureError, match="originates from an architecture"):
+        train_model(options)
+
+
+def test_oom_error(options, monkeypatch, tmp_path):
+    """Test an error raise if there is problem wth the architecture."""
+
+    def oom_error(*args, **kwargs):
+        raise torch.cuda.OutOfMemoryError()
+
+    monkeypatch.setattr(metatrain.soap_bpnn.Trainer, "train", oom_error)
+
+    monkeypatch.chdir(tmp_path)
+    shutil.copy(DATASET_PATH_QM9, "qm9_reduced_100.xyz")
+
+    match = (
+        "The error above likely means that the model ran out of memory during training."
+    )
+    with pytest.raises(ArchitectureError, match=match):
         train_model(options)
 
 

--- a/tests/utils/test_errors.py
+++ b/tests/utils/test_errors.py
@@ -1,6 +1,7 @@
 import pytest
+import torch
 
-from metatrain.utils.errors import ArchitectureError
+from metatrain.utils.errors import ArchitectureError, OutOfMemoryError
 
 
 def test_architecture_error():
@@ -10,3 +11,14 @@ def test_architecture_error():
             raise ValueError("An example error from the architecture")
         except Exception as e:
             raise ArchitectureError(e) from e
+
+
+def test_oom_error():
+    match = (
+        "The error above likely means that the model ran out of memory during training."
+    )
+    with pytest.raises(OutOfMemoryError, match=match):
+        try:
+            raise torch.cuda.OutOfMemoryError("An example out of memory error")
+        except torch.cuda.OutOfMemoryError as e:
+            raise OutOfMemoryError(e) from e


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Fixes #748

Implements a more helpful OOM error message for PET.

We could also catch all torch OOM errors for all models in our training cli script: 

https://github.com/metatensor/metatrain/blob/c07d491fa655862638c54e96e28b967f18eaa9f7/src/metatrain/cli/train.py#L553-L563

I think I like the second general approach but are open for other ideas.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Maintainer/Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--749.org.readthedocs.build/en/749/

<!-- readthedocs-preview metatrain end -->