### PR TITLE
Feed target names to readers to allow correct property names

### DIFF
--- a/docs/src/advanced-concepts/auxiliary-outputs.rst
+++ b/docs/src/advanced-concepts/auxiliary-outputs.rst
@@ -76,9 +76,9 @@ mtt::aux::{target}_last_layer_features
       equivariant.
 
   * - properties
-    - ``"properties"``
+    - ``"feature"``
     - the last-layer features have a single property dimension named
-      ``"properties"``, with entries ranging from 0 to the number of features
+      ``"feature"``, with entries ranging from 0 to the number of features
       in the last layer.
 
 features

--- a/src/metatrain/deprecated/pet/model.py
+++ b/src/metatrain/deprecated/pet/model.py
@@ -181,7 +181,7 @@ class PET(ModelInterface):
                 samples=samples,
                 components=[],
                 properties=Labels(
-                    names=["properties"],
+                    names=["feature"],
                     values=torch.arange(
                         ll_features.shape[1], device=predictions.device
                     ).reshape(-1, 1),

--- a/src/metatrain/deprecated/pet/tests/test_exported.py
+++ b/src/metatrain/deprecated/pet/tests/test_exported.py
@@ -33,7 +33,7 @@ def test_to(device):
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     model = WrappedPET(DEFAULT_HYPERS["model"], dataset_info)
     ARCHITECTURAL_HYPERS = Hypers(model.hypers)

--- a/src/metatrain/deprecated/pet/tests/test_functionality.py
+++ b/src/metatrain/deprecated/pet/tests/test_functionality.py
@@ -303,13 +303,13 @@ def test_output_features():
         4,
         768,  # 768 = 3 (gnn layers) * 256 (128 for edge repr, 128 for node repr)
     )
-    assert last_layer_features.properties.names == ["properties"]
+    assert last_layer_features.properties.names == ["feature"]
     assert features.samples.names == ["system", "atom"]
     assert features.values.shape == (
         4,
         768,  # 768 = 3 (gnn layers) * 256 (128 for edge repr, 128 for node repr)
     )
-    assert features.properties.names == ["properties"]
+    assert features.properties.names == ["feature"]
 
     # last-layer features per system:
     ll_output_options = ModelOutput(
@@ -336,11 +336,11 @@ def test_output_features():
         768,  # 768 = 3 (gnn layers) * 256 (128 for edge repr, 128 for node repr)
     )
     assert outputs["mtt::aux::energy_last_layer_features"].block().properties.names == [
-        "properties",
+        "feature",
     ]
     assert outputs["features"].block().samples.names == ["system"]
     assert outputs["features"].block().values.shape == (
         1,
         768,  # 768 = 3 (gnn layers) * 256 (128 for edge repr, 128 for node repr)
     )
-    assert outputs["features"].block().properties.names == ["properties"]
+    assert outputs["features"].block().properties.names == ["feature"]

--- a/src/metatrain/deprecated/pet/tests/test_functionality.py
+++ b/src/metatrain/deprecated/pet/tests/test_functionality.py
@@ -69,7 +69,7 @@ def test_prediction():
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     model = WrappedPET(DEFAULT_HYPERS["model"], dataset_info)
     ARCHITECTURAL_HYPERS = Hypers(model.hypers)
@@ -120,7 +120,7 @@ def test_per_atom_predictions_functionality():
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     model = WrappedPET(DEFAULT_HYPERS["model"], dataset_info)
     ARCHITECTURAL_HYPERS = Hypers(model.hypers)
@@ -172,7 +172,7 @@ def test_selected_atoms_functionality():
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     model = WrappedPET(DEFAULT_HYPERS["model"], dataset_info)
     ARCHITECTURAL_HYPERS = Hypers(model.hypers)
@@ -236,6 +236,7 @@ def test_vector_output(per_atom):
         atomic_types=[1, 6, 7, 8],
         targets={
             "forces": get_generic_target_info(
+                "forces",
                 {
                     "quantity": "forces",
                     "unit": "",
@@ -244,7 +245,7 @@ def test_vector_output(per_atom):
                     },
                     "num_subtargets": 100,
                     "per_atom": per_atom,
-                }
+                },
             )
         },
     )
@@ -258,7 +259,7 @@ def test_output_features():
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
 
     model = WrappedPET(DEFAULT_HYPERS["model"], dataset_info)

--- a/src/metatrain/deprecated/pet/tests/test_pet_compatibility.py
+++ b/src/metatrain/deprecated/pet/tests/test_pet_compatibility.py
@@ -98,7 +98,7 @@ def test_predictions_compatibility(cutoff):
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=structure.numbers,
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     capabilities = ModelCapabilities(
         length_unit="Angstrom",

--- a/src/metatrain/deprecated/pet/tests/test_torchscript.py
+++ b/src/metatrain/deprecated/pet/tests/test_torchscript.py
@@ -19,7 +19,7 @@ def test_torchscript():
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     model = WrappedPET(DEFAULT_HYPERS["model"], dataset_info)
     ARCHITECTURAL_HYPERS = Hypers(model.hypers)
@@ -34,7 +34,7 @@ def test_torchscript_save_load(tmpdir):
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     model = WrappedPET(DEFAULT_HYPERS["model"], dataset_info)
     ARCHITECTURAL_HYPERS = Hypers(model.hypers)
@@ -58,7 +58,7 @@ def test_torchscript_integers():
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     model = WrappedPET(new_hypers, dataset_info)
     ARCHITECTURAL_HYPERS = Hypers(model.hypers)

--- a/src/metatrain/experimental/nanopet/model.py
+++ b/src/metatrain/experimental/nanopet/model.py
@@ -379,7 +379,7 @@ class NanoPET(ModelInterface):
                         samples=sample_labels,
                         components=[],
                         properties=Labels(
-                            names=["properties"],
+                            names=["feature"],
                             values=torch.arange(
                                 node_features.shape[-1], device=node_features.device
                             ).reshape(-1, 1),
@@ -426,7 +426,7 @@ class NanoPET(ModelInterface):
                         samples=sample_labels,
                         components=[],
                         properties=Labels(
-                            names=["properties"],
+                            names=["feature"],
                             values=torch.arange(
                                 atomic_features_dict[base_name].shape[-1],
                                 device=atomic_features_dict[base_name].device,

--- a/src/metatrain/experimental/nanopet/tests/test_checkpoints.py
+++ b/src/metatrain/experimental/nanopet/tests/test_checkpoints.py
@@ -93,7 +93,7 @@ def test_get_checkpoint(context):
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     model = NanoPET(MODEL_HYPERS, dataset_info)
     checkpoint = model.get_checkpoint()

--- a/src/metatrain/experimental/nanopet/tests/test_continue.py
+++ b/src/metatrain/experimental/nanopet/tests/test_continue.py
@@ -27,7 +27,7 @@ def test_continue(monkeypatch, tmp_path):
 
     target_info_dict = {}
     target_info_dict["mtt::U0"] = get_energy_target_info(
-        {"quantity": "energy", "unit": "eV"}
+        "mtt::U0", {"quantity": "energy", "unit": "eV"}
     )
 
     dataset_info = DatasetInfo(

--- a/src/metatrain/experimental/nanopet/tests/test_exported.py
+++ b/src/metatrain/experimental/nanopet/tests/test_exported.py
@@ -24,7 +24,9 @@ def test_to(device, dtype):
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
     model = NanoPET(MODEL_HYPERS, dataset_info).to(dtype=dtype)

--- a/src/metatrain/experimental/nanopet/tests/test_functionality.py
+++ b/src/metatrain/experimental/nanopet/tests/test_functionality.py
@@ -233,7 +233,7 @@ def test_output_last_layer_features():
         128,
     )
     assert features.properties.names == [
-        "properties",
+        "feature",
     ]
 
     last_layer_features = outputs["mtt::aux::energy_last_layer_features"].block()
@@ -246,7 +246,7 @@ def test_output_last_layer_features():
         128,
     )
     assert last_layer_features.properties.names == [
-        "properties",
+        "feature",
     ]
 
     # last-layer features per system:
@@ -284,7 +284,7 @@ def test_output_last_layer_features():
         128,
     )
     assert outputs["mtt::aux::energy_last_layer_features"].block().properties.names == [
-        "properties",
+        "feature",
     ]
 
 

--- a/src/metatrain/experimental/nanopet/tests/test_functionality.py
+++ b/src/metatrain/experimental/nanopet/tests/test_functionality.py
@@ -25,7 +25,9 @@ def test_nanopet_padding():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
 
@@ -76,7 +78,9 @@ def test_prediction_subset_elements():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
 
@@ -107,7 +111,9 @@ def test_prediction_subset_atoms():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
 
@@ -181,7 +187,9 @@ def test_output_last_layer_features():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
 
@@ -286,7 +294,9 @@ def test_output_per_atom():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
 
@@ -350,13 +360,14 @@ def test_vector_output(per_atom):
         atomic_types=[1, 6, 7, 8],
         targets={
             "forces": get_generic_target_info(
+                "forces",
                 {
                     "quantity": "forces",
                     "unit": "",
                     "type": {"cartesian": {"rank": 1}},
                     "num_subtargets": 100,
                     "per_atom": per_atom,
-                }
+                },
             )
         },
     )
