### PR TITLE
Add imports in the tutorial of transfer learning

### DIFF
--- a/examples/1-advanced/00-transfer-learning.py
+++ b/examples/1-advanced/00-transfer-learning.py
@@ -116,6 +116,10 @@ using a relatively simple python script:
 
 .. code-block:: python
 
+  import metatomic.torch
+  import torch
+
+
   def set_output_head(checkpoint, head_name):
       for state_dict_name in ["model_state_dict", "best_model_state_dict"]:
           state_dict = checkpoint.get(state_dict_name)


### PR DESCRIPTION
The current example script in the tutorial of transfer learning doesn't have imports. This PR aims at adding these imports and preventing users from encountering with the following error due to the missing of `metatomic.torch`
```
Traceback (most recent call last):
  File ".../reexport.py", line 28, in <module>
    checkpoint = torch.load(
                 ^^^^^^^^^^^
  File "...site-packages/torch/serialization.py", line 1530, in load
    return _load(
           ^^^^^^
  File ".../site-packages/torch/serialization.py", line 2122, in _load
    result = unpickler.load()
             ^^^^^^^^^^^^^^^^
RuntimeError: Tried to deserialize class __torch__.torch.classes.metatomic.ModelMetadata which is not known to the runtime. If this is a custom C++ class, make sure the appropriate code is linked.
```


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Maintainer/Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1018.org.readthedocs.build/en/1018/

<!-- readthedocs-preview metatrain end -->