### PR TITLE
Allow augmentations to be parametrized with rotations and inversions

### DIFF
--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -27,9 +27,6 @@ Unreleased
 Changed
 #######
 
-- ``RotaionalAugmenter`` method ``apply_random_augmentations`` has been renamed to
-  ``apply_augmentations``, and now can be parametrized by ``rotations`` and
-  ``inversions``.
 - ``NanoPET`` has been deprecated in favor of the stable ``PET`` architecture. The
   ``deprecated.nanopet`` architecture is still available for loading old checkpoints,
   but it will not receive any updates or bug fixes.

--- a/src/metatrain/deprecated/nanopet/trainer.py
+++ b/src/metatrain/deprecated/nanopet/trainer.py
@@ -172,7 +172,7 @@ class Trainer(TrainerInterface):
         collate_fn_train = CollateFn(
             target_keys=list(train_targets.keys()),
             callables=[
-                rotational_augmenter.apply_augmentations,
+                rotational_augmenter.apply_random_augmentations,
                 get_system_with_neighbor_lists_transform(requested_neighbor_lists),
                 get_remove_additive_transform(additive_models, train_targets),
                 get_remove_scale_transform(scaler),

--- a/src/metatrain/pet/trainer.py
+++ b/src/metatrain/pet/trainer.py
@@ -212,7 +212,7 @@ class Trainer(TrainerInterface):
         collate_fn_train = CollateFn(
             target_keys=list(train_targets.keys()),
             callables=[
-                rotational_augmenter.apply_augmentations,
+                rotational_augmenter.apply_random_augmentations,
                 get_system_with_neighbor_lists_transform(requested_neighbor_lists),
                 get_remove_additive_transform(additive_models, train_targets),
                 get_remove_scale_transform(scaler),

--- a/src/metatrain/utils/augmentation.py
+++ b/src/metatrain/utils/augmentation.py
@@ -105,19 +105,15 @@ class RotationalAugmenter:
                     _complex_to_real_spherical_harmonics_transform(ell)
                 )
 
-    def apply_augmentations(
+    def apply_random_augmentations(
         self,
         systems: List[System],
         targets: Dict[str, TensorMap],
         extra_data: Optional[Dict[str, TensorMap]] = None,
-        rotations: Optional[List[Rotation]] = None,
-        inversions: Optional[List[int]] = None,
     ) -> Tuple[List[System], Dict[str, TensorMap], Dict[str, TensorMap]]:
         """
-        Applies augmentations to a number of ``System`` objects and their targets.
-
-        If the rotations and inversions are not provided, random ones will be generated
-        separately for each system.
+        Applies random augmentations to a number of ``System`` objects, their targets,
+        and optionally extra data.
 
         :param systems: A list of :py:class:`System` objects to be augmented.
         :param targets: A dictionary mapping target names to their corresponding
@@ -125,38 +121,77 @@ class RotationalAugmenter:
         :param extra_data: An optional dictionary mapping extra data names to their
             corresponding :class:`TensorMap` objects. This extra data will also be
             augmented if provided.
-        :param rotations: An optional list of :class:`scipy.spatial.transform.Rotation
-            `Rotation` objects representing the rotations to be applied to each system.
-            If not provided, random rotations will be generated.
-        :param inversions: An optional list of integers (1 or -1) representing the
-            inversion factors to be applied to each system. If not provided, random
-            inversions will be generated.
 
         :return: A tuple containing the augmented systems and targets.
         """
-        # Randomly generate rotations and inversions if not provided
-        if rotations is None:
-            rotations = [get_random_rotation() for _ in range(len(systems))]
-        else:
-            if len(rotations) != len(systems):
-                raise ValueError(
-                    "The number of rotations must match the number of systems."
-                )
-        if inversions is None:
-            inversions = [get_random_inversion() for _ in range(len(systems))]
-        else:
-            if len(inversions) != len(systems):
-                raise ValueError(
-                    "The number of inversions must match the number of systems."
-                )
-            if any(i not in [1, -1] for i in inversions):
-                raise ValueError("Inversions must be either 1 or -1.")
+        rotations = [get_random_rotation() for _ in range(len(systems))]
+        inversions = [get_random_inversion() for _ in range(len(systems))]
+        return self.apply_augmentations(
+            systems, targets, rotations, inversions, extra_data=extra_data
+        )
+
+    def apply_augmentations(
+        self,
+        systems: List[System],
+        targets: Dict[str, TensorMap],
+        rotations: List[Rotation],
+        inversions: List[int],
+        extra_data: Optional[Dict[str, TensorMap]] = None,
+    ) -> Tuple[List[System], Dict[str, TensorMap], Dict[str, TensorMap]]:
+        """
+        Applies augmentations to a number of ``System`` objects, their targets, and
+        optionally extra data. The augmentations are defined by a list of rotations
+        and a list of inversions.
+
+        :param systems: A list of :py:class:`System` objects to be augmented.
+        :param targets: A dictionary mapping target names to their corresponding
+            :py:class:`TensorMap` objects. These are the targets to be augmented.
+        :param rotations: A list of :class:`scipy.spatial.transform.Rotation` objects
+            representing the rotations to be applied to each system.
+        :param inversions: A list of integers (1 or -1) representing the
+            inversion factors to be applied to each system.
+        :param extra_data: An optional dictionary mapping extra data names to their
+            corresponding :class:`TensorMap` objects. This extra data will also be
+            augmented if provided.
+
+        :return: A tuple containing the augmented systems and targets.
+        """
+        self._validate(systems, rotations, inversions)
 
         transformations = [
             torch.from_numpy(r.as_matrix() * i)
             for r, i in zip(rotations, inversions, strict=True)
         ]
 
+        wigner_D_matrices = self._create_wigner_D_matrices(
+            rotations, targets, extra_data=extra_data
+        )
+
+        return _apply_augmentations(
+            systems, targets, transformations, wigner_D_matrices, extra_data=extra_data
+        )
+
+    def _validate(
+        self, systems: List[System], rotations: List[Rotation], inversions: List[int]
+    ) -> None:
+        if len(rotations) != len(systems):
+            raise ValueError(
+                "The number of rotations must match the number of systems."
+            )
+
+        if len(inversions) != len(systems):
+            raise ValueError(
+                "The number of inversions must match the number of systems."
+            )
+        if any(i not in [1, -1] for i in inversions):
+            raise ValueError("Inversions must be either 1 or -1.")
+
+    def _create_wigner_D_matrices(
+        self,
+        rotations: List[Rotation],
+        targets: Dict[str, TensorMap],
+        extra_data: Optional[Dict[str, TensorMap]] = None,
+    ) -> Dict[int, List[torch.Tensor]]:
         wigner_D_matrices = {}
         if self.wigner is not None:
             scipy_quaternions = [r.as_quat() for r in rotations]
@@ -209,10 +244,7 @@ class RotationalAugmenter:
                                         torch.from_numpy(wigner_D_matrix)
                                     )
                                 wigner_D_matrices[ell] = wigner_D_matrices_l
-
-        return _apply_augmentations(
-            systems, targets, transformations, wigner_D_matrices, extra_data=extra_data
-        )
+        return wigner_D_matrices
 
 
 def _apply_wigner_D_matrices(


### PR DESCRIPTION
Instead of just random (which is still the default) augmentations, this PR allows the `RotationalAugmenter` class to apply augmentations with specified transformations. This may be useful for more complex O(3) sampling down the line, but for now allows us to test the functionality.



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - ~[ ] Documentation updated (for new features)?~
 - ~[ ] Issue referenced (for PRs that solve an issue)?~

# Maintainer/Reviewer checklist

 - ~[ ] CHANGELOG updated with public API or any other important changes?~
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--809.org.readthedocs.build/en/809/

<!-- readthedocs-preview metatrain end -->