### PR TITLE
Fix URL displayed in test failures

### DIFF
--- a/src/metatrain/utils/testing/mtt_plugin.py
+++ b/src/metatrain/utils/testing/mtt_plugin.py
@@ -32,7 +32,7 @@ def pytest_runtest_makereport(item: Any, call: Any) -> Generator:
         import_path = f"metatrain.utils.testing.{item.obj.__qualname__}"
 
         # Example: customize your documentation URL here
-        doc_url = f"https://https://docs.metatensor.org/metatrain/latest/dev-docs/utils/testing.html#{import_path}"
+        doc_url = f"https://docs.metatensor.org/metatrain/latest/dev-docs/utils/testing.html#{import_path}"
 
         longrepr = report.longrepr
 


### PR DESCRIPTION
I wrote `https://https://` instead `https://`, this is what happens when you do things manually instead of just doing the right thing which is using an LLM :sweat_smile: 


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--949.org.readthedocs.build/en/949/

<!-- readthedocs-preview metatrain end -->