### PR TITLE
Move linter config into pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,8 +112,11 @@ exclude = ["docs/src/examples/**", "src/metatrain/_version.py"]
 line-length = 88
 
 [tool.ruff.lint]
-select = ["E", "F", "B", "I"]
+select = ["E", "F", "B", "I", "D103"]
 ignore = ["B018", "B904"]
+
+[tool.ruff.lint.per-file-ignores]
+"**/{docs,deprecated,examples,experimental,tests}/*" = ["D"]
 
 [tool.ruff.lint.isort]
 lines-after-imports = 2
@@ -134,6 +137,15 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "metatrain.*.documentation"
 disable_error_code = ["misc"]
+
+[tool.pydoclint]
+quiet = true
+style = "sphinx"
+check_return_types = false
+arg_type_hints_in_docstring = false
+skip_checking_raises = true
+check_class_attributes = false
+skip_checking_short_docstrings = false
 
 [tool.pytest.ini_options]
 # ignore" a bunch of internal warnings with Python 3.13 and PyTorch

--- a/src/metatrain/deprecated/nanopet/checkpoints.py
+++ b/src/metatrain/deprecated/nanopet/checkpoints.py
@@ -121,6 +121,11 @@ def trainer_update_v1_v2(checkpoint: Dict[str, Any]) -> None:
 
 
 def trainer_update_v2_v3(checkpoint):
+    """
+    Update trainer checkpoint from version 2 to version 3.
+
+    :param checkpoint: The checkpoint to be updated.
+    """
     # num_workers=0 means that the main process will do the data loading, which is
     # equivalent to not setting it (this was the behavior before v3)
     checkpoint["train_hypers"]["num_workers"] = 0

--- a/src/metatrain/deprecated/nanopet/modules/nef.py
+++ b/src/metatrain/deprecated/nanopet/modules/nef.py
@@ -9,16 +9,18 @@ import torch
 
 
 def get_nef_indices(centers, n_nodes: int, n_edges_per_node: int):
-    # computes tensors of indices useful to convert between edge
-    # and NEF layouts; the usage and function of nef_indices and
-    # nef_to_edges_neighbor is clear in the edge_array_to_nef and
-    # nef_array_to_edges functions below.
-    # In particular:
-    # nef_array = edge_array[nef_indices]
-    # edge_array = nef_array[centers, nef_to_edges_neighbor]
-    # The third output, nef_mask, is a mask that can be used to
-    # filter out the padding values in the NEF array, as different
-    # nodes will have, in general, different number of edges.
+    """Computes tensors of indices useful to convert between edge and NEF layouts.
+
+    The usage and function of nef_indices and nef_to_edges_neighbor is clear in the
+    edge_array_to_nef and nef_array_to_edges functions below. In particular:
+
+    nef_array = edge_array[nef_indices]
+    edge_array = nef_array[centers, nef_to_edges_neighbor]
+
+    The third output, ``nef_mask``, is a mask that can be used to filter out the padding
+    values in the NEF array, as different nodes will have, in general, different number
+    of edges.
+    """
 
     bincount = torch.bincount(centers, minlength=n_nodes)
 
@@ -40,9 +42,11 @@ def get_nef_indices(centers, n_nodes: int, n_edges_per_node: int):
 
 
 def get_corresponding_edges(array):
-    # computes the corresponding edge (i.e., the edge that goes in the
-    # opposite direction) for each edge in the array; this is useful
-    # in the message-passing operation
+    """Compute the corresponding edges.
+
+    (i.e., the edge that goes in the opposite direction) for each edge in the array;
+    this is useful in the message-passing operation
+    """
 
     if array.numel() == 0:
         return torch.empty((0,), dtype=array.dtype, device=array.device)
@@ -117,7 +121,7 @@ def edge_array_to_nef(
     mask: Optional[torch.Tensor] = None,
     fill_value: float = 0.0,
 ):
-    # converts an edge array to a NEF array
+    """Convert an edge array to a NEF array"""
     if mask is None:
         return edge_array[nef_indices]
     else:
