### PR TITLE
[BUG] Isolation of tests in pet

### DIFF
--- a/src/metatrain/pet/tests/test_continue.py
+++ b/src/metatrain/pet/tests/test_continue.py
@@ -1,3 +1,4 @@
+import copy
 import shutil
 
 import metatensor
@@ -56,7 +57,7 @@ def test_continue(monkeypatch, tmp_path):
 
     dataset = Dataset.from_dict({"system": systems, "mtt::U0": targets["mtt::U0"]})
 
-    hypers = DEFAULT_HYPERS.copy()
+    hypers = copy.deepcopy(DEFAULT_HYPERS)
     hypers["training"]["num_epochs"] = 0
     loss_conf = OmegaConf.create({"mtt::U0": CONF_LOSS.copy()})
     OmegaConf.resolve(loss_conf)

--- a/src/metatrain/pet/tests/test_finetuning.py
+++ b/src/metatrain/pet/tests/test_finetuning.py
@@ -1,3 +1,4 @@
+import copy
 import shutil
 
 import pytest
@@ -140,7 +141,7 @@ def test_finetuning_restart(monkeypatch, tmp_path):
 
     dataset = Dataset.from_dict({"system": systems, "mtt::U0": targets["mtt::U0"]})
 
-    hypers = DEFAULT_HYPERS.copy()
+    hypers = copy.deepcopy(DEFAULT_HYPERS)
 
     hypers["training"]["num_epochs"] = 1
 
@@ -166,7 +167,7 @@ def test_finetuning_restart(monkeypatch, tmp_path):
     assert isinstance(model_finetune, PET)
     model_finetune.restart(dataset_info)
 
-    hypers = DEFAULT_HYPERS.copy()
+    hypers = copy.deepcopy(DEFAULT_HYPERS)
 
     hypers["training"]["num_epochs"] = 0
 
@@ -203,7 +204,7 @@ def test_finetuning_restart(monkeypatch, tmp_path):
         ["lora_" in name for name, _ in model_finetune_restart.named_parameters()]
     )
 
-    hypers = DEFAULT_HYPERS.copy()
+    hypers = copy.deepcopy(DEFAULT_HYPERS)
 
     hypers["training"]["num_epochs"] = 0
 

--- a/src/metatrain/pet/tests/test_functionality.py
+++ b/src/metatrain/pet/tests/test_functionality.py
@@ -1,3 +1,5 @@
+import copy
+
 import metatensor.torch as mts
 import pytest
 import torch
@@ -354,7 +356,7 @@ def test_output_per_atom():
 def test_fixed_composition_weights():
     """Tests the correctness of the json schema for fixed_composition_weights"""
 
-    hypers = DEFAULT_HYPERS.copy()
+    hypers = copy.deepcopy(DEFAULT_HYPERS)
     hypers["training"]["fixed_composition_weights"] = {
         "energy": {
             1: 1.0,
@@ -370,7 +372,7 @@ def test_fixed_composition_weights():
 
 def test_fixed_composition_weights_error():
     """Test that only input of type Dict[str, Dict[int, float]] are allowed."""
-    hypers = DEFAULT_HYPERS.copy()
+    hypers = copy.deepcopy(DEFAULT_HYPERS)
     hypers["training"]["fixed_composition_weights"] = {"energy": {"H": 300.0}}
     hypers = OmegaConf.create(hypers)
     with pytest.raises(ValueError, match=r"'H' does not match '\^\[0-9\]\+\$'"):

--- a/src/metatrain/pet/tests/test_long_range.py
+++ b/src/metatrain/pet/tests/test_long_range.py
@@ -1,9 +1,10 @@
+import copy
+
 import pytest
 
 
 pytest.importorskip("torchpme")
 
-import copy
 
 import torch
 from metatomic.torch import ModelOutput, System
@@ -79,7 +80,7 @@ def test_long_range_training(use_ewald):
     targets, target_info_dict = read_targets(OmegaConf.create(conf))
     targets = {"energy": targets["energy"]}
     dataset = Dataset.from_dict({"system": systems, "energy": targets["energy"]})
-    hypers = DEFAULT_HYPERS.copy()
+    hypers = copy.deepcopy(DEFAULT_HYPERS)
     hypers["training"]["num_epochs"] = 2
     hypers["training"]["scheduler_patience"] = 1
     hypers["training"]["fixed_composition_weights"] = {}

--- a/src/metatrain/pet/tests/test_regression.py
+++ b/src/metatrain/pet/tests/test_regression.py
@@ -1,3 +1,4 @@
+import copy
 import random
 
 import numpy as np
@@ -95,7 +96,7 @@ def test_regression_energies_forces_train(device):
     targets, target_info_dict = read_targets(OmegaConf.create(conf))
     targets = {"energy": targets["energy"]}
     dataset = Dataset.from_dict({"system": systems, "energy": targets["energy"]})
-    hypers = DEFAULT_HYPERS.copy()
+    hypers = copy.deepcopy(DEFAULT_HYPERS)
     hypers["training"]["num_epochs"] = 2
     hypers["training"]["scheduler_patience"] = 1
     hypers["training"]["fixed_composition_weights"] = {}


### PR DESCRIPTION
The tests for PET were all using and some of them modifying global variables (`DEFAULT_HYPERS` and `MODEL_HYPERS`) which is of course very bad. I realised because running the tests of a single file was passing but running the tests of all files was failing (in a branch).

I just took the approach that some of the tests were already taking, which is to deepcopy the hypers before modifying them.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--882.org.readthedocs.build/en/882/

<!-- readthedocs-preview metatrain end -->