### PR TITLE
Keep more context around in JSON schema validation errors

### DIFF
--- a/src/metatrain/deprecated/nanopet/tests/test_functionality.py
+++ b/src/metatrain/deprecated/nanopet/tests/test_functionality.py
@@ -1,7 +1,6 @@
 import metatensor.torch as mts
 import pytest
 import torch
-from jsonschema.exceptions import ValidationError
 from metatomic.torch import ModelOutput, System
 from omegaconf import OmegaConf
 
@@ -341,11 +340,11 @@ def test_fixed_composition_weights():
 
 
 def test_fixed_composition_weights_error():
-    """Test that only inputd of type Dict[str, Dict[int, float]] are allowed."""
+    """Test that only input of type Dict[str, Dict[int, float]] are allowed."""
     hypers = DEFAULT_HYPERS.copy()
     hypers["training"]["fixed_composition_weights"] = {"energy": {"H": 300.0}}
     hypers = OmegaConf.create(hypers)
-    with pytest.raises(ValidationError, match=r"'H' does not match '\^\[0-9\]\+\$'"):
+    with pytest.raises(ValueError, match=r"'H' does not match '\^\[0-9\]\+\$'"):
         check_architecture_options(
             name="deprecated.nanopet", options=OmegaConf.to_container(hypers)
         )

--- a/src/metatrain/pet/tests/test_functionality.py
+++ b/src/metatrain/pet/tests/test_functionality.py
@@ -1,7 +1,6 @@
 import metatensor.torch as mts
 import pytest
 import torch
-from jsonschema.exceptions import ValidationError
 from metatomic.torch import ModelOutput, System
 from omegaconf import OmegaConf
 
@@ -365,11 +364,11 @@ def test_fixed_composition_weights():
 
 
 def test_fixed_composition_weights_error():
-    """Test that only inputd of type Dict[str, Dict[int, float]] are allowed."""
+    """Test that only input of type Dict[str, Dict[int, float]] are allowed."""
     hypers = DEFAULT_HYPERS.copy()
     hypers["training"]["fixed_composition_weights"] = {"energy": {"H": 300.0}}
     hypers = OmegaConf.create(hypers)
-    with pytest.raises(ValidationError, match=r"'H' does not match '\^\[0-9\]\+\$'"):
+    with pytest.raises(ValueError, match=r"'H' does not match '\^\[0-9\]\+\$'"):
         check_architecture_options(name="pet", options=OmegaConf.to_container(hypers))
 
 

--- a/src/metatrain/soap_bpnn/tests/test_functionality.py
+++ b/src/metatrain/soap_bpnn/tests/test_functionality.py
@@ -3,7 +3,6 @@ import copy
 import metatensor.torch as mts
 import pytest
 import torch
-from jsonschema.exceptions import ValidationError
 from metatomic.torch import ModelOutput, System
 from omegaconf import OmegaConf
 
@@ -276,11 +275,11 @@ def test_fixed_composition_weights():
 
 
 def test_fixed_composition_weights_error():
-    """Test that only inputd of type Dict[str, Dict[int, float]] are allowed."""
+    """Test that only input of type Dict[str, Dict[int, float]] are allowed."""
     hypers = copy.deepcopy(DEFAULT_HYPERS)
     hypers["training"]["fixed_composition_weights"] = {"energy": {"H": 300.0}}
     hypers = OmegaConf.create(hypers)
-    with pytest.raises(ValidationError, match=r"'H' does not match '\^\[0-9\]\+\$'"):
+    with pytest.raises(ValueError, match=r"'H' does not match '\^\[0-9\]\+\$'"):
         check_architecture_options(
             name="soap_bpnn", options=OmegaConf.to_container(hypers)
         )

--- a/src/metatrain/utils/architectures.py
+++ b/src/metatrain/utils/architectures.py
@@ -52,7 +52,7 @@ def check_architecture_name(name: str) -> None:
             word=name, possibilities=find_all_architectures()
         )
         if closest_match:
-            msg += f" Do you mean '{closest_match[0]}'?"
+            msg += f" Did you mean '{closest_match[0]}'?"
 
     raise ValueError(msg)
 

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import ase.io
 import pytest
 import torch
-from jsonschema.exceptions import ValidationError
 from metatensor.torch import Labels, TensorBlock, TensorMap
 from metatomic.torch import NeighborListOptions, systems_to_torch
 from omegaconf import OmegaConf
