### PR TITLE
Avoid redundant work in `_compute_single_neighbor_list` for full neighbor list

### DIFF
--- a/src/metatrain/utils/neighbor_lists.py
+++ b/src/metatrain/utils/neighbor_lists.py
@@ -171,26 +171,18 @@ def _compute_single_neighbor_list(
             )
         )
         selected = np.logical_not(reject_condition)
-        n_pairs = selected.sum()
+        nl_i = nl_i[selected]
+        nl_j = nl_j[selected]
+        nl_S = nl_S[selected]
+        nl_D = nl_D[selected]
 
-        distances = np.empty((2 * n_pairs, 3), dtype=np.float64)
-        samples = np.empty((2 * n_pairs, 5), dtype=np.int32)
-        samples[:n_pairs, 0] = nl_i[selected]
-        samples[:n_pairs, 1] = nl_j[selected]
-        samples[:n_pairs, 2:] = nl_S[selected]
+    samples = np.concatenate(
+        [nl_i[:, None], nl_j[:, None], nl_S], axis=-1, dtype=np.int32
+    )
 
-        samples[n_pairs:, 0] = nl_j[selected]
-        samples[n_pairs:, 1] = nl_i[selected]
-        samples[n_pairs:, 2:] = -nl_S[selected]
-
-    else:
-        samples = np.concatenate(
-            [nl_i[:, None], nl_j[:, None], nl_S], axis=-1, dtype=np.int32
-        )
-        distances = nl_D.astype(np.float64)
-
-    distances = torch.from_numpy(distances)
     samples = torch.from_numpy(samples)
+    distances = torch.from_numpy(nl_D)
+
     return TensorBlock(
         values=distances.reshape(-1, 3, 1),
         samples=Labels(


### PR DESCRIPTION
This avoids doing unnecessary  work if a full neighborlist is requested -- we don't have to filter for half first, then restore.

With the attached benchmark script ([run.py](https://github.com/user-attachments/files/22763421/run.py)), on my MacBook (M3 Max), with the first number the timing for `_compute_single_neighbor_list`, and the second for a plain call to `vesin`:

before
```
125 atoms
2.089986652135849µs/atom
0.7555699907243252µs/atom
1000 atoms
1.611151669640094µs/atom
0.9999045799486339µs/atom
3375 atoms
1.7297576533423529µs/atom
1.0932425926956866µs/atom
```

after
```
125 atoms
1.4709333702921867µs/atom
0.7579967193305492µs/atom
1000 atoms
1.1619366705417633µs/atom
1.0076149995438755µs/atom
3375 atoms
1.233055185250662µs/atom
1.1272704918627385µs/atom
```

This is an about 30% improvement in execution time.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue?

# Maintainer/Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?
