### PR TITLE
Remove leftover from documentation PR

### DIFF
--- a/src/metatrain/gap/model.py
+++ b/src/metatrain/gap/model.py
@@ -39,7 +39,6 @@ class GAP(ModelInterface[ModelHypers]):
             ],
         }
     )
-    __hypers_cls__ = ModelHypers
 
     def __init__(self, hypers: ModelHypers, dataset_info: DatasetInfo) -> None:
         super().__init__(hypers, dataset_info, self.__default_metadata__)


### PR DESCRIPTION
Sorry I forgot to remove this one when I did the cleaning


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--919.org.readthedocs.build/en/919/

<!-- readthedocs-preview metatrain end -->