### PR TITLE
Fix formatting of directory tree in tutorial

### DIFF
--- a/examples/train_from_scratch/train_from_scratch.py
+++ b/examples/train_from_scratch/train_from_scratch.py
@@ -43,13 +43,17 @@ training run.
 
 .. code-block:: bash
 
-    outputs/2025-10-07/17-08-25/ ├── indices  # the results of dataset-spliting │   ├──
-    test.txt │   ├── training.txt │   └── validation.txt ├── model_0.ckpt  # the
-    intermediate model saved at the 0th training step ├── model.ckpt  # the final model
-    ├── model.pt  # the final model in .pt format, can be directly used by ASE and
-    LAMMPS ├── options_restart.yaml  # an expanded options file ├── train.csv  # a
-    structured output of training criteria, like training losses, energy MAEs, and force
-    RMSEs └── train.log  # a human-friendly output
+    outputs/2025-10-07/17-08-25/
+    ├── indices  # the results of dataset-spliting
+    │   ├── test.txt
+    │   ├── training.txt
+    │   └── validation.txt
+    ├── model_0.ckpt  # the intermediate model saved at the 0th training step
+    ├── model.ckpt  # the final model
+    ├── model.pt  # the final model , usable directly by ASE and LAMMPS
+    ├── options_restart.yaml  # an expanded options file
+    ├── train.csv  # structured log of training metrics (loss, MAE, RMSE,...)
+    └── train.log  # a human-friendly output
 
 The ``train.log`` provides information of the training procedure. For example, by
 checking the following:


### PR DESCRIPTION
The code block here was just not correctly formatted:

<img width="843" height="414" alt="Screenshot from 2025-10-16 13-29-46" src="https://github.com/user-attachments/assets/83a7cc63-aca0-4974-8621-5f1311757514" />



<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--833.org.readthedocs.build/en/833/

<!-- readthedocs-preview metatrain end -->