### PR TITLE
Fix excluded pattern in yamlfix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ lint_folders =
     "{toxinidir}/docs/src/"
 # We apply stricter checks on the main code, but not on tests, examples, or
 # external architectures
-lint_strict_folders = 
+lint_strict_folders =
     "{toxinidir}/src/metatrain/cli" \
     "{toxinidir}/src/metatrain/utils" \
     "{toxinidir}/src/metatrain/llpr" \
@@ -44,7 +44,7 @@ commands =
     ruff format --diff {[testenv]lint_folders}
     ruff check {[testenv]lint_folders}
     python {toxinidir}/developer/jsonfix.py --check {[testenv]lint_folders}
-    yamlfix --check {[testenv]lint_folders} -e "**/outputs/**"
+    yamlfix --check {[testenv]lint_folders} -e "**/outputs/**/*.yaml"
     mypy {[testenv]lint_folders}
     sphinx-lint \
         --enable all \
@@ -214,4 +214,3 @@ deps =
     torch
 commands =
     python -c "import torch; assert(torch.cuda.is_available() and torch.version.cuda)"
-


### PR DESCRIPTION
Without this, I was getting a bunch of errors locally:

```
Would fix /Users/guillaume/code/metatensor/metatrain/tests/resources/outputs/2025-10-07/17-44-03/options_restart.yaml
[+] Would fix /Users/guillaume/code/metatensor/metatrain/tests/resources/outputs/2025-10-07/17-39-47/options_restart.yaml
[+] Would fix /Users/guillaume/code/metatensor/metatrain/tests/resources/outputs/2025-10-09/16-43-19/options_restart.yaml
[+] Would fix /Users/guillaume/code/metatensor/metatrain/tests/resources/outputs/2025-10-09/16-45-47/options_restart.yaml
[+] Would fix /Users/guillaume/code/metatensor/metatrain/tests/resources/outputs/2025-10-07/12-08-03/options_restart.yaml
[+] Would fix /Users/guillaume/code/metatensor/metatrain/tests/resources/outputs/2025-10-09/16-43-14/options_restart.yaml
[+] Would fix /Users/guillaume/code/metatensor/metatrain/tests/resources/outputs/2025-10-07/17-42-08/options_restart.yaml
[+] Would fix /Users/guillaume/code/metatensor/metatrain/tests/resources/outputs/2025-10-07/17-42-17/options_restart.yaml
```



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Maintainer/Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--814.org.readthedocs.build/en/814/

<!-- readthedocs-preview metatrain end -->