### PR TITLE
doc(contrib): update requirements

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -68,7 +68,7 @@ supported tox environments please use
 
 Running the tests
 -----------------
-The testsuite is implemented using Python's `unittest`_ framework and should be set-up
+The testsuite is implemented using `pytest`_ framework and should be set-up
 and run in an isolated virtual environment with `tox`_. All tests can be run with
 
 .. code-block:: bash
@@ -98,7 +98,7 @@ If you want to test a specific archicture you can also do it. For example
 Will run the unit and regression tests for the :ref:`SOAP-BPNN <architecture-soap-bpnn>`
 model. Note that architecture tests are not run by default if you just type ``tox``.
 
-.. _unittest: https://docs.python.org/3/library/unittest.html
+.. _pytest: https://pytest.org
 .. _tox: https://tox.readthedocs.io/en/latest
 
 Contributing to the documentation


### PR DESCRIPTION
Perhaps we should just drop the explanation of them in the file alltogether.. 

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--783.org.readthedocs.build/en/783/

<!-- readthedocs-preview metatrain end -->