### PR TITLE
Fix usage of `restart()`

### DIFF
--- a/src/metatrain/deprecated/nanopet/model.py
+++ b/src/metatrain/deprecated/nanopet/model.py
@@ -209,7 +209,7 @@ class NanoPET(ModelInterface):
         self.dataset_info = merged_info
 
         # restart the composition and scaler models
-        self.additive_models[0].restart(
+        self.additive_models[0] = self.additive_models[0].restart(
             dataset_info=DatasetInfo(
                 length_unit=dataset_info.length_unit,
                 atomic_types=self.atomic_types,
@@ -220,7 +220,7 @@ class NanoPET(ModelInterface):
                 },
             ),
         )
-        self.scaler.restart(dataset_info)
+        self.scaler = self.scaler.restart(dataset_info)
 
         return self
 

--- a/src/metatrain/experimental/flashmd/model.py
+++ b/src/metatrain/experimental/flashmd/model.py
@@ -208,7 +208,7 @@ class FlashMD(ModelInterface):
         self.dataset_info = merged_info
 
         # restart the composition and scaler models
-        self.additive_models[0].restart(
+        self.additive_models[0] = self.additive_models[0].restart(
             dataset_info=DatasetInfo(
                 length_unit=dataset_info.length_unit,
                 atomic_types=self.atomic_types,
@@ -219,7 +219,7 @@ class FlashMD(ModelInterface):
                 },
             ),
         )
-        self.additive_models[1].restart(
+        self.additive_models[1] = self.additive_models[1].restart(
             dataset_info=DatasetInfo(
                 length_unit=dataset_info.length_unit,
                 atomic_types=self.atomic_types,
@@ -230,7 +230,7 @@ class FlashMD(ModelInterface):
                 },
             ),
         )
-        self.scaler.restart(dataset_info)
+        self.scaler = self.scaler.restart(dataset_info)
 
         return self
 

--- a/src/metatrain/pet/model.py
+++ b/src/metatrain/pet/model.py
@@ -203,7 +203,7 @@ class PET(ModelInterface):
         self.dataset_info = merged_info
 
         # restart the composition and scaler models
-        self.additive_models[0].restart(
+        self.additive_models[0] = self.additive_models[0].restart(
             dataset_info=DatasetInfo(
                 length_unit=dataset_info.length_unit,
                 atomic_types=self.atomic_types,
@@ -214,7 +214,7 @@ class PET(ModelInterface):
                 },
             ),
         )
-        self.scaler.restart(dataset_info)
+        self.scaler = self.scaler.restart(dataset_info)
 
         return self
 

--- a/src/metatrain/soap_bpnn/model.py
+++ b/src/metatrain/soap_bpnn/model.py
@@ -348,7 +348,7 @@ class SoapBpnn(ModelInterface):
         self.dataset_info = merged_info
 
         # restart the composition and scaler models
-        self.additive_models[0].restart(
+        self.additive_models[0] = self.additive_models[0].restart(
             dataset_info=DatasetInfo(
                 length_unit=dataset_info.length_unit,
                 atomic_types=self.atomic_types,
@@ -359,7 +359,7 @@ class SoapBpnn(ModelInterface):
                 },
             ),
         )
-        self.scaler.restart(dataset_info)
+        self.scaler = self.scaler.restart(dataset_info)
 
         return self
 

--- a/src/metatrain/utils/additive/zbl.py
+++ b/src/metatrain/utils/additive/zbl.py
@@ -66,10 +66,6 @@ class ZBL(torch.nn.Module):
 
         n_types = len(self.atomic_types)
 
-        self.output_to_output_index = {
-            target: i for i, target in enumerate(sorted(dataset_info.targets.keys()))
-        }
-
         self.register_buffer(
             "species_to_index",
             torch.full((max(self.atomic_types) + 1,), -1, dtype=torch.int),
@@ -109,7 +105,8 @@ class ZBL(torch.nn.Module):
                     "Please report this issue and help us improve!"
                 )
 
-        return self({}, self.dataset_info.union(dataset_info))
+        self.dataset_info = self.dataset_info.union(dataset_info)
+        return self
 
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.outputs


### PR DESCRIPTION
The `ModelInterface` base class defines `restart()` as
```
    @abstractmethod
    def restart(self, dataset_info: DatasetInfo) -> "ModelInterface":
```

However, many parts of the code were using it as if this method acted on the object in-place:

```
    @abstractmethod
    def restart(self, dataset_info: DatasetInfo) -> None:
```

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--816.org.readthedocs.build/en/816/

<!-- readthedocs-preview metatrain end -->