@@ -385,6 +396,7 @@ def test_spherical_output(per_atom):
         atomic_types=[1, 6, 7, 8],
         targets={
             "spherical_tensor": get_generic_target_info(
+                "spherical_tensor",
                 {
                     "quantity": "spherical_tensor",
                     "unit": "",
@@ -393,7 +405,7 @@ def test_spherical_output(per_atom):
                     },
                     "num_subtargets": 100,
                     "per_atom": per_atom,
-                }
+                },
             )
         },
     )
@@ -423,6 +435,7 @@ def test_spherical_output_multi_block(per_atom):
         atomic_types=[1, 6, 7, 8],
         targets={
             "spherical_tensor": get_generic_target_info(
+                "spherical_tensor",
                 {
                     "quantity": "spherical_tensor",
                     "unit": "",
@@ -437,7 +450,7 @@ def test_spherical_output_multi_block(per_atom):
                     },
                     "num_subtargets": 100,
                     "per_atom": per_atom,
-                }
+                },
             )
         },
     )
@@ -466,7 +479,9 @@ def test_nanopet_single_atom():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
     model = NanoPET(MODEL_HYPERS, dataset_info)
@@ -493,13 +508,14 @@ def test_nanopet_rank_2(per_atom):
         atomic_types=[1, 6, 7, 8],
         targets={
             "stress": get_generic_target_info(
+                "stress",
                 {
                     "quantity": "stress",
                     "unit": "",
                     "type": {"cartesian": {"rank": 2}},
                     "num_subtargets": 100,
                     "per_atom": per_atom,
-                }
+                },
             )
         },
     )

--- a/src/metatrain/experimental/nanopet/tests/test_regression.py
+++ b/src/metatrain/experimental/nanopet/tests/test_regression.py
@@ -22,7 +22,9 @@ def test_regression_init():
     torch.manual_seed(0)
 
     targets = {}
-    targets["mtt::U0"] = get_energy_target_info({"quantity": "energy", "unit": "eV"})
+    targets["mtt::U0"] = get_energy_target_info(
+        "mtt::U0", {"quantity": "energy", "unit": "eV"}
+    )
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=targets

--- a/src/metatrain/experimental/nanopet/tests/test_torchscript.py
+++ b/src/metatrain/experimental/nanopet/tests/test_torchscript.py
@@ -18,7 +18,9 @@ def test_torchscript():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
     model = NanoPET(MODEL_HYPERS, dataset_info)
@@ -47,7 +49,9 @@ def test_torchscript_save_load(tmpdir):
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
     model = NanoPET(MODEL_HYPERS, dataset_info)
@@ -69,7 +73,9 @@ def test_torchscript_integers():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
     model = NanoPET(new_hypers, dataset_info)

--- a/src/metatrain/gap/tests/test_errors.py
+++ b/src/metatrain/gap/tests/test_errors.py
@@ -63,7 +63,7 @@ def test_more_sparse_points_than_envs():
 
     target_info_dict = {
         "energy": get_energy_target_info(
-            {"unit": "kcal/mol"}, add_position_gradients=True
+            "energy", {"unit": "kcal/mol"}, add_position_gradients=True
         )
     }
 
@@ -99,6 +99,7 @@ def test_vector_output(per_atom):
         atomic_types=[1, 6, 7, 8],
         targets={
             "forces": get_generic_target_info(
+                "forces",
                 {
                     "quantity": "forces",
                     "unit": "",
@@ -107,7 +108,7 @@ def test_vector_output(per_atom):
                     },
                     "num_subtargets": 100,
                     "per_atom": per_atom,
-                }
+                },
             )
         },
     )

--- a/src/metatrain/gap/tests/test_exported.py
+++ b/src/metatrain/gap/tests/test_exported.py
@@ -34,7 +34,7 @@ def test_export():
     dataset = Dataset.from_dict({"system": systems, "energy": targets["energy"]})
 
     target_info_dict = {}
-    target_info_dict["energy"] = get_energy_target_info({"unit": "eV"})
+    target_info_dict["energy"] = get_energy_target_info("energy", {"unit": "eV"})
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=target_info_dict
@@ -44,7 +44,9 @@ def test_export():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
     model = GAP(DEFAULT_HYPERS["model"], dataset_info)

--- a/src/metatrain/gap/tests/test_regression.py
+++ b/src/metatrain/gap/tests/test_regression.py
@@ -45,7 +45,7 @@ def test_regression_train():
     dataset = Dataset.from_dict({"system": systems, "mtt::U0": targets["mtt::U0"]})
 
     target_info_dict = {}