@@ -232,9 +231,9 @@ def test_train_unknown_arch_options(monkeypatch, tmp_path):
 
     match = (
         r"Unrecognized options \('num_epoch' was unexpected\). "
-        r"Do you mean 'num_epochs'?"
+        r"Did you mean 'num_epochs'?"
     )
-    with pytest.raises(ValidationError, match=match):
+    with pytest.raises(ValueError, match=match):
         train_model(options)
 
 
@@ -353,7 +352,7 @@ def test_wrong_test_split_size(split, monkeypatch, tmp_path, options):
     if split < 0:
         match = rf"{split} is less than the minimum of 0"
 
-    with pytest.raises(ValidationError, match=match):
+    with pytest.raises(ValueError, match=match):
         train_model(options)
 
 
@@ -372,7 +371,7 @@ def test_wrong_validation_split_size(split, monkeypatch, tmp_path, options):
     if split <= 0:
         match = rf"{split} is less than or equal to the minimum of 0"
 
-    with pytest.raises(ValidationError, match=match):
+    with pytest.raises(ValueError, match=match):
         train_model(options)
 
 
@@ -788,7 +787,7 @@ def test_base_validation(options, monkeypatch, tmp_path):
     options["base_precision"] = 67
 
     match = r"67 is not one of \[16, 32, 64\]"
-    with pytest.raises(ValidationError, match=match):
+    with pytest.raises(ValueError, match=match):
         train_model(options)
 
 

--- a/tests/utils/test_architectures.py
+++ b/tests/utils/test_architectures.py
@@ -2,7 +2,6 @@ import importlib
 from pathlib import Path
 
 import pytest
-from jsonschema.exceptions import ValidationError
 
 from metatrain import PACKAGE_ROOT
 from metatrain.utils.architectures import (
@@ -54,7 +53,7 @@ def test_check_architecture_name_suggest():
     name = "soap-bpnn"
     match = (
         rf"Architecture {name!r} is not a valid architecture. "
-        r"Do you mean 'soap_bpnn'?"
+        r"Did you mean 'soap_bpnn'?"
     )
     with pytest.raises(ValueError, match=match):
         check_architecture_name(name)
@@ -117,7 +116,7 @@ def test_check_architecture_options_error_raise():
     options["training"]["num_epochxxx"] = 10
 
     match = r"Unrecognized options \('num_epochxxx' was unexpected\)"
-    with pytest.raises(ValidationError, match=match):
+    with pytest.raises(ValueError, match=match):
         check_architecture_options(name=name, options=options)
 
 

--- a/tests/utils/test_jsonschema.py
+++ b/tests/utils/test_jsonschema.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-from jsonschema.exceptions import ValidationError
 
 from metatrain.utils.architectures import get_architecture_path
 from metatrain.utils.jsonschema import validate
@@ -28,9 +27,9 @@ def test_validate_single_suggestion():
     }
     match = (
         r"Unrecognized options \('batch_sizes', 'nasdasd' were unexpected\). "
-        r"Do you mean 'batch_size'?"
+        r"Did you mean 'batch_size'?"
     )
-    with pytest.raises(ValidationError, match=match):
+    with pytest.raises(ValueError, match=match):
         validate(instance=instance, schema=schema())
 
 
@@ -41,7 +40,7 @@ def test_validate_multi_suggestion():
     }
     match = (
         r"Unrecognized options \('batch_sizes', 'num_epoch' were unexpected\). "
-        r"Do you mean"
+        r"Did you mean"
     )
-    with pytest.raises(ValidationError, match=match):
+    with pytest.raises(ValueError, match=match):
         validate(instance=instance, schema=schema())


### PR DESCRIPTION
Before:

```
None is not of type 'object'
```

After:

```
None is not of type 'object'

Failed validating 'type' in schema[1]['properties']['cartesian']:
    {'type': 'object',
     'properties': {'rank': {'type': 'integer'}},
     'required': ['rank'],
     'additionalProperties': False}

On instance['cartesian']:
    None
```

It should still be improved to be easier to understand from the user perspective (I'll have a quick go at it tomorrow) but at least we can know what's going on.


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Maintainer/Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--813.org.readthedocs.build/en/813/

<!-- readthedocs-preview metatrain end -->