### PR TITLE
Doc restructuring

### DIFF
--- a/docs/src/advanced-concepts/index.rst
+++ b/docs/src/advanced-concepts/index.rst
@@ -13,6 +13,3 @@ such as output naming, auxiliary outputs, and wrapper models.
    auxiliary-outputs
    multi-gpu
    auto-restarting
-   fine-tuning
-   fitting-generic-targets
-   transfer-learning

--- a/docs/src/tutorials/advanced_tutorials/index.rst
+++ b/docs/src/tutorials/advanced_tutorials/index.rst
@@ -1,0 +1,15 @@
+.. _advanced_tutorials:
+
+Advanced Tutorials
+==================
+
+This sections includes the advanced tutorials on the usage of the
+``metatrain`` package.
+
+.. toctree::
+   :maxdepth: 1
+
+   ../../advanced-concepts/transfer-learning
+   ../../examples/llpr/llpr
+   ../../examples/zbl/dimers
+   ../../advanced-concepts/fitting-generic-targets

--- a/docs/src/tutorials/beginner_tutorials/index.rst
+++ b/docs/src/tutorials/beginner_tutorials/index.rst
@@ -1,0 +1,16 @@
+.. _beginner_tutorials:
+
+Beginner Tutorials
+=========
+
+This sections includes the beginner tutorials on the usage of the
+``metatrain`` package.
+
+.. toctree::
+   :maxdepth: 1
+
+   ../../examples/ase/run_ase
+   ../../examples/zbl/dimers
+   ../../examples/llpr/llpr
+   ../../examples/programmatic/use_architectures_outside/use_outside
+   ../../examples/programmatic/disk_dataset/disk_dataset

--- a/docs/src/tutorials/beginner_tutorials/index.rst
+++ b/docs/src/tutorials/beginner_tutorials/index.rst
@@ -1,7 +1,7 @@
 .. _beginner_tutorials:
 
 Beginner Tutorials
-=========
+==================
 
 This sections includes the beginner tutorials on the usage of the
 ``metatrain`` package.
@@ -9,8 +9,5 @@ This sections includes the beginner tutorials on the usage of the
 .. toctree::
    :maxdepth: 1
 
+   ../../advanced-concepts/fine-tuning
    ../../examples/ase/run_ase
-   ../../examples/zbl/dimers
-   ../../examples/llpr/llpr
-   ../../examples/programmatic/use_architectures_outside/use_outside
-   ../../examples/programmatic/disk_dataset/disk_dataset

--- a/docs/src/tutorials/index.rst
+++ b/docs/src/tutorials/index.rst
@@ -3,14 +3,11 @@
 Tutorials
 =========
 
-This sections includes some more advanced tutorials on the usage of the
-``metatrain`` package.
+This sections includes all tutorials on the usage of the
+``metatrain`` package. There are beginner tutorials to get you started and more advanced tutorials.
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
-   ../examples/ase/run_ase
-   ../examples/zbl/dimers
-   ../examples/llpr/llpr
-   ../examples/programmatic/use_architectures_outside/use_outside
-   ../examples/programmatic/disk_dataset/disk_dataset
+   beginner_tutorials/index  
+

--- a/docs/src/tutorials/index.rst
+++ b/docs/src/tutorials/index.rst
@@ -4,12 +4,12 @@ Tutorials
 =========
 
 This sections includes all tutorials on the usage of the
-``metatrain`` package. There are beginner tutorials to help you get started, intermediate tutorials to deepen your understanding, and advanced tutorials for more complex applications and workflows. 
+``metatrain`` package. There are beginner tutorials to help you get started 
+ and advanced tutorials for more complex applications and workflows. 
 
 .. toctree::
    :maxdepth: 2
 
    beginner_tutorials/index  
-   intermediate_tutorials/index  
    advanced_tutorials/index  
 

--- a/docs/src/tutorials/index.rst
+++ b/docs/src/tutorials/index.rst
@@ -4,10 +4,12 @@ Tutorials
 =========
 
 This sections includes all tutorials on the usage of the
-``metatrain`` package. There are beginner tutorials to get you started and more advanced tutorials.
+``metatrain`` package. There are beginner tutorials to help you get started, intermediate tutorials to deepen your understanding, and advanced tutorials for more complex applications and workflows. 
 
 .. toctree::
    :maxdepth: 2
 
    beginner_tutorials/index  
+   intermediate_tutorials/index  
+   advanced_tutorials/index  
 

--- a/docs/src/tutorials/index.rst
+++ b/docs/src/tutorials/index.rst
@@ -5,7 +5,7 @@ Tutorials
 
 This sections includes all tutorials on the usage of the
 ``metatrain`` package. There are beginner tutorials to help you get started 
- and advanced tutorials for more complex applications and workflows. 
+and advanced tutorials for more complex applications and workflows. 
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
We split the tutorials in two sections: Beginner tutorials and advanced tutorials.
We moved fine-tuning tutorials from advanced concepts to advanced tutorials.