### PR TITLE
Remove unneeded sections from LLPR documentation

### DIFF
--- a/src/metatrain/llpr/documentation.py
+++ b/src/metatrain/llpr/documentation.py
@@ -17,12 +17,6 @@ implementation of the LLPR.
 
 Note that the uncertainties computed with this implementation are returned as
 standard deviations, and not variances.
-
-{{SECTION_INSTALLATION}}
-
-{{SECTION_DEFAULT_HYPERS}}
-
-{{SECTION_MODEL_HYPERS}}
 """
 
 from typing import Literal, Optional


### PR DESCRIPTION
I just saw the llpr PR that got merged, and since it removed `EnsembleHypers`, the documentation no longer needs the sections to be explicitly specified. The sections are all automatically appended at the end of the docstring.


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--932.org.readthedocs.build/en/932/

<!-- readthedocs-preview metatrain end -->