### PR TITLE
Don't always retrain when creating the documentation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -110,6 +110,8 @@ machine as described above. Then, build the documentation with
 .. code-block:: bash
 
     tox -e docs
+    # Optional: Prepend TRAIN=0 to skip training models when generating documentation 
+    TRAIN=0 tox -e docs
 
 You can then visualize the local documentation with your favorite browser using the
 following command (or open the :file:`docs/build/html/index.html` file manually).

--- a/tox.ini
+++ b/tox.ini
@@ -156,6 +156,7 @@ commands =
 
 [testenv:docs]
 description = builds the documentation with sphinx
+passenv = TRAIN
 deps =
     -r docs/requirements.txt
     cmake
@@ -165,10 +166,10 @@ extras = # these models are used in the documentation
 commands =
     python -m pip install --no-build-isolation sphericart torch-spex>=0.1,<0.2 wigners
     # Run example and usage scripts.
-    bash -c "set -e && cd {toxinidir}/examples/basic_usage && bash usage.sh"
-    bash -c "set -e && cd {toxinidir}/examples/ase && bash train.sh"
-    bash -c "set -e && cd {toxinidir}/examples/llpr && bash train.sh"
-    bash -c "set -e && cd {toxinidir}/examples/zbl && bash train.sh"
+    bash -c 'if [ "{env:TRAIN:1}" != "0" ]; then set -e && cd {toxinidir}/examples/basic_usage && bash usage.sh; fi'
+    bash -c 'if [ "{env:TRAIN:1}" != "0" ]; then set -e && cd {toxinidir}/examples/ase && bash train.sh; fi'
+    bash -c 'if [ "{env:TRAIN:1}" != "0" ]; then set -e && cd {toxinidir}/examples/llpr && bash train.sh; fi'
+    bash -c 'if [ "{env:TRAIN:1}" != "0" ]; then set -e && cd {toxinidir}/examples/zbl && bash train.sh; fi'
     sphinx-build \
         {posargs:-E} \
         --builder html \


### PR DESCRIPTION
Right now, `tox -e docs` runs some training steps, which can take a long time. This PR adds a switch to skip training and directly builds the docs with `TRAIN=0 tox -e docs`.