### PR TITLE
fix docs for contributing

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -81,7 +81,6 @@ If you wish to test only specific functionalities, for example:
 
   tox -e lint          # code style
   tox -e tests         # unit tests of the main library
-  tox -e examples      # test the examples
 
 
 You can also use ``tox -e format`` to use tox to do actual formatting instead of just


### PR DESCRIPTION
tox -e examples doesn't exist...

Please go the the `Preview` tab and select the appropriate PR template:

- [Default template](?expand=1&template=pull_request_template.md)
- [Adding a new architecture](?expand=1&template=pull_request_new-architecture.md)


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--751.org.readthedocs.build/en/751/

<!-- readthedocs-preview metatrain end -->