### PR TITLE
Re-enabled wandb tests, pin pydantic to an older version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -93,7 +93,10 @@ deps =
     pytest-xdist
     spherical  # for nanoPET spherical target
     torch-pme  # for long-range tests
-    # wandb # XXX(rg): fix later
+    wandb
+    # pydantic started to send a bunch of warning with wandb, so we can pin it
+    # until https://github.com/wandb/wandb/issues/10662 is resolved
+    pydantic <2.12
     cmake
 changedir = tests
 extras =  # architectures used in the package tests


### PR DESCRIPTION
Ref #784, not yet fixed but at least we can run the tests again.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [x] Issue referenced (for PRs that solve an issue)?

# Maintainer/Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--811.org.readthedocs.build/en/811/

<!-- readthedocs-preview metatrain end -->