-    target_info_dict["mtt::U0"] = get_energy_target_info({"unit": "eV"})
+    target_info_dict["mtt::U0"] = get_energy_target_info("mtt::U0", {"unit": "eV"})
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=target_info_dict
@@ -104,7 +104,9 @@ def test_invariance():
     hypers["model"]["krr"]["num_sparse_points"] = 900
 
     target_info_dict = {
-        "energy": get_energy_target_info({"unit": "eV"}, add_position_gradients=True)
+        "energy": get_energy_target_info(
+            "energy", {"unit": "eV"}, add_position_gradients=True
+        )
     }
 
     dataset_info = DatasetInfo(

--- a/src/metatrain/gap/tests/test_torchscript.py
+++ b/src/metatrain/gap/tests/test_torchscript.py
@@ -17,7 +17,7 @@ torch.set_default_dtype(torch.float64)  # GAP only supports float64
 def test_torchscript():
     """Tests that the model can be jitted."""
     target_info_dict = {}
-    target_info_dict["mtt::U0"] = get_energy_target_info({"unit": "eV"})
+    target_info_dict["mtt::U0"] = get_energy_target_info("mtt::U0", {"unit": "eV"})
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=target_info_dict
@@ -69,7 +69,7 @@ def test_torchscript():
 def test_torchscript_save_load(tmpdir):
     """Tests that the model can be jitted and saved."""
     targets = {}
-    targets["mtt::U0"] = get_energy_target_info({"unit": "eV"})
+    targets["mtt::U0"] = get_energy_target_info("mtt::U0", {"unit": "eV"})
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=targets
@@ -94,7 +94,7 @@ def test_torchscript_integers():
     new_hypers["soap"]["density"]["scaling"]["exponent"] = 7
 
     target_info_dict = {}
-    target_info_dict["mtt::U0"] = get_energy_target_info({"unit": "eV"})
+    target_info_dict["mtt::U0"] = get_energy_target_info("mtt::U0", {"unit": "eV"})
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=target_info_dict

--- a/src/metatrain/pet/model.py
+++ b/src/metatrain/pet/model.py
@@ -364,7 +364,7 @@ class PET(ModelInterface):
                         samples=sample_labels,
                         components=[],
                         properties=Labels(
-                            names=["properties"],
+                            names=["feature"],
                             values=torch.arange(
                                 features.shape[-1], device=features.device
                             ).reshape(-1, 1),
@@ -455,7 +455,7 @@ class PET(ModelInterface):
                         samples=sample_labels,
                         components=[],
                         properties=Labels(
-                            names=["properties"],
+                            names=["feature"],
                             values=torch.arange(
                                 last_layer_features_values.shape[-1],
                                 device=last_layer_features_values.device,

--- a/src/metatrain/pet/tests/test_autograd.py
+++ b/src/metatrain/pet/tests/test_autograd.py
@@ -25,7 +25,9 @@ def test_autograd_positions(device):
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
 
@@ -74,7 +76,9 @@ def test_autograd_cell(device):
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
 

--- a/src/metatrain/pet/tests/test_checkpoints.py
+++ b/src/metatrain/pet/tests/test_checkpoints.py
@@ -110,7 +110,7 @@ def test_get_checkpoint(context, caplog):
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     model = PET(MODEL_HYPERS, dataset_info)
     checkpoint = model.get_checkpoint()

--- a/src/metatrain/pet/tests/test_continue.py
+++ b/src/metatrain/pet/tests/test_continue.py
@@ -26,7 +26,7 @@ def test_continue(monkeypatch, tmp_path):
 
     target_info_dict = {}
     target_info_dict["mtt::U0"] = get_energy_target_info(
-        {"quantity": "energy", "unit": "eV"}
+        "mtt::U0", {"quantity": "energy", "unit": "eV"}
     )
 
     dataset_info = DatasetInfo(

--- a/src/metatrain/pet/tests/test_exported.py
+++ b/src/metatrain/pet/tests/test_exported.py
@@ -24,7 +24,9 @@ def test_to(device, dtype):
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
     model = PET(MODEL_HYPERS, dataset_info).to(dtype=dtype)

--- a/src/metatrain/pet/tests/test_finetuning.py
+++ b/src/metatrain/pet/tests/test_finetuning.py
@@ -20,7 +20,7 @@ from . import DATASET_PATH, DEFAULT_HYPERS, MODEL_HYPERS
 def test_lora_finetuning_functionality():
     target_info_dict = {}
     target_info_dict["energy"] = get_energy_target_info(
-        {"quantity": "energy", "unit": "eV"}
+        "energy", {"quantity": "energy", "unit": "eV"}
     )
     dataset_info = DatasetInfo(
         length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=target_info_dict
@@ -50,7 +50,7 @@ def test_lora_finetuning_device(device):
 
     target_info_dict = {}
     target_info_dict["energy"] = get_energy_target_info(
-        {"quantity": "energy", "unit": "eV"}
+        "energy", {"quantity": "energy", "unit": "eV"}
     )
     dataset_info = DatasetInfo(
         length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=target_info_dict
@@ -75,7 +75,7 @@ def test_lora_finetuning_device(device):
 def test_heads_finetuning_functionality():
     target_info_dict = {}
     target_info_dict["energy"] = get_energy_target_info(
-        {"quantity": "energy", "unit": "eV"}
+        "energy", {"quantity": "energy", "unit": "eV"}
     )
     dataset_info = DatasetInfo(
         length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=target_info_dict
@@ -110,7 +110,7 @@ def test_finetuning_restart(monkeypatch, tmp_path):
 
     target_info_dict = {}
     target_info_dict["mtt::U0"] = get_energy_target_info(
-        {"quantity": "energy", "unit": "eV"}
+        "mtt::U0", {"quantity": "energy", "unit": "eV"}
     )
 
     dataset_info = DatasetInfo(

--- a/src/metatrain/pet/tests/test_functionality.py
+++ b/src/metatrain/pet/tests/test_functionality.py
@@ -24,7 +24,9 @@ def test_prediction():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
 
@@ -49,7 +51,9 @@ def test_pet_padding():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
 
@@ -100,7 +104,9 @@ def test_prediction_subset_elements():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
 
@@ -131,7 +137,9 @@ def test_prediction_subset_atoms():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
 
@@ -205,7 +213,9 @@ def test_output_last_layer_features():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
 
@@ -310,7 +320,9 @@ def test_output_per_atom():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
 
@@ -370,13 +382,14 @@ def test_vector_output(per_atom):
         atomic_types=[1, 6, 7, 8],
         targets={
             "forces": get_generic_target_info(
+                "forces",
                 {
                     "quantity": "forces",
                     "unit": "",
                     "type": {"cartesian": {"rank": 1}},
                     "num_subtargets": 100,
                     "per_atom": per_atom,
-                }
+                },
             )
         },
     )
@@ -405,6 +418,7 @@ def test_spherical_output(per_atom):
         atomic_types=[1, 6, 7, 8],
         targets={
             "spherical_tensor": get_generic_target_info(
+                "spherical_tensor",
                 {
                     "quantity": "spherical_tensor",
                     "unit": "",
@@ -413,7 +427,7 @@ def test_spherical_output(per_atom):
                     },
                     "num_subtargets": 100,
                     "per_atom": per_atom,
-                }
+                },
             )
         },
     )
@@ -443,6 +457,7 @@ def test_spherical_output_multi_block(per_atom):
         atomic_types=[1, 6, 7, 8],
         targets={
             "spherical_tensor": get_generic_target_info(
+                "spherical_tensor",
                 {
                     "quantity": "spherical_tensor",
                     "unit": "",
@@ -457,7 +472,7 @@ def test_spherical_output_multi_block(per_atom):
                     },
                     "num_subtargets": 100,
                     "per_atom": per_atom,
-                }
+                },
             )
         },
     )
@@ -506,7 +521,9 @@ def test_pet_single_atom():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
     model = PET(MODEL_HYPERS, dataset_info)
@@ -532,13 +549,14 @@ def test_pet_rank_2(per_atom):
         atomic_types=[1, 6, 7, 8],
         targets={
             "stress": get_generic_target_info(
+                "stress",
                 {
                     "quantity": "stress",
                     "unit": "",
                     "type": {"cartesian": {"rank": 2}},
                     "num_subtargets": 100,
                     "per_atom": per_atom,
-                }
+                },
             )
         },
     )

--- a/src/metatrain/pet/tests/test_functionality.py
+++ b/src/metatrain/pet/tests/test_functionality.py
@@ -259,7 +259,7 @@ def test_output_last_layer_features():
         MODEL_HYPERS["d_pet"] * MODEL_HYPERS["num_gnn_layers"] * 2,
     )
     assert features.properties.names == [
-        "properties",
+        "feature",
     ]
 
     last_layer_features = outputs["mtt::aux::energy_last_layer_features"].block()
