### PR TITLE
Fix dimension of center embedding for extra lambda term in MCoV

### DIFF
--- a/src/metatrain/soap_bpnn/modules/tensor_basis.py
+++ b/src/metatrain/soap_bpnn/modules/tensor_basis.py
@@ -456,7 +456,7 @@ class TensorBasis(torch.nn.Module):
                 self.spex_contraction = FakeLinearMap()
                 self.center_encoding = torch.nn.Embedding(
                     num_embeddings=len(self.atomic_types),
-                    embedding_dim=self.spex_calculator.radial.n_per_l[1] * 4,
+                    embedding_dim=self.spex_calculator.radial.n_per_l[o3_lambda] * 4,
                 )
         else:
             # needed to make torchscript work


### PR DESCRIPTION
The dimension of the center embedding for the extra lambda term has been fixed.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--963.org.readthedocs.build/en/963/

<!-- readthedocs-preview metatrain end -->