### PR TITLE
Fix cumulative trapezoid calculation in loss.py

### DIFF
--- a/src/metatrain/utils/loss.py
+++ b/src/metatrain/utils/loss.py
@@ -578,9 +578,9 @@ class MaskedDOSLoss(LossInterface):
             gradient_loss = 0.0
         if self.int_weight > 0:
             int_predictions = torch.cumulative_trapezoid(
-                aligned_predictions**2, dx=0.05, dim=1
+                aligned_predictions, dx=0.05, dim=1
             )
-            int_target = torch.cumulative_trapezoid(target**2, dx=0.05, dim=1)
+            int_target = torch.cumulative_trapezoid(target, dx=0.05, dim=1)
             int_error = (int_predictions - int_target) ** 2
             int_error = int_error * mask[:, 1:].unsqueeze(
                 dim=1


### PR DESCRIPTION
Loss function was erroneously computing the cumulative integral. This is a very small change and should not affect anything.




<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--994.org.readthedocs.build/en/994/

<!-- readthedocs-preview metatrain end -->