@@ -272,7 +272,7 @@ def test_output_last_layer_features():
         MODEL_HYPERS["d_head"] * MODEL_HYPERS["num_gnn_layers"] * 2,
     )
     assert last_layer_features.properties.names == [
-        "properties",
+        "feature",
     ]
 
     # last-layer features per system:
@@ -310,7 +310,7 @@ def test_output_last_layer_features():
         MODEL_HYPERS["d_head"] * MODEL_HYPERS["num_gnn_layers"] * 2,
     )
     assert outputs["mtt::aux::energy_last_layer_features"].block().properties.names == [
-        "properties",
+        "feature",
     ]
 
 

--- a/src/metatrain/pet/tests/test_long_range.py
+++ b/src/metatrain/pet/tests/test_long_range.py
@@ -31,7 +31,9 @@ def test_long_range_features(use_ewald):
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
     hypers = copy.deepcopy(MODEL_HYPERS)

--- a/src/metatrain/pet/tests/test_pet_compatibility.py
+++ b/src/metatrain/pet/tests/test_pet_compatibility.py
@@ -252,7 +252,9 @@ def get_identical_pet_models():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
     nativepet_model = NativePET(DEFAULT_NATIVEPET_HYPERS["model"], dataset_info)

--- a/src/metatrain/pet/tests/test_regression.py
+++ b/src/metatrain/pet/tests/test_regression.py
@@ -27,7 +27,9 @@ def test_regression_init():
     torch.manual_seed(0)
 
     targets = {}
-    targets["mtt::U0"] = get_energy_target_info({"quantity": "energy", "unit": "eV"})
+    targets["mtt::U0"] = get_energy_target_info(
+        "mtt::U0", {"quantity": "energy", "unit": "eV"}
+    )
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=targets

--- a/src/metatrain/pet/tests/test_torchscript.py
+++ b/src/metatrain/pet/tests/test_torchscript.py
@@ -18,7 +18,9 @@ def test_torchscript():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
     model = PET(MODEL_HYPERS, dataset_info)
@@ -46,7 +48,9 @@ def test_torchscript_save_load(tmpdir):
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
     model = PET(MODEL_HYPERS, dataset_info)
@@ -68,7 +72,9 @@ def test_torchscript_integers():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
     model = PET(new_hypers, dataset_info)

--- a/src/metatrain/soap_bpnn/model.py
+++ b/src/metatrain/soap_bpnn/model.py
@@ -74,7 +74,7 @@ class MLPMap(ModuleMap):
         )
         out_properties = [
             Labels(
-                names=["properties"],
+                names=["feature"],
                 values=torch.arange(
                     hypers["num_neurons_per_layer"],
                 ).reshape(-1, 1),
@@ -98,7 +98,7 @@ class LayerNormMap(ModuleMap):
         )
         out_properties = [
             Labels(
-                names=["properties"],
+                names=["feature"],
                 values=torch.arange(n_layer).reshape(-1, 1),
             )
             for _ in range(len(in_keys))
@@ -898,7 +898,7 @@ def _remove_center_type_from_properties(tensor_map: TensorMap) -> TensorMap:
                 samples=block.samples,
                 components=block.components,
                 properties=Labels(
-                    names=["properties"],
+                    names=["feature"],
                     values=torch.arange(
                         block.values.shape[-1], device=block.values.device
                     ).reshape(-1, 1),

--- a/src/metatrain/soap_bpnn/tests/test_checkpoints.py
+++ b/src/metatrain/soap_bpnn/tests/test_checkpoints.py
@@ -98,7 +98,7 @@ def test_get_checkpoint(context, caplog):
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
     checkpoint = model.get_checkpoint()

--- a/src/metatrain/soap_bpnn/tests/test_continue.py
+++ b/src/metatrain/soap_bpnn/tests/test_continue.py
@@ -29,7 +29,7 @@ def test_continue(monkeypatch, tmp_path):
     systems = [system.to(torch.float32) for system in systems]
 
     target_info_dict = {}
-    target_info_dict["mtt::U0"] = get_energy_target_info({"unit": "eV"})
+    target_info_dict["mtt::U0"] = get_energy_target_info("mtt::U0", {"unit": "eV"})
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=target_info_dict

--- a/src/metatrain/soap_bpnn/tests/test_equivariance.py
+++ b/src/metatrain/soap_bpnn/tests/test_equivariance.py
@@ -31,7 +31,7 @@ def test_rotational_invariance():
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
 
@@ -74,6 +74,7 @@ def test_equivariance_rotations(o3_lambda, o3_sigma):
         atomic_types=[1, 6, 7, 8],
         targets={
             "spherical_target": get_generic_target_info(
+                "spherical_target",
                 {
                     "quantity": "",
                     "unit": "",
@@ -84,7 +85,7 @@ def test_equivariance_rotations(o3_lambda, o3_sigma):
                     },
                     "num_subtargets": 100,
                     "per_atom": False,
-                }
+                },
             )
         },
     )
@@ -133,6 +134,7 @@ def test_equivariance_inversion(o3_lambda, o3_sigma):
         atomic_types=[1, 6, 7, 8],
         targets={
             "spherical_target": get_generic_target_info(
+                "spherical_target",
                 {
                     "quantity": "",
                     "unit": "",
@@ -143,7 +145,7 @@ def test_equivariance_inversion(o3_lambda, o3_sigma):
                     },
                     "num_subtargets": 100,
                     "per_atom": False,
-                }
+                },
             )
         },
     )

--- a/src/metatrain/soap_bpnn/tests/test_exported.py
+++ b/src/metatrain/soap_bpnn/tests/test_exported.py
@@ -23,7 +23,7 @@ def test_to(device, dtype):
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     model = SoapBpnn(MODEL_HYPERS, dataset_info).to(dtype=dtype)
     exported = model.export(metadata=ModelMetadata(name="test"))

--- a/src/metatrain/soap_bpnn/tests/test_functionality.py
+++ b/src/metatrain/soap_bpnn/tests/test_functionality.py
@@ -29,7 +29,7 @@ def test_prediction_subset_elements():
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
 
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
@@ -55,7 +55,7 @@ def test_prediction_subset_atoms():
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
 
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
@@ -126,7 +126,7 @@ def test_output_last_layer_features():
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
 
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
@@ -233,7 +233,7 @@ def test_output_per_atom():
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
 
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
@@ -295,6 +295,7 @@ def test_vector_output(per_atom):
         atomic_types=[1, 6, 7, 8],
         targets={
             "forces": get_generic_target_info(
+                "forces",
                 {
                     "quantity": "forces",
                     "unit": "",
@@ -303,7 +304,7 @@ def test_vector_output(per_atom):
                     },
                     "num_subtargets": 100,
                     "per_atom": per_atom,
-                }
+                },
             )
         },
     )
@@ -333,6 +334,7 @@ def test_spherical_outputs(per_atom):
         atomic_types=[1, 6, 7, 8],
         targets={
             "spherical_target": get_generic_target_info(
+                "spherical_target",
                 {
                     "quantity": "",
                     "unit": "",
@@ -346,7 +348,7 @@ def test_spherical_outputs(per_atom):
                     },
                     "num_subtargets": 100,
                     "per_atom": per_atom,
-                }
+                },
             )
         },
     )
@@ -376,7 +378,9 @@ def test_soap_bpnn_single_atom():
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
         targets={
-            "energy": get_energy_target_info({"quantity": "energy", "unit": "eV"})
+            "energy": get_energy_target_info(
+                "energy", {"quantity": "energy", "unit": "eV"}
+            )
         },
     )
     hypers = copy.deepcopy(MODEL_HYPERS)

