### PR TITLE
Document why we set the sphinx constraint

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,9 @@ jinja2
 matplotlib
 myst-parser
 pytest
-sphinx < 9.0
+# Sphinx < 9.0 because of some warnings on docs build (likely sphinx bug), 
+# if future sphinx builds without warnings, remove constraint
+sphinx < 9.0 
 sphinxcontrib-bibtex
 sphinx-gallery
 sphinx-copybutton


### PR DESCRIPTION
In #1009 we added a new constraint for sphinx, but forgot to document it. I document it so in the future it can be removed without fear of breaking something in the website.