### PR TITLE
Bump old python version in CI to 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            python-version: "3.9"
+            python-version: "3.19"
           - os: ubuntu-22.04
             python-version: "3.13"
           - os: macos-14


### PR DESCRIPTION
Just bumping recently deprecated Python version from the CI

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--791.org.readthedocs.build/en/791/

<!-- readthedocs-preview metatrain end -->