--- a/src/metatrain/soap_bpnn/tests/test_functionality.py
+++ b/src/metatrain/soap_bpnn/tests/test_functionality.py
@@ -170,7 +170,7 @@ def test_output_last_layer_features():
         128,
     )
     assert features.properties.names == [
-        "properties",
+        "feature",
     ]
 
     last_layer_features = outputs["mtt::aux::energy_last_layer_features"].block()
@@ -183,7 +183,7 @@ def test_output_last_layer_features():
         128,
     )
     assert last_layer_features.properties.names == [
-        "properties",
+        "feature",
     ]
 
     # last-layer features per system:
@@ -213,7 +213,7 @@ def test_output_last_layer_features():
         128,
     )
     assert features.properties.names == [
-        "properties",
+        "feature",
     ]
 
     assert outputs["mtt::aux::energy_last_layer_features"].block().samples.names == [
@@ -224,7 +224,7 @@ def test_output_last_layer_features():
         128,
     )
     assert outputs["mtt::aux::energy_last_layer_features"].block().properties.names == [
-        "properties",
+        "feature",
     ]
 
 

--- a/src/metatrain/soap_bpnn/tests/test_regression.py
+++ b/src/metatrain/soap_bpnn/tests/test_regression.py
@@ -27,7 +27,7 @@ def test_regression_init():
     torch.manual_seed(0)
 
     targets = {}
-    targets["mtt::U0"] = get_energy_target_info({"unit": "eV"})
+    targets["mtt::U0"] = get_energy_target_info("mtt::U0", {"unit": "eV"})
 
     dataset_info = DatasetInfo(
         length_unit="Angstrom", atomic_types=[1, 6, 7, 8], targets=targets

--- a/src/metatrain/soap_bpnn/tests/test_torchscript.py
+++ b/src/metatrain/soap_bpnn/tests/test_torchscript.py
@@ -24,7 +24,7 @@ def test_torchscript():
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
     requested_neighbor_lists = get_requested_neighbor_lists(model)
@@ -51,7 +51,7 @@ def test_torchscript_with_identity():
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     hypers = copy.deepcopy(MODEL_HYPERS)
     hypers["bpnn"]["layernorm"] = False
@@ -84,6 +84,7 @@ def test_torchscript_spherical(o3_lambda, o3_sigma):
         atomic_types=[1, 6, 7, 8],
         targets={
             "spherical_target": get_generic_target_info(
+                "spherical_target",
                 {
                     "quantity": "",
                     "unit": "",
@@ -94,7 +95,7 @@ def test_torchscript_spherical(o3_lambda, o3_sigma):
                     },
                     "num_subtargets": 100,
                     "per_atom": False,
-                }
+                },
             )
         },
     )
@@ -123,7 +124,7 @@ def test_torchscript_save_load(tmpdir):
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     model = SoapBpnn(MODEL_HYPERS, dataset_info)
 
@@ -143,7 +144,7 @@ def test_torchscript_integers():
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 7, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     model = SoapBpnn(new_hypers, dataset_info)
     requested_neighbor_lists = get_requested_neighbor_lists(model)

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -560,12 +560,12 @@ class DiskDataset(torch.utils.data.Dataset):
                 add_position_gradients = tensor_map.block().has_gradient("positions")
                 add_strain_gradients = tensor_map.block().has_gradient("strain")
                 target_info = get_energy_target_info(
-                    target, add_position_gradients, add_strain_gradients
+                    target_key, target, add_position_gradients, add_strain_gradients
                 )
                 _check_tensor_map_metadata(tensor_map, target_info.layout)
                 target_info_dict[target_key] = target_info
             else:
-                target_info = get_generic_target_info(target)
+                target_info = get_generic_target_info(target_key, target)
                 _check_tensor_map_metadata(tensor_map, target_info.layout)
                 # make sure that the properties of the target_info.layout also match the
                 # actual properties of the tensor maps

--- a/src/metatrain/utils/data/readers/ase.py
+++ b/src/metatrain/utils/data/readers/ase.py
@@ -214,7 +214,9 @@ def _read_virial_stress_ase(
     return blocks
 
 
-def read_energy(target: DictConfig) -> Tuple[List[TensorMap], TargetInfo]:
+def read_energy(
+    target_name: str, target: DictConfig
+) -> Tuple[List[TensorMap], TargetInfo]:
     target_key = target["key"]
 
     blocks = _read_energy_ase(
@@ -289,12 +291,14 @@ def read_energy(target: DictConfig) -> Tuple[List[TensorMap], TargetInfo]:
         for block in blocks
     ]
     target_info = get_energy_target_info(
-        target, add_position_gradients, add_strain_gradients
+        target_name, target, add_position_gradients, add_strain_gradients
     )
     return tensor_map_list, target_info
 
 
-def read_generic(target: DictConfig) -> Tuple[List[TensorMap], TargetInfo]:
+def read_generic(
+    target_name: str, target: DictConfig
+) -> Tuple[List[TensorMap], TargetInfo]:
     filename = target["read_from"]
     frames = read(filename, ":")
 
@@ -312,7 +316,7 @@ def read_generic(target: DictConfig) -> Tuple[List[TensorMap], TargetInfo]:
                 "representation. Please use the metatensor reader."
             )
 
-    target_info = get_generic_target_info(target)
+    target_info = get_generic_target_info(target_name, target)
     components = target_info.layout.block().components
     properties = target_info.layout.block().properties
     shape_after_samples = target_info.layout.block().shape[1:]

--- a/src/metatrain/utils/data/readers/readers.py
+++ b/src/metatrain/utils/data/readers/readers.py
@@ -176,7 +176,7 @@ def _read_conf_section(
             ) from e
 
         # execute reader and collect outputs
-        tensormaps, info = reader_fn(entry)
+        tensormaps, info = reader_fn(key, entry)
 
         # enforce double precision (dtype == 7)
         if not all(t.dtype == 7 for t in tensormaps):
@@ -193,6 +193,8 @@ _standard_outputs_list = {
     "energy",
     "non_conservative_forces",
     "non_conservative_stress",
+    "positions",
+    "momenta",
 }
 
 

--- a/src/metatrain/utils/data/target_info.py
+++ b/src/metatrain/utils/data/target_info.py
@@ -364,7 +364,7 @@ def _get_scalar_target_info(target_name: str, target: DictConfig) -> TargetInfo:
             values=torch.empty((0, len(sample_names)), dtype=torch.int32),
         ),
         components=[],
-        properties=Labels.range("properties", target["num_subtargets"]),
+        properties=Labels.range(target_name, target["num_subtargets"]),
     )
     layout = TensorMap(
         keys=Labels.single(),
@@ -409,7 +409,7 @@ def _get_cartesian_target_info(target_name: str, target: DictConfig) -> TargetIn
             values=torch.empty((0, len(sample_names)), dtype=torch.int32),
         ),
         components=components,
-        properties=Labels.range("properties", target["num_subtargets"]),
+        properties=Labels.range(target_name, target["num_subtargets"]),
     )
     layout = TensorMap(
         keys=Labels.single(),
@@ -454,7 +454,7 @@ def _get_spherical_target_info(target_name: str, target: DictConfig) -> TargetIn
                 values=torch.empty((0, len(sample_names)), dtype=torch.int32),
             ),
             components=components,
-            properties=Labels.range("properties", target["num_subtargets"]),
+            properties=Labels.range(target_name, target["num_subtargets"]),
         )
         keys.append([irrep["o3_lambda"], irrep["o3_sigma"]])
         blocks.append(block)

