### PR TITLE
Rename MACE output features temporarily

### DIFF
--- a/src/metatrain/experimental/mace/model.py
+++ b/src/metatrain/experimental/mace/model.py
@@ -242,8 +242,8 @@ class MetaMACE(ModelInterface[ModelHypers]):
         for target_name, target_info in dataset_info.targets.items():
             self._add_output(target_name, target_info)
 
-        self.layouts["features"] = get_e3nn_mts_layout(
-            "features",
+        self.layouts["mtt::aux::mace_features"] = get_e3nn_mts_layout(
+            "mtt::aux::mace_features",
             {
                 "type": {"spherical": {"irreps": self.features_irreps}},
                 "per_atom": True,
@@ -384,8 +384,8 @@ class MetaMACE(ModelInterface[ModelHypers]):
         model_outputs: dict[str, torch.Tensor] = {}
 
         # Add features if requested
-        if "features" in outputs:
-            model_outputs["features"] = node_features
+        if "mtt::aux::mace_features" in outputs:
+            model_outputs["mtt::aux::mace_features"] = node_features
 
         # Run heads
         for output_name, head in self.heads.items():

--- a/src/metatrain/experimental/mace/tests/test_basic.py
+++ b/src/metatrain/experimental/mace/tests/test_basic.py
@@ -81,8 +81,12 @@ class TestInput(InputTests, MACETests): ...
 
 
 class TestOutput(OutputTests, MACETests):
+    supports_features = False
+
     @pytest.fixture
     def n_features(self, model_hypers: dict) -> list[int]:
+        """Features output was renamed to mtt::aux:mace_features so
+        for now this is not used."""
         hidden_irreps = o3.Irreps(model_hypers["hidden_irreps"])
         num_interactions = model_hypers["num_interactions"]
 
@@ -114,12 +118,7 @@ class TestTorchscript(TorchscriptTests, MACETests):
         return torch.jit.script(e3nn.util.jit.compile(model))
 
 
-class TestExported(ExportedTests, MACETests):
-    # For now, AtomisticModel does not consider the possibility that
-    # the "features" output can have a well defined equivariant
-    # behavior, and therefore checking consistency when returning
-    # this output raises an error.
-    avoid_consistency_check = ["features"]
+class TestExported(ExportedTests, MACETests): ...
 
 
 class TestTraining(TrainingTests, MACETests): ...


### PR DESCRIPTION
MACE features don't adhere to metatomic's definition of the "features" output, since they are equivariant and metatomic only considers the possibility of invariant features.

Until we decide if we allow equivariant features, the output that returns MACE internal features is renamed to `mtt::aux::mace_features`


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--998.org.readthedocs.build/en/998/

<!-- readthedocs-preview metatrain end -->