### PR TITLE
`get_generic_target_info`: allow diferent num_subtargets for each irrep

### DIFF
--- a/src/metatrain/utils/data/target_info.py
+++ b/src/metatrain/utils/data/target_info.py
@@ -467,9 +467,12 @@ def _get_spherical_target_info(target_name: str, target: DictConfig) -> TargetIn
         sample_names.append("atom")
 
     irreps = target["type"]["spherical"]["irreps"]
+    num_subtargets = target["num_subtargets"]
+    if isinstance(num_subtargets, int):
+        num_subtargets = [num_subtargets] * len(irreps)
     keys = []
     blocks = []
-    for irrep in irreps:
+    for irrep, num_properties in zip(irreps, num_subtargets, strict=True):
         components = [
             Labels(
                 names=["o3_mu"],
@@ -483,7 +486,7 @@ def _get_spherical_target_info(target_name: str, target: DictConfig) -> TargetIn
             values=torch.empty(
                 0,
                 2 * irrep["o3_lambda"] + 1,
-                target["num_subtargets"],
+                num_properties,
                 dtype=torch.float64,
             ),
             samples=Labels(
@@ -491,9 +494,7 @@ def _get_spherical_target_info(target_name: str, target: DictConfig) -> TargetIn
                 values=torch.empty((0, len(sample_names)), dtype=torch.int32),
             ),
             components=components,
-            properties=Labels.range(
-                target_name.replace("mtt::", ""), target["num_subtargets"]
-            ),
+            properties=Labels.range(target_name.replace("mtt::", ""), num_properties),
         )
         keys.append([irrep["o3_lambda"], irrep["o3_sigma"]])
         blocks.append(block)


### PR DESCRIPTION
The `get_generic_target_info` function allows spherical targets to pass multiple irreps, but the same number of subtargets was imposed for each of the irreps. This PR allows also to pass a list of integers to `num_subtargets`.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--927.org.readthedocs.build/en/927/

<!-- readthedocs-preview metatrain end -->