--- a/src/metatrain/utils/data/target_info.py
+++ b/src/metatrain/utils/data/target_info.py
@@ -268,6 +268,7 @@ class TargetInfo:
 
 
 def get_energy_target_info(
+    target_name: str,
     target: DictConfig,
     add_position_gradients: bool = False,
     add_strain_gradients: bool = False,
@@ -336,13 +337,13 @@ def get_energy_target_info(
     return target_info
 
 
-def get_generic_target_info(target: DictConfig) -> TargetInfo:
+def get_generic_target_info(target_name: str, target: DictConfig) -> TargetInfo:
     if target["type"] == "scalar":
-        return _get_scalar_target_info(target)
+        return _get_scalar_target_info(target_name, target)
     elif len(target["type"]) == 1 and next(iter(target["type"])).lower() == "cartesian":
-        return _get_cartesian_target_info(target)
+        return _get_cartesian_target_info(target_name, target)
     elif len(target["type"]) == 1 and next(iter(target["type"])) == "spherical":
-        return _get_spherical_target_info(target)
+        return _get_spherical_target_info(target_name, target)
     else:
         raise ValueError(
             f"Target type {target['type']} is not supported. "
@@ -350,7 +351,7 @@ def get_generic_target_info(target: DictConfig) -> TargetInfo:
         )
 
 
-def _get_scalar_target_info(target: DictConfig) -> TargetInfo:
+def _get_scalar_target_info(target_name: str, target: DictConfig) -> TargetInfo:
     sample_names = ["system"]
     if target["per_atom"]:
         sample_names.append("atom")
@@ -378,7 +379,7 @@ def _get_scalar_target_info(target: DictConfig) -> TargetInfo:
     return target_info
 
 
-def _get_cartesian_target_info(target: DictConfig) -> TargetInfo:
+def _get_cartesian_target_info(target_name: str, target: DictConfig) -> TargetInfo:
     sample_names = ["system"]
     if target["per_atom"]:
         sample_names.append("atom")
@@ -423,7 +424,7 @@ def _get_cartesian_target_info(target: DictConfig) -> TargetInfo:
     return target_info
 
 
-def _get_spherical_target_info(target: DictConfig) -> TargetInfo:
+def _get_spherical_target_info(target_name: str, target: DictConfig) -> TargetInfo:
     sample_names = ["system"]
     if target["per_atom"]:
         sample_names.append("atom")

--- a/src/metatrain/utils/data/target_info.py
+++ b/src/metatrain/utils/data/target_info.py
@@ -364,7 +364,9 @@ def _get_scalar_target_info(target_name: str, target: DictConfig) -> TargetInfo:
             values=torch.empty((0, len(sample_names)), dtype=torch.int32),
         ),
         components=[],
-        properties=Labels.range(target_name, target["num_subtargets"]),
+        properties=Labels.range(
+            target_name.replace("mtt::", ""), target["num_subtargets"]
+        ),
     )
     layout = TensorMap(
         keys=Labels.single(),
@@ -409,7 +411,9 @@ def _get_cartesian_target_info(target_name: str, target: DictConfig) -> TargetIn
             values=torch.empty((0, len(sample_names)), dtype=torch.int32),
         ),
         components=components,
-        properties=Labels.range(target_name, target["num_subtargets"]),
+        properties=Labels.range(
+            target_name.replace("mtt::", ""), target["num_subtargets"]
+        ),
     )
     layout = TensorMap(
         keys=Labels.single(),
@@ -454,7 +458,9 @@ def _get_spherical_target_info(target_name: str, target: DictConfig) -> TargetIn
                 values=torch.empty((0, len(sample_names)), dtype=torch.int32),
             ),
             components=components,
-            properties=Labels.range(target_name, target["num_subtargets"]),
+            properties=Labels.range(
+                target_name.replace("mtt::", ""), target["num_subtargets"]
+            ),
         )
         keys.append([irrep["o3_lambda"], irrep["o3_sigma"]])
         blocks.append(block)

--- a/tests/cli/test_eval_model.py
+++ b/tests/cli/test_eval_model.py
@@ -122,7 +122,7 @@ def test_eval_export(monkeypatch, tmp_path, options):
     dataset_info = DatasetInfo(
         length_unit="angstrom",
         atomic_types={1, 6, 7, 8},
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
     model = __model__(hypers=MODEL_HYPERS, dataset_info=dataset_info)
 

--- a/tests/utils/data/test_readers.py
+++ b/tests/utils/data/test_readers.py
@@ -394,7 +394,7 @@ def test_read_extra_data(monkeypatch, tmp_path):
             result_block = tensormap.block()
             assert result_block.values.dtype is torch.float64
             assert result_block.samples.names == ["system"]
-            assert result_block.properties == Labels("properties", torch.tensor([[0]]))
+            assert result_block.properties == Labels("energy", torch.tensor([[0]]))
 
         extra_data_info = info_dict[name]
         assert type(extra_data_info) is TargetInfo

--- a/tests/utils/data/test_readers_metatensor.py
+++ b/tests/utils/data/test_readers_metatensor.py
@@ -42,7 +42,7 @@ def scalar_tensor_map():
                     values=torch.tensor([[0, 0], [0, 1], [1, 0]], dtype=torch.int32),
                 ),
                 components=[],
-                properties=Labels.range("properties", 10),
+                properties=Labels.range("scalar", 10),
             )
         ],
     )
@@ -68,7 +68,7 @@ def spherical_tensor_map():
                         values=torch.arange(0, 1, dtype=torch.int32).reshape(-1, 1),
                     ),
                 ],
-                properties=Labels.range("properties", 1),
+                properties=Labels.range("spherical", 1),
             ),
             TensorBlock(
                 values=torch.rand(2, 5, 1, dtype=torch.float64),
@@ -82,7 +82,7 @@ def spherical_tensor_map():
                         values=torch.arange(-2, 3, dtype=torch.int32).reshape(-1, 1),
                     ),
                 ],
-                properties=Labels.range("properties", 1),
+                properties=Labels.range("spherical", 1),
             ),
         ],
     )
@@ -109,7 +109,7 @@ def cartesian_tensor_map():
                         values=torch.arange(0, 3, dtype=torch.int32).reshape(-1, 1),
                     ),
                 ],
-                properties=Labels.range("properties", 1),
+                properties=Labels.range("cartesian", 1),
             ),
         ],
     )

--- a/tests/utils/data/test_readers_metatensor.py
+++ b/tests/utils/data/test_readers_metatensor.py
@@ -137,7 +137,7 @@ def test_read_energy(tmpdir, energy_tensor_map):
 
     with tmpdir.as_cwd():
         mts.save("energy.mts", energy_tensor_map)
-        tensor_maps, _ = read_energy(OmegaConf.create(conf))
+        tensor_maps, _ = read_energy("energy", OmegaConf.create(conf))
 
     tensor_map = mts.join(tensor_maps, axis="samples", remove_tensor_name=True)
     assert mts.equal(tensor_map, energy_tensor_map)
@@ -157,7 +157,7 @@ def test_read_generic_scalar(tmpdir, scalar_tensor_map):
 
     with tmpdir.as_cwd():
         mts.save("generic.mts", scalar_tensor_map)
-        tensor_maps, _ = read_generic(OmegaConf.create(conf))
+        tensor_maps, _ = read_generic("generic", OmegaConf.create(conf))
 
     tensor_map = mts.join(tensor_maps, axis="samples", remove_tensor_name=True)
     assert mts.equal(tensor_map, scalar_tensor_map)
@@ -184,7 +184,7 @@ def test_read_generic_spherical(tmpdir, spherical_tensor_map):
 
     with tmpdir.as_cwd():
         mts.save("generic.mts", spherical_tensor_map)
