### PR TITLE
Bump wandb in test dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,7 @@ deps =
     pytest-xdist
     spherical  # for nanoPET spherical target
     torch-pme >= 0.3.2  # for long-range tests
-    wandb
+    wandb >= 0.23 # Lower versions emit warnings with pydantic>=2.12
     cmake
 changedir = tests
 extras =  # architectures used in the package tests


### PR DESCRIPTION
Earlier versions of `wandb` emit warnings when used with `pydantic>=2.12`, and tests do not accept warnings. With this PR we are more strict with the wandb that we use for tests, but still for normal use any version of `wandb` can be used


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--926.org.readthedocs.build/en/926/

<!-- readthedocs-preview metatrain end -->