### PR TITLE
Add copybutton to code blocks in the docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,6 +5,7 @@ myst-parser
 sphinx >= 7
 sphinxcontrib-bibtex
 sphinx-gallery
+sphinx-copybutton
 sphinx-sitemap
 sphinx-toggleprompt
 tomli

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -78,6 +78,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_sitemap",
     "sphinxcontrib.bibtex",
+    "sphinx_copybutton",
     "sphinx_toggleprompt",
     "sphinx_gallery.gen_gallery",
     "chemiscope.sphinx",


### PR DESCRIPTION
Just adds a simple button to copy the text of code blocks in the documentation. I was going through a tutorial and thought it might be useful e.g. to copy the config files, but if you don't want it, it is completely fine :)

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--837.org.readthedocs.build/en/837/

<!-- readthedocs-preview metatrain end -->