-        tensor_maps, _ = read_generic(OmegaConf.create(conf))
+        tensor_maps, _ = read_generic("generic", OmegaConf.create(conf))
 
     tensor_map = mts.join(tensor_maps, axis="samples", remove_tensor_name=True)
     assert mts.equal(tensor_map, spherical_tensor_map)
@@ -208,7 +208,7 @@ def test_read_generic_cartesian(tmpdir, cartesian_tensor_map):
 
     with tmpdir.as_cwd():
         mts.save("generic.mts", cartesian_tensor_map)
-        tensor_maps, _ = read_generic(OmegaConf.create(conf))
+        tensor_maps, _ = read_generic("generic", OmegaConf.create(conf))
 
     tensor_map = mts.join(tensor_maps, axis="samples", remove_tensor_name=True)
 
@@ -239,16 +239,16 @@ def test_read_errors(tmpdir, energy_tensor_map, scalar_tensor_map):
         np.save("numpy_array.mts", numpy_array)
         conf["read_from"] = "numpy_array.mts"
         with pytest.raises(ValueError, match="Failed to read"):
-            read_energy(OmegaConf.create(conf))
+            read_energy("energy", OmegaConf.create(conf))
         conf["read_from"] = "energy.mts"
 
         conf["forces"] = True
         with pytest.raises(ValueError, match="Unexpected gradients"):
-            read_energy(OmegaConf.create(conf))
+            read_energy("energy", OmegaConf.create(conf))
         conf["forces"] = False
 
         mts.save("scalar.mts", scalar_tensor_map)
 
         conf["read_from"] = "scalar.mts"
         with pytest.raises(ValueError, match="Unexpected samples"):
-            read_generic(OmegaConf.create(conf))
+            read_generic("scalar", OmegaConf.create(conf))

--- a/tests/utils/data/test_target_info.py
+++ b/tests/utils/data/test_target_info.py
@@ -73,7 +73,7 @@ def spherical_target_config() -> DictConfig:
 
 
 def test_layout_energy(energy_target_config):
-    target_info = get_energy_target_info(energy_target_config)
+    target_info = get_energy_target_info("energy", energy_target_config)
     assert target_info.quantity == "energy"
     assert target_info.unit == "eV"
     assert target_info.per_atom is False
@@ -81,7 +81,7 @@ def test_layout_energy(energy_target_config):
     assert target_info.device == target_info.layout.device
 
     target_info = get_energy_target_info(
-        energy_target_config, add_position_gradients=True
+        "energy", energy_target_config, add_position_gradients=True
     )
     assert target_info.quantity == "energy"
     assert target_info.unit == "eV"
@@ -90,7 +90,10 @@ def test_layout_energy(energy_target_config):
     assert target_info.device == target_info.layout.device
 
     target_info = get_energy_target_info(
-        energy_target_config, add_position_gradients=True, add_strain_gradients=True
+        "energy",
+        energy_target_config,
+        add_position_gradients=True,
+        add_strain_gradients=True,
     )
     assert target_info.quantity == "energy"
     assert target_info.unit == "eV"
@@ -100,7 +103,7 @@ def test_layout_energy(energy_target_config):
 
 
 def test_layout_scalar(scalar_target_config):
-    target_info = get_generic_target_info(scalar_target_config)
+    target_info = get_generic_target_info("scalar", scalar_target_config)
     assert target_info.quantity == "scalar"
     assert target_info.unit == ""
     assert target_info.per_atom is False
@@ -109,7 +112,7 @@ def test_layout_scalar(scalar_target_config):
 
 
 def test_layout_cartesian(cartesian_target_config):
-    target_info = get_generic_target_info(cartesian_target_config)
+    target_info = get_generic_target_info("cartesian", cartesian_target_config)
     assert target_info.quantity == "dipole"
     assert target_info.unit == "D"
     assert target_info.per_atom is True
@@ -118,7 +121,7 @@ def test_layout_cartesian(cartesian_target_config):
 
 
 def test_layout_spherical(spherical_target_config):
-    target_info = get_generic_target_info(spherical_target_config)
+    target_info = get_generic_target_info("spherical", spherical_target_config)
     assert target_info.quantity == "spherical"
     assert target_info.unit == ""
     assert target_info.per_atom is False
@@ -138,10 +141,12 @@ def test_is_auxiliary_output():
 
 
 def test_is_compatible_with(energy_target_config, spherical_target_config):
-    energy_target_info = get_energy_target_info(energy_target_config)
-    spherical_target_config = get_generic_target_info(spherical_target_config)
+    energy_target_info = get_energy_target_info("energy", energy_target_config)
+    spherical_target_config = get_generic_target_info(
+        "spherical", spherical_target_config
+    )
     energy_target_info_with_forces = get_energy_target_info(
-        energy_target_config, add_position_gradients=True
+        "energy", energy_target_config, add_position_gradients=True
     )
     assert energy_target_info.is_compatible_with(energy_target_info)
     assert energy_target_info_with_forces.is_compatible_with(energy_target_info)
@@ -161,5 +166,7 @@ def test_is_compatible_with(energy_target_config, spherical_target_config):
     ],
 )
 def test_instance_torchscript_compatible(target_config, request):
-    target_info = get_generic_target_info(request.getfixturevalue(target_config))
+    target_info = get_generic_target_info(
+        "target_name", request.getfixturevalue(target_config)
+    )
     torch.jit.script(target_info)

--- a/tests/utils/test_additive.py
+++ b/tests/utils/test_additive.py
@@ -46,7 +46,7 @@ def test_composition_model_float32_error():
         dataset_info=DatasetInfo(
             length_unit="angstrom",
             atomic_types=[1, 8],
-            targets={"energy": get_energy_target_info({"unit": "eV"})},
+            targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
         ),
     )
     with pytest.raises(
@@ -123,7 +123,7 @@ def test_old_composition_model_train():
         dataset_info=DatasetInfo(
             length_unit="angstrom",
             atomic_types=[1, 8],
-            targets={"energy": get_energy_target_info({"unit": "eV"})},
+            targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
         ),
     )
 
@@ -249,7 +249,7 @@ def test_composition_model_train(fixed_weights):
         dataset_info=DatasetInfo(
             length_unit="angstrom",
             atomic_types=[1, 8],
-            targets={"energy": get_energy_target_info({"unit": "eV"})},
+            targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
         ),
     )
 
@@ -595,7 +595,7 @@ def test_old_composition_model_torchscript(tmpdir):
         dataset_info=DatasetInfo(
             length_unit="angstrom",
             atomic_types=[1, 8],
-            targets={"energy": get_energy_target_info({"unit": "eV"})},
+            targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
         ),
     )
     composition_model = torch.jit.script(composition_model)
@@ -626,7 +626,7 @@ def test_composition_model_torchscript(tmpdir):
         dataset_info=DatasetInfo(
             length_unit="angstrom",
             atomic_types=[1, 8],
-            targets={"energy": get_energy_target_info({"unit": "eV"})},
+            targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
         ),
     )
     composition_model = torch.jit.script(composition_model)
@@ -805,7 +805,7 @@ def test_old_composition_model_missing_types(caplog):
         dataset_info=DatasetInfo(
             length_unit="angstrom",
             atomic_types=[1],
-            targets={"energy": get_energy_target_info({"unit": "eV"})},
+            targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
         ),
     )
     with pytest.raises(
@@ -819,7 +819,7 @@ def test_old_composition_model_missing_types(caplog):
         dataset_info=DatasetInfo(
             length_unit="angstrom",
             atomic_types=[1, 8, 100],
-            targets={"energy": get_energy_target_info({"unit": "eV"})},
+            targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
         ),
     )
     # need to capture the warning from the logger
