### PR TITLE
Avoid docs messing with linter

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ commands =
     sphinx-lint \
         --enable all \
         --disable line-too-long \
-        -i "{toxinidir}/docs/src/examples" \
+        -i "{toxinidir}/docs/src/generated_examples" \
         {[testenv]lint_folders} "{toxinidir}/README.md"
     # Stricter checks on the main code
     # Check type annotations


### PR DESCRIPTION
Building the documentation locally and then running the linter resulted in this error:

<img width="1568" height="227" alt="Screenshot from 2025-11-06 21-25-08" src="https://github.com/user-attachments/assets/dbb1dd5d-7071-42b7-8fe3-e20e607a6a6a" />

which was annoying because it required you to remove the `docs/src/generated_examples` folder.

This PR fixes that. I thought about adding a `tox -e lint` in the CI after building the docs, but I'm not sure if it's a good idea given that the linter often fails and it is nice that the documentation still builds for the PR (or maybe this shouldn't be the case?)


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--897.org.readthedocs.build/en/897/

<!-- readthedocs-preview metatrain end -->