### PR TITLE
Avoid docs messing with linter (part 2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ docstring-code-format = true
 
 [tool.mypy]
 exclude = [
-    "docs/src/examples"
+    "docs/src/generated_examples"
 ]
 follow_imports = 'skip'
 ignore_missing_imports = true


### PR DESCRIPTION
Sorry, I just realised that when I force pushed to #897 I removed this change, which was also necessary.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--899.org.readthedocs.build/en/899/

<!-- readthedocs-preview metatrain end -->