### PR TITLE
Change quantity key from 'positions' to 'length' in FlashMD tutorial

### DIFF
--- a/examples/programmatic/flashmd/options.yaml
+++ b/examples/programmatic/flashmd/options.yaml
@@ -24,7 +24,7 @@ training_set:
   targets:
     positions:
       key: future_positions
-      quantity: positions
+      quantity: length
       unit: A
       type:
         cartesian:


### PR DESCRIPTION
`positions` triggers warnings because it's not a registered quantity in metatomic


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--824.org.readthedocs.build/en/824/

<!-- readthedocs-preview metatrain end -->