### PR TITLE
Added machinery to autogenerate sitemaps for the docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,6 @@ myst-parser
 sphinx >= 7
 sphinxcontrib-bibtex
 sphinx-gallery
+sphinx-sitemap
 sphinx-toggleprompt
 tomli

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -76,6 +76,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
+    "sphinx_sitemap",
     "sphinxcontrib.bibtex",
     "sphinx_toggleprompt",
     "sphinx_gallery.gen_gallery",
@@ -113,6 +114,11 @@ intersphinx_mapping = {
 bibtex_bibfiles = ["../static/refs.bib"]
 bibtex_default_style = "unsrt"
 bibtex_reference_style = "author_year"
+
+# sitemap/SEO settings
+html_baseurl = "https://docs.metatensor.org/metatrain/latest/"  # prefix for the sitemap
+sitemap_url_scheme = "{link}"  # avoids language settings
+html_extra_path = ["robots.txt"]  # extra files to move
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/src/robots.txt
+++ b/docs/src/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+
+Disallow: /_sources/
+Disallow: /_datasets/
+Disallow: /_downloads/
+
+Sitemap: https://metatensor.org/metatrain/latest/sitemap.xml
+


### PR DESCRIPTION
This simply adds the machinery to generate a sitemap of the documentation pages, to simplify the job of search engines in indexing it

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--810.org.readthedocs.build/en/810/

<!-- readthedocs-preview metatrain end -->