### PR TITLE
Improve DiskDataset performance

### DIFF
--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -628,8 +628,8 @@ class DiskDataset(torch.utils.data.Dataset):
         self._sample_class = namedtuple("Sample", self._fields_to_read)
 
         # Do not open file in the main process and start sub-processes with None
-        self.zip_file = None
-        self._zip_file_pid = None
+        self.zip_file: Optional[zipfile.ZipFile] = None
+        self._zip_file_pid: Optional[int] = None
 
     def _open_zip_once(self) -> None:
         pid = os.getpid()
@@ -644,6 +644,7 @@ class DiskDataset(torch.utils.data.Dataset):
 
     def __getitem__(self, index: int) -> Any:
         self._open_zip_once()
+        assert self.zip_file is not None
 
         system_and_targets = []
         for field_name in self._fields_to_read:


### PR DESCRIPTION
Improve `DiskDataset` by avoiding to open and close the file at each iteration.

Before this PR:
```
RANK  0 ||| Dataset Type: DiskDataset
RANK  0 ||| Dataset: QM7X_train_19991_polarizability.zip
RANK  0 ||| Creating DiskDataset
RANK  0 ||| Created DiskDataset of size 19991 in 0.18966269493103027s
RANK  0 ||| Start iterations on DiskDataset
RANK  0 ||| 250 terations on DiskDataset completed in 41.268508195877075s
```

```
RANK  0 ||| Dataset Type: DiskDataset
RANK  0 ||| Dataset: QM7X_train_19991_polarizability.zip
RANK  0 ||| Creating DiskDataset
RANK  0 ||| Created DiskDataset of size 19991 in 0.1929149627685547s
RANK  0 ||| Start iterations on DiskDataset
RANK  0 ||| 500 terations on DiskDataset completed in 82.76450181007385s
```

After this PR:
```
RANK  0 ||| Dataset Type: DiskDataset
RANK  0 ||| Dataset: QM7X_train_19991_polarizability.zip
RANK  0 ||| Creating DiskDataset
RANK  0 ||| Created DiskDataset of size 19991 in 0.37998318672180176s
RANK  0 ||| Start iterations on DiskDataset
RANK  0 ||| 250 terations on DiskDataset completed in 0.07430386543273926s
```

```
RANK  0 ||| Dataset Type: DiskDataset
RANK  0 ||| Dataset: QM7X_train_19991_polarizability.zip
RANK  0 ||| Creating DiskDataset
RANK  0 ||| Created DiskDataset of size 19991 in 0.38308286666870117s
RANK  0 ||| Start iterations on DiskDataset
RANK  0 ||| 500 terations on DiskDataset completed in 0.14654850959777832s
```

There is a bigger upfront cost in initialization (constant), while the iterations are sped up considerably.

I also tried to cache all other file openings happening during an iteration, but those didn't seem to affect the performance considerably.


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--859.org.readthedocs.build/en/859/

<!-- readthedocs-preview metatrain end -->