### PR TITLE
feat(export): add `gh` style interactions

### DIFF
--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -44,6 +44,7 @@ Added
 - The PET architecture now features a temperature hyperparameter for the softmax
   operation in attention.
 - The FlashMD architecture added fine-tuning capabilities similar to those of PET.
+- Metatrain now has a simpler CLI interface for HuggingFace models
 
 Changed
 #######

--- a/docs/src/getting-started/checkpoints.rst
+++ b/docs/src/getting-started/checkpoints.rst
@@ -69,6 +69,17 @@ Downloading private HuggingFace models is also supported, by specifying the
 corresponding API token with the ``--token`` flag or the ``HF_TOKEN`` environment
 variable.
 
+When working with HuggingFace, a more concise form may be used.
+
+.. code-block:: bash
+
+    # instead of
+    mtt export https://huggingface.co/lab-cosmo/upet/resolve/main/models/pet-mad-s-v1.0.2.ckpt
+    # we can use
+    mtt export lab-cosmo/upet models/pet-mad-s-v1.0.2.ckpt
+    # or with a revision (branch, tag, commit)
+    mtt export lab-cosmo/pet-mad models/pet-mad-v1.0.2.ckpt --revision=v1.0.2
+
 Keep in mind that a checkpoint (``.ckpt``) is only a temporary file, which can have
 several dependencies and may become unusable if the corresponding architecture is
 updated. In constrast, exported models (``.pt``) act as standalone files. For long-term

--- a/src/metatrain/utils/io.py
+++ b/src/metatrain/utils/io.py
@@ -98,21 +98,36 @@ def _hf_hub_download_url(
     revision = unquote(match.group("revision"))
     filename = unquote(match.group("filename"))
 
-    # Extract subfolder if applicable
-    parts = filename.split("/", 1)
-    if len(parts) == 2:
-        subfolder, filename = parts
-    else:
-        subfolder = None
-
     return hf_hub_download(
         repo_id=repo_id,
         filename=filename,
-        subfolder=subfolder,
         cache_dir=cache_dir,
         revision=revision,
         token=hf_token,
         endpoint=endpoint,
+    )
+
+
+def download_model_from_hf(
+    repo_id: str,
+    filename: str,
+    revision: Optional[str] = None,
+    token: Optional[str] = None,
+) -> str:
+    """
+    Download a model file from the Hugging Face Hub.
+
+    :param repo_id: The repository ID (e.g., "metatensor/metatrain-test").
+    :param filename: The filename within the repository (e.g., "model.ckpt").
+    :param revision: The specific revision (branch, tag, or commit hash) to download.
+    :param token: Hugging Face API token for private repositories.
+    :return: The local path to the downloaded file.
+    """
+    return hf_hub_download(
+        repo_id=repo_id,
+        filename=filename,
+        revision=revision,
+        token=token,
     )
 
 

--- a/tests/cli/test_export_model.py
+++ b/tests/cli/test_export_model.py
@@ -255,3 +255,57 @@ def test_export_checkpoint_with_metadata(monkeypatch, tmp_path):
     )
 
     assert f"This is the {model_name} model" in str(model.metadata())
+
+
+def test_huggingface_gh_interface(monkeypatch, tmp_path):
+    """Test that the export cli succeeds when exporting using the
+    GitHub-style interface (repo_id + filename)."""
+    monkeypatch.chdir(tmp_path)
+
+    hf_token = os.getenv("HUGGINGFACE_TOKEN_METATRAIN")
+    if hf_token is None or len(hf_token) == 0:
+        pytest.skip("HuggingFace token not found in environment.")
+
+    command = [
+        "mtt",
+        "export",
+        "metatensor/metatrain-test",
+        "model.ckpt",
+        f"--token={hf_token}",
+    ]
+
+    output = "model.pt"
+
+    subprocess.check_call(command)
+    assert Path(output).is_file()
+
+    # Test if extensions are saved
+    extensions_glob = glob.glob("extensions/")
+    assert len(extensions_glob) == 1
+
+    # Test that the model can be loaded
+    load_model(output, extensions_directory="extensions/")
+
+
+def test_huggingface_gh_interface_revision(monkeypatch, tmp_path):
+    """Test that the export cli succeeds when exporting using the
+    GitHub-style interface with a revision."""
+    monkeypatch.chdir(tmp_path)
+
+    hf_token = os.getenv("HUGGINGFACE_TOKEN_METATRAIN")
+    if hf_token is None or len(hf_token) == 0:
+        pytest.skip("HuggingFace token not found in environment.")
+
+    command = [
+        "mtt",
+        "export",
+        "metatensor/metatrain-test",
+        "model.ckpt",
+        "--revision=main",
+        f"--token={hf_token}",
+    ]
+
+    output = "model.pt"
+
+    subprocess.check_call(command)
+    assert Path(output).is_file()


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Closes #1023. This is implemented as an "additional" optional interface, so the "before" and "after" cases both work. 

