### PR TITLE
Fix lint with new mypy

### DIFF
--- a/src/metatrain/utils/testing/_utils.py
+++ b/src/metatrain/utils/testing/_utils.py
@@ -1,9 +1,9 @@
-import importlib
 from collections import namedtuple
+from importlib.util import find_spec
 
 
 DepStatus = namedtuple("DepStatus", ["present", "message"])
-if importlib.util.find_spec("wandb"):
+if find_spec("wandb"):
     WANDB_AVAILABLE = DepStatus(True, "present")
 else:
     WANDB_AVAILABLE = DepStatus(False, "wandb not installed")


### PR DESCRIPTION
40 minutes ago a new release of `mypy` was made which results in a lint error in `main` 

```
src/metatrain/utils/testing/_utils.py:6: error: Module has no attribute "util"  [attr-defined]
```

:sweat_smile: 

This PR fixes the lint error


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--950.org.readthedocs.build/en/950/

<!-- readthedocs-preview metatrain end -->