### PR TITLE
Fix adaptive cutoff weight normalization problem

### DIFF
--- a/src/metatrain/pet/modules/adaptive_cutoff.py
+++ b/src/metatrain/pet/modules/adaptive_cutoff.py
@@ -148,8 +148,9 @@ def get_gaussian_cutoff_weights(
     baseline = num_neighbors_adaptive_t * x**3
 
     diff = diff + baseline.unsqueeze(0)
+    logw = -0.5 * (diff / width) ** 2
 
-    weights = torch.exp(-0.5 * (diff / width) ** 2)
+    weights = torch.exp(logw - logw.max())
 
     # row-wise normalization of the weights
     weights_sum = weights.sum(dim=1, keepdim=True)


### PR DESCRIPTION
Fixes #984 

The seemingly harmless "regularization" for the adaptive cutoff weights messes up badly in a few rare corner cases 

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 This is not something that can be easily fixed as it happens only in 1/1000 cases and is a consequence of very unfortunate neighbor distribution.
 - [x] Issue referenced (for PRs that solve an issue)?

# Maintainer/Reviewer checklist

 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--983.org.readthedocs.build/en/983/

<!-- readthedocs-preview metatrain end -->