### PR TITLE
Fix docs

### DIFF
--- a/docs/src/concepts/loss-functions.rst
+++ b/docs/src/concepts/loss-functions.rst
@@ -236,7 +236,7 @@ The values used in the above example are the ones used for PETMADDOS training an
 Ensemble Loss Function
 ----------------------
 
-An :ref:`architecture-llpr` ensemble can be further trained to improve its uncertainty quantification.
+An :ref:`arch-llpr` ensemble can be further trained to improve its uncertainty quantification.
 This is done by using the :py:class:`metatrain.utils.loss.TensorMapEnsembleLoss` function, which implements strictly proper scoring rules for probabilistic regression.
 
 Two of the available losses assume a Gaussian predictive distribution and operate only on the ensemble-predicted mean :math:`\mu` and standard deviation :math:`\sigma`.


### PR DESCRIPTION
Fixes a docs problem given by the simultaneous merging of #971 and #986

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1021.org.readthedocs.build/en/1021/

<!-- readthedocs-preview metatrain end -->