@@ -129,8 +133,10 @@ def edge_array_to_nef(
 
 
 def nef_array_to_edges(nef_array, centers, nef_to_edges_neighbor):
-    # converts a NEF array to an edge array. Most often, this converts
-    # a NEF array (three-dimensional, where the dimensions are the nodes,
-    # the edges, and the features) to an edge array (two-dimensional,
-    # where the dimensions are the edges and the features).
+    """Converts a NEF array to an edge array.
+
+    Most often, this converts a NEF array (three-dimensional, where the dimensions are
+    the nodes, the edges, and the features) to an edge array (two-dimensional, where the
+    dimensions are the edges and the features).
+    """
     return nef_array[centers, nef_to_edges_neighbor]

--- a/src/metatrain/deprecated/nanopet/modules/radial_mask.py
+++ b/src/metatrain/deprecated/nanopet/modules/radial_mask.py
@@ -2,7 +2,7 @@ import torch
 
 
 def get_radial_mask(r, r_cut: float, r_transition: float):
-    # All radii are already guaranteed to be smaller than r_cut
+    """All radii are already guaranteed to be smaller than ``r_cut``."""
     return torch.where(
         r < r_transition,
         torch.ones_like(r),

--- a/src/metatrain/deprecated/nanopet/modules/structures.py
+++ b/src/metatrain/deprecated/nanopet/modules/structures.py
@@ -7,6 +7,7 @@ from metatomic.torch import NeighborListOptions, System
 def concatenate_structures(
     systems: List[System], neighbor_list_options: NeighborListOptions
 ):
+    """Concatenate a list of systems into a single batch."""
     positions = []
     centers = []
     neighbors = []

--- a/src/metatrain/experimental/flashmd/modules/structures.py
+++ b/src/metatrain/experimental/flashmd/modules/structures.py
@@ -17,6 +17,7 @@ def concatenate_structures(
     neighbor_list_options: NeighborListOptions,
     selected_atoms: Optional[Labels] = None,
 ):
+    """Concatenate a list of systems into a single batch."""
     positions: list[torch.Tensor] = []
     momenta: list[torch.Tensor] = []
     centers: list[torch.Tensor] = []

--- a/src/metatrain/gap/model.py
+++ b/src/metatrain/gap/model.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
-import featomic
 import featomic.torch
 import metatensor.torch as mts
 import numpy as np

--- a/src/metatrain/utils/testing/checkpoints.py
+++ b/src/metatrain/utils/testing/checkpoints.py
@@ -97,6 +97,14 @@ def make_checkpoint_load_tests(
     *,
     incompatible_trainer_checkpoints: Optional[List[str]] = None,
 ) -> Callable:
+    """
+    Factory function that creates a test function to check loading of old checkpoints.
+
+    :param DEFAULT_HYPERS: The default hypers to be used for the trainer.
+    :param incompatible_trainer_checkpoints: A list of checkpoint paths that are known
+        to be incompatible with the current trainer version when restarting.
+    :return: A test function that checks loading of old checkpoints.
+    """
     if incompatible_trainer_checkpoints is None:
         incompatible_trainer_checkpoints = []
 

--- a/src/metatrain/utils/testing/equivariance.py
+++ b/src/metatrain/utils/testing/equivariance.py
@@ -6,6 +6,10 @@ from scipy.spatial.transform import Rotation
 
 
 def get_random_rotation() -> Rotation:
+    """Generate a random 3D rotation.
+
+    :return: A scipy.spatial.transform.Rotation object representing the random rotation.
+    """
     return Rotation.random()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -68,17 +68,6 @@ commands =
     # Check docstrings match with function signature
     pydoclint \
         --exclude {[testenv]exclude_tests_regex} \
-        --style sphinx \
-        --check-return-types f \
-        --arg-type-hints-in-docstring f \
-        --skip-checking-raises t \
-        --check-class-attributes f \
-        --skip-checking-short-docstrings f \
-        {[testenv]lint_strict_folders}
-    # Ensure all public functions have docstrings, except tests
-    ruff check --preview \
-        --exclude {[testenv]exclude_tests_glob} \
-        --select D103 \
         {[testenv]lint_strict_folders}
 
 [testenv:format]


### PR DESCRIPTION
I think it is good to have all linter rules in one file and not spread across many files. Also, the freshly introduced rule "D103" was not taken into account. This is fixed as well by writing several missing docstrings in the core part.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--925.org.readthedocs.build/en/925/

<!-- readthedocs-preview metatrain end -->