### PR TITLE
Remove outdated `-c auto` suggestion from docs

### DIFF
--- a/docs/src/getting-started/checkpoints.rst
+++ b/docs/src/getting-started/checkpoints.rst
@@ -31,7 +31,7 @@ or running on an HPC cluster with short time limits), it is useful to be able
 to train and restart multiple times with the same command.
 
 In ``metatrain``, this functionality is provided via the ``--restart auto``
-(or ``-c auto``) flag of ``mtt train``. This flag will automatically restart
+flag of ``mtt train``. This flag will automatically restart
 the training from the last checkpoint, if one is found in the ``outputs/``
 of the current directory. If no checkpoint is found, the training will start
 from scratch.


### PR DESCRIPTION
`-c auto` was removed AFAIK. People are now supposed to do `--restart auto`

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--894.org.readthedocs.build/en/894/

<!-- readthedocs-preview metatrain end -->