### PR TITLE
Fix docs

### DIFF
--- a/examples/1-advanced/options-mixed-stress.yaml
+++ b/examples/1-advanced/options-mixed-stress.yaml
@@ -1,3 +1,5 @@
+seed: 42
+
 architecture:
   name: soap_bpnn
   training:


### PR DESCRIPTION
Fixes the docs by preventing unlucky splits of the data where all validation set samples have an undefined stress

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--891.org.readthedocs.build/en/891/

<!-- readthedocs-preview metatrain end -->