FWIW I don't understand why we'd parse a hugging face URL to make the same library call anyway (i.e. what happens with the URL now). No additional dependencies are added either. In a follow up we could talk about maybe dropping the URL or making it more useful (i.e. support more kinds of URLs, importantly, the kind from a right click in the web interface... see #1023 for details)

# UX improvements

## With versions

**Before:**
```bash
❯ mtt export https://huggingface.co/lab-cosmo/pet-mad/resolve/v1.1.0/models/pet-mad-v1.1.0.ckpt
[2026-01-28 21:23:21][INFO] - Logging to file is disabled.
[2026-01-28 21:23:21][INFO] - Package version: 2025.12.dev98+g4c6ca13ca.d20260128
[2026-01-28 21:23:21][INFO] - Package directory: /home/rgoswami/Git/Github/epfl/pixi_envs/orgs/metatensor/metatrain/metatrain/src/metatrain
[2026-01-28 21:23:21][INFO] - Working directory: /home/rgoswami/Git/Github/epfl/tmp
[2026-01-28 21:23:21][INFO] - Executed command: mtt export https://huggingface.co/lab-cosmo/pet-mad/resolve/v1.1.0/models/pet-mad-v1.1.0.ckpt
[2026-01-28 21:23:21][INFO] - HTTP Request: HEAD https://huggingface.co/lab-cosmo/pet-mad/resolve/v1.1.0/models/pet-mad-v1.1.0.ckpt "HTTP/1.1 302 Found"
[2026-01-28 21:23:21][WARNING] - /home/rgoswami/Git/Github/epfl/pixi_envs/orgs/metatensor/metatrain/metatrain/src/metatrain/utils/io.py:211: UserWarning: trying to upgrade an old model checkpoint with unknown version, this might fail and require manual modifications
  warnings.warn(

[2026-01-28 21:23:21][INFO] - Using best model from epoch None
[2026-01-28 21:23:22][INFO] - Model exported to '/home/rgoswami/Git/Github/epfl/tmp/pet-mad-v1.1.0.pt'
```

**After**
```bash
❯ mtt export lab-cosmo/pet-mad models/pet-mad-v1.1.0.ckpt -b "v1.1.0"
[2026-01-28 21:22:07][INFO] - Logging to file is disabled.
[2026-01-28 21:22:07][INFO] - Package version: 2025.12.dev98+g4c6ca13ca.d20260128
[2026-01-28 21:22:07][INFO] - Package directory: /home/rgoswami/Git/Github/epfl/pixi_envs/orgs/metatensor/metatrain/metatrain/src/metatrain
[2026-01-28 21:22:07][INFO] - Working directory: /home/rgoswami/Git/Github/epfl/tmp
[2026-01-28 21:22:07][INFO] - Executed command: mtt export lab-cosmo/pet-mad models/pet-mad-v1.1.0.ckpt -b v1.1.0
[2026-01-28 21:22:07][INFO] - Downloading 'models/pet-mad-v1.1.0.ckpt' from 'lab-cosmo/pet-mad'...
[2026-01-28 21:22:07][INFO] - HTTP Request: HEAD https://huggingface.co/lab-cosmo/pet-mad/resolve/v1.1.0/models/pet-mad-v1.1.0.ckpt "HTTP/1.1 302 Found"
```

## Misc

Other setups work just as well:
```bash
# before
mtt export https://huggingface.co/lab-cosmo/upet/resolve/main/models/pet-mad-s-v1.0.2.ckpt
# after
mtt export lab-cosmo/upet models/pet-mad-s-v1.0.2.ckpt
```

# Contributor (creator of pull-request) checklist

 - [X] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [X] Issue referenced (for PRs that solve an issue)?

# Maintainer/Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1025.org.readthedocs.build/en/1025/

<!-- readthedocs-preview metatrain end -->