### PR TITLE
Clarify default gradient clipping value in docstring

### DIFF
--- a/src/metatrain/pet/documentation.py
+++ b/src/metatrain/pet/documentation.py
@@ -227,7 +227,7 @@ class TrainerHypers(TypedDict):
     best_model_metric: Literal["rmse_prod", "mae_prod", "loss"] = "mae_prod"
     """Metric used to select best checkpoint (e.g., ``rmse_prod``)"""
     grad_clip_norm: float = 1.0
-    """Maximum gradient norm value, by default 1.0."""
+    """Maximum gradient norm value."""
     loss: str | dict[str, LossSpecification | str] = "mse"
     """This section describes the loss function to be used. See the
     :ref:`loss-functions` for more details."""


### PR DESCRIPTION
Updated documentation to clarify default gradient clipping value.

<!-- What does this implement/fix? Explain your changes here. -->



# Contributor (creator of pull-request) checklist

 - ~[ ] Tests updated (for new features and bugfixes)?~
 - ~[ ] Documentation updated (for new features)?~
 - ~[ ] Issue referenced (for PRs that solve an issue)?~

# Maintainer/Reviewer checklist

 - ~[ ] CHANGELOG updated with public API or any other important changes?~
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?