@@ -894,7 +894,7 @@ def test_composition_model_missing_types(caplog):
         dataset_info=DatasetInfo(
             length_unit="angstrom",
             atomic_types=[1],
-            targets={"energy": get_energy_target_info({"unit": "eV"})},
+            targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
         ),
     )
     with pytest.raises(
@@ -916,13 +916,14 @@ def test_old_composition_model_wrong_target():
                 atomic_types=[1],
                 targets={
                     "force": get_generic_target_info(
+                        "force",
                         {
                             "quantity": "force",
                             "unit": "",
                             "type": {"cartesian": {"rank": 1}},
                             "num_subtargets": 1,
                             "per_atom": True,
-                        }
+                        },
                     )
                 },
             ),
@@ -941,13 +942,14 @@ def test_composition_model_wrong_target():
                 atomic_types=[1],
                 targets={
                     "force": get_generic_target_info(
+                        "force",
                         {
                             "quantity": "force",
                             "unit": "",
                             "type": {"cartesian": {"rank": 1}},
                             "num_subtargets": 1,
                             "per_atom": True,
-                        }
+                        },
                     )
                 },
             ),
@@ -1110,13 +1112,14 @@ def test_old_composition_model_train_per_atom(where_is_center_type):
             atomic_types=[1, 8],
             targets={
                 "energy": get_generic_target_info(
+                    "energy",
                     {
                         "quantity": "energy",
                         "unit": "",
                         "type": "scalar",
                         "num_subtargets": 1,
                         "per_atom": True,
-                    }
+                    },
                 )
             },
         ),
@@ -1227,13 +1230,14 @@ def test_composition_model_train_per_atom(where_is_center_type):
             atomic_types=[1, 8],
             targets={
                 "energy": get_generic_target_info(
+                    "energy",
                     {
                         "quantity": "energy",
                         "unit": "",
                         "type": "scalar",
                         "num_subtargets": 1,
                         "per_atom": True,
-                    }
+                    },
                 )
             },
         ),
@@ -1335,13 +1339,14 @@ def test_old_composition_many_subtargets():
             atomic_types=[1, 8],
             targets={
                 "energy": get_generic_target_info(
+                    "energy",
                     {
                         "quantity": "energy",
                         "unit": "",
                         "type": "scalar",
                         "num_subtargets": 2,
                         "per_atom": False,
-                    }
+                    },
                 )
             },
         ),
@@ -1445,13 +1450,14 @@ def test_composition_many_subtargets():
             atomic_types=[1, 8],
             targets={
                 "energy": get_generic_target_info(
+                    "energy",
                     {
                         "quantity": "energy",
                         "unit": "",
                         "type": "scalar",
                         "num_subtargets": 2,
                         "per_atom": False,
-                    }
+                    },
                 )
             },
         ),
@@ -1572,6 +1578,7 @@ def test_old_composition_spherical():
             atomic_types=[1, 8],
             targets={
                 "energy": get_generic_target_info(
+                    "energy",
                     {
                         "quantity": "energy",
                         "unit": "",
@@ -1585,7 +1592,7 @@ def test_old_composition_spherical():
                         },
                         "num_subtargets": 1,
                         "per_atom": False,
-                    }
+                    },
                 )
             },
         ),
@@ -1714,6 +1721,7 @@ def test_composition_spherical():
             atomic_types=[1, 8],
             targets={
                 "energy": get_generic_target_info(
+                    "energy",
                     {
                         "quantity": "energy",
                         "unit": "",
@@ -1727,7 +1735,7 @@ def test_composition_spherical():
                         },
                         "num_subtargets": 1,
                         "per_atom": False,
-                    }
+                    },
                 )
             },
         ),

--- a/tests/utils/test_evaluate_model.py
+++ b/tests/utils/test_evaluate_model.py
@@ -26,6 +26,7 @@ def test_evaluate_model(training, exported):
 
     targets = {
         "energy": get_energy_target_info(
+            "energy",
             {"unit": "eV"},
             add_position_gradients=True,
             add_strain_gradients=True,

--- a/tests/utils/test_external_naming.py
+++ b/tests/utils/test_external_naming.py
@@ -6,9 +6,9 @@ def test_to_external_name():
     """Tests the to_external_name function."""
 
     quantities = {
-        "energy": get_energy_target_info({"unit": "eV"}),
-        "mtt::free_energy": get_energy_target_info({"unit": "eV"}),
-        "mtt::foo": get_energy_target_info({"unit": "eV"}),
+        "energy": get_energy_target_info("energy", {"unit": "eV"}),
+        "mtt::free_energy": get_energy_target_info("mtt::free_energy", {"unit": "eV"}),
+        "mtt::foo": get_energy_target_info("mtt::foo", {"unit": "eV"}),
     }
 
     # hack to test the fact that non-energies should be treated differently

--- a/tests/utils/test_long_range.py
+++ b/tests/utils/test_long_range.py
@@ -34,7 +34,7 @@ def test_long_range(periodicity, model_name, model_cls, tmpdir):
     dataset_info = DatasetInfo(
         length_unit="Angstrom",
         atomic_types=[1, 6, 8],
-        targets={"energy": get_energy_target_info({"unit": "eV"})},
+        targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
     )
 
     hypers = get_default_hypers(model_name)

--- a/tests/utils/test_output_gradient.py
+++ b/tests/utils/test_output_gradient.py
@@ -23,7 +23,7 @@ def test_forces(is_training):
         atomic_types={1, 6, 7, 8},
         targets={
             "energy": get_energy_target_info(
-                {"unit": "eV"}, add_position_gradients=True
+                "energy", {"unit": "eV"}, add_position_gradients=True
             )
         },
     )
@@ -90,7 +90,9 @@ def test_virial(is_training):
         length_unit="angstrom",
         atomic_types={6},
         targets={
-            "energy": get_energy_target_info({"unit": "eV"}, add_strain_gradients=True)
+            "energy": get_energy_target_info(
+                "energy", {"unit": "eV"}, add_strain_gradients=True
+            )
         },
     )
     model = __model__(hypers=MODEL_HYPERS, dataset_info=dataset_info)
@@ -169,6 +171,7 @@ def test_both(is_training):
         atomic_types={6},
         targets={
             "energy": get_energy_target_info(
+                "energy",
                 {"unit": "eV"},
                 add_position_gradients=True,
                 add_strain_gradients=True,

--- a/tests/utils/test_scaler.py
+++ b/tests/utils/test_scaler.py
@@ -77,7 +77,7 @@ def test_scaler_train():
         dataset_info=DatasetInfo(
             length_unit="angstrom",
             atomic_types=[1, 8],
-            targets={"energy": get_energy_target_info({"unit": "eV"})},
+            targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
         ),
     )
 
@@ -183,7 +183,7 @@ def test_scaler_torchscript(tmpdir):
         dataset_info=DatasetInfo(
             length_unit="angstrom",
             atomic_types=[1, 8],
-            targets={"energy": get_energy_target_info({"unit": "eV"})},
+            targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
         ),
     )
 


### PR DESCRIPTION
This PR changes the name of properties to the name of the target. This is necessary to conform to the specification of outputs in metatomic. In turn, this makes it necessary to feed the name of the target to a few more functions. The property dimension of `features` and `last_layer_features` is also renamed to `features`. When a target starts with `mtt::`, this prefix is removed as it is not allowed as a name in `Labels`.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - ~Issue referenced (for PRs that solve an issue)?~

# Maintainer/Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--753.org.readthedocs.build/en/753/

<!-- readthedocs-preview metatrain end -->