### PR TITLE
Clearer validation errors

### DIFF
--- a/ci/cscs.yml
+++ b/ci/cscs.yml
@@ -210,7 +210,7 @@ soap-bpnn-tests:
     SLURM_JOB_NUM_NODES: 1
     SLURM_PARTITION: normal
     SLURM_NTASKS: 1
-    SLURM_TIMELIMIT: '00:08:00'
+    SLURM_TIMELIMIT: '00:10:00'
     GIT_STRATEGY: fetch
 
 # Run tox tests (single GPU)

--- a/src/metatrain/share/base_hypers.py
+++ b/src/metatrain/share/base_hypers.py
@@ -2,10 +2,17 @@
 # We ignore misc errors in this file because TypedDict
 # with default values is not allowed by mypy.
 import warnings
-from typing import Annotated, Literal, Optional
+from typing import Annotated, Any, Literal, Optional
 
 from annotated_types import Interval
-from pydantic import AfterValidator, ConfigDict, NonNegativeInt, with_config
+from pydantic import (
+    AfterValidator,
+    ConfigDict,
+    Discriminator,
+    NonNegativeInt,
+    Tag,
+    with_config,
+)
 from typing_extensions import NotRequired, TypedDict
 
 
@@ -145,6 +152,37 @@ class SphericalTargetTypeHypers(TypedDict):
     spherical: SphericalTargetConfig
 
 
+def target_type_discriminator(v: Any) -> str | None:
+    """Discriminator function for the TargetType union.
+
+    It helps pydantic determine whether it is dealing with a scalar,
+    cartesian or spherical target. This will make pydantic try to
+    validate only against the relevant typed dict, which makes
+    validation errors much cleaner.
+
+    :param v: The value to discriminate.
+    :return: The tag of the type that pydantic should validate.
+    """
+    if isinstance(v, dict):
+        if "cartesian" in v:
+            return "cartesian"
+        elif "spherical" in v:
+            return "spherical"
+    elif isinstance(v, str) and v == "scalar":
+        return "scalar"
+    # Could not determine the target type, pydantic will raise a
+    # validation error with the appropriate message.
+    return None
+
+
+TargetType = Annotated[
+    Annotated[ScalarTargetTypeHyper, Tag("scalar")]
+    | Annotated[CartesianTargetTypeHypers, Tag("cartesian")]
+    | Annotated[SphericalTargetTypeHypers, Tag("spherical")],
+    Discriminator(target_type_discriminator),
+]
+
+
 @with_config(ConfigDict(extra="forbid", strict=True))
 class TargetHypers(TypedDict):
     """Hyperparameters for the targets in the dataset."""
@@ -192,9 +230,7 @@ class TargetHypers(TypedDict):
     If this and ``sample_kind`` are both provided and they are not
     consistent with each other, an error is raised.
     """
-    type: NotRequired[
-        ScalarTargetTypeHyper | CartesianTargetTypeHypers | SphericalTargetTypeHypers
-    ]
+    type: NotRequired[TargetType]
     """Specifies the type of the target.
 
     See :ref:`Fitting Generic Targets <fitting-generic-targets>` to understand
@@ -282,7 +318,81 @@ class DatasetDictHypers(TypedDict):
     """
 
 
-DatasetSpec = DatasetDictHypers | list[DatasetDictHypers] | str
+@with_config(ConfigDict(extra="forbid", strict=True))
+class IndicesOnlyHypers(TypedDict):
+    """
+    Config for validation/test sets that reference the training source via indices.
+    """
+
+    indices: list[int] | str
+    """Indices into the training set source file.
+
+    Can be either a list of integers (e.g., ``[0, 1, 5, 10]``) or a path to a
+    text file containing one index per line. The indices reference the same
+    source file as specified in ``training_set.systems.read_from``.
+    """
+
+
+def training_set_discriminator(v: Any) -> str | None:
+    """Discriminator function for the TrainingSetSpec union.
+
+    It helps pydantic determine whether it is dealing with a single dataset
+    specification, a list of dataset specifications or a string path to a
+    dataset. This will make pydantic try to validate only against the
+    relevant type, which makes validation errors much cleaner.
+
+    :param v: The value to discriminate.
+    :return: The tag of the type that pydantic should validate.
+    """
+    if isinstance(v, dict):
+        return "dict"
+    elif isinstance(v, list):
+        return "list"
+    elif isinstance(v, str):
+        return "str"
+    # Could not determine the training set spec type, pydantic will raise a
+    # validation error with the appropriate message.
+    return None
+
+
+def val_or_test_set_discriminator(v: Any) -> str | None:
+    """Discriminator function for the ValOrTestSetSpec union.
+
+    Same as the training discriminator, but accepts also numbers.
+
+    :param v: The value to discriminate.
+    :return: The tag of the type that pydantic should validate.
+    """
+    if isinstance(v, dict):
+        if len(v) == 1 and "indices" in v:
+            return "indices"
+        return "dict"
+    elif isinstance(v, list):
+        return "list"
+    elif isinstance(v, str):
+        return "str"
+    elif isinstance(v, (int, float)):
+        return "fraction"
+    # Could not determine the val/test set spec type, pydantic will raise a
+    # validation error with the appropriate message.
+    return None
+
+
+TrainingSetSpec = Annotated[
+    Annotated[DatasetDictHypers, Tag("dict")]
+    | Annotated[list[DatasetDictHypers], Tag("list")]
+    | Annotated[str, Tag("str")],
+    Discriminator(training_set_discriminator),
+]
+
+ValOrTestSetSpec = Annotated[
+    Annotated[IndicesOnlyHypers, Tag("indices")]
+    | Annotated[DatasetDictHypers, Tag("dict")]
+    | Annotated[list[DatasetDictHypers], Tag("list")]
+    | Annotated[str, Tag("str")]
+    | Annotated[int | float, Interval(ge=0.0, lt=1.0), Tag("fraction")],
+    Discriminator(val_or_test_set_discriminator),
+]
 
 
 @with_config(ConfigDict(extra="forbid", strict=True))
@@ -305,21 +415,6 @@ class EvalDatasetDictHypers(TypedDict):
 
 
 EvalHypers = EvalDatasetDictHypers | list[EvalDatasetDictHypers]
-
-
-@with_config(ConfigDict(extra="forbid", strict=True))
-class IndicesOnlyHypers(TypedDict):
-    """
-    Config for validation/test sets that reference the training source via indices.
-    """
-
-    indices: list[int] | str
-    """Indices into the training set source file.
-
-    Can be either a list of integers (e.g., ``[0, 1, 5, 10]``) or a path to a
-    text file containing one index per line. The indices reference the same
-    source file as specified in ``training_set.systems.read_from``.
-    """
 
 
 WandbConfig = dict
@@ -354,24 +449,16 @@ class BaseHypers(TypedDict):
 
     If ``None``, W&B logging is disabled."""
 
-    training_set: DatasetSpec
+    training_set: TrainingSetSpec
     """Specification of the training dataset."""
-    validation_set: (
-        IndicesOnlyHypers
-        | DatasetSpec
-        | Annotated[int | float, Interval(ge=0.0, lt=1.0)]
-    )
+    validation_set: ValOrTestSetSpec
     """Specification of the validation dataset.
 
     Can be a float fraction (e.g., ``0.1`` for 10% of training data),
     a full dataset specification, or an ``indices`` dict referencing
     the training source file.
     """
-    test_set: NotRequired[
-        IndicesOnlyHypers
-        | DatasetSpec
-        | Annotated[int | float, Interval(ge=0.0, lt=1.0)]
-    ]
+    test_set: NotRequired[ValOrTestSetSpec] = 0.0
     """Specification of the test dataset.
 
     Can be a float fraction (e.g., ``0.1`` for 10% of training data),

--- a/src/metatrain/utils/architectures.py
+++ b/src/metatrain/utils/architectures.py
@@ -71,7 +71,10 @@ def check_architecture_options(
     """
     hypers_classes = get_hypers_classes(name)
     validate_architecture_options(
-        options, hypers_classes["model"], hypers_classes["trainer"]
+        options,
+        hypers_classes["model"],
+        hypers_classes["trainer"],
+        architecture_name=name,
     )
 
 

--- a/src/metatrain/utils/pydantic.py
+++ b/src/metatrain/utils/pydantic.py
@@ -206,9 +206,9 @@ class MetatrainArchitectureValidationError(MetatrainValidationError):
             error_dict[top_level].append(err)
 
         error_str = (
-            f"{len(errors)} validation errors occurred for the  {self._architecture} "
-            if self._architecture
-            else " architecture options:\n"
+            f"{len(errors)} validation errors occurred for the "
+            + (f"{self._architecture} " if self._architecture else "")
+            + "architecture options:\n"
         )
 
         # Log errors for the model hyperparameters

--- a/src/metatrain/utils/pydantic.py
+++ b/src/metatrain/utils/pydantic.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any, Literal, Union
 from pydantic import BaseModel, Field, TypeAdapter, ValidationError, create_model
 from typing_extensions import NotRequired
 
+from ..share import base_hypers
 from ..share.base_hypers import BaseHypers, EvalHypers
 from .hypers import init_with_defaults
 
@@ -32,8 +33,10 @@ class MetatrainValidationError(Exception):
 
         # This is a field that was not expected
         if error["type"] == "extra_forbidden":
-            extra_field = ".".join([str(loc_part) for loc_part in error["loc"]])
-            return f"Unrecognized option '{extra_field}'."
+            error_loc = error["loc"]
+            cls = error_loc[-2]
+            field = error_loc[-1]
+            return f"Unrecognized option '{field}' for '{cls}'."
 
         # If it doesn't match any special case, use the default Pydantic formatting
         return self.default_pydantic(error)
@@ -48,7 +51,7 @@ class MetatrainValidationError(Exception):
         pydantic_error += f" [type={err['type']}, input_value={err['input']},"
         pydantic_error += f" input_type={err.get('type', 'unknown')}]"
 
-        pydantic_error += f"\n\tFor further information visit {err['url']}"
+        pydantic_error += f"\n  For further information visit {err['url']}"
         return pydantic_error
 
     def __str__(self) -> str:
@@ -56,20 +59,46 @@ class MetatrainValidationError(Exception):
 
         :return: The formatted error string to display to the user.
         """
-        error_str = f"{len(self.errors)} validation errors occurred:\n"
-        for i, err in enumerate(self.errors):
-            error_path = ".".join([str(loc_part) for loc_part in err["loc"]])
-            error_str += f"[Error {i}] {error_path}\n\t{self.get_error_string(err)}\n"
+        errors = self.errors
+        error_str = f"{len(errors)} validation errors occurred:\n"
+        for i, err in enumerate(errors):
+            error_str += (
+                f"\n---- [Error {i}] {self.get_loc_path(err['loc'])}"
+                f"\n\n  {self.get_error_string(err)}\n"
+            )
         return error_str
 
+    def get_loc_path(self, error_loc: tuple) -> str:
+        """Convert the error location tuple into a dot-separated string path.
 
-def validate(model_cls: Any, data: dict, **kwargs: Any) -> dict:
+        :param error_loc: The 'loc' field from a Pydantic error dictionary, which
+          is a tuple representing the location of the error in the input data.
+        :return: A string representing the path to the error location, with
+          certain internal ``pydantic`` function calls filtered out for readability.
+        """
+        return ".".join(
+            [
+                str(item)
+                for item in error_loc
+                if not str(item).startswith("function-after")
+                or str(item).startswith("function-before")
+            ]
+        )
+
+
+def validate(
+    model_cls: Any,
+    data: dict,
+    error_cls: type[MetatrainValidationError] = MetatrainValidationError,
+    **kwargs: Any,
+) -> dict:
     r"""Validate with pydantic, raising custom metatrain errors.
 
     :param model_cls: The Pydantic model class to use for validation.
       If it is not a pydantic model, it will be adapted to pydantic
       using ``pydantic.TypeAdapter``.
     :param data: The data to validate.
+    :param error_cls: The custom error class to raise if validation fails.
     :param \*\*kwargs: Additional keyword arguments to pass to the validation method.
 
     :return: The validated options, which have been sanitized.
@@ -81,25 +110,143 @@ def validate(model_cls: Any, data: dict, **kwargs: Any) -> dict:
         try:
             validated = model_cls.model_validate(data, **kwargs)
         except ValidationError as e:
-            raise MetatrainValidationError(model_cls, e.errors()) from e
+            raise error_cls(model_cls, e.errors()) from e
     else:
         adapter = TypeAdapter(model_cls)
         try:
             validated = adapter.validate_python(data, **kwargs)
         except ValidationError as e:
-            raise MetatrainValidationError(model_cls, e.errors()) from e
+            raise error_cls(model_cls, e.errors()) from e
 
     return validated
 
 
+class MetatrainArchitectureValidationError(MetatrainValidationError):
+    """Custom validation error for architecture options."""
+
+    _architecture: str | None = None
+
+    @classmethod
+    def for_architecture(
+        cls, name: str | None
+    ) -> type["MetatrainArchitectureValidationError"]:
+        if name is None:
+            return cls
+        return type(f"{cls.__name__}{name}", (cls,), {"_architecture": name})
+
+    def architecture_link(self, cls: str) -> str:
+        if self._architecture is None:
+            return ""
+
+        architecture_name = self._architecture.replace("experimental.", "").replace(
+            "deprecated.", ""
+        )
+
+        return f"https://docs.metatensor.org/metatrain/latest/architectures/generated/{architecture_name}.html#metatrain.{self._architecture}.documentation.{cls}"
+
+    def get_error_string(self, error: dict) -> str:
+        """Given an individual error from Pydantic, return a user-friendly string.
+
+        :param error: The Pydantic error dictionary.
+
+        :return: The formatted error string to display to the user.
+        """
+
+        hyper_type: Literal["model", "training"] = error["loc"][0]
+        field = error["loc"][1]
+        cls = "ModelHypers" if hyper_type == "model" else "TrainerHypers"
+
+        arch_link = self.architecture_link(cls)
+
+        if error["type"] == "extra_forbidden":
+            # This is a field that was not expected
+            error_loc = error["loc"]
+            field = error_loc[-1]
+
+            if len(error_loc) == 2:
+                msg = f"Unrecognized option '{field}' for {hyper_type} hyperparameters."
+                if arch_link:
+                    msg += (
+                        f"\n  For the available {hyper_type} hyperparameters see:"
+                        f"\n    {arch_link}"
+                    )
+            else:
+                return (
+                    f"Unrecognized option '{field}' for '{cls}'."
+                    f"\n  See the documentation of {cls}:"
+                    f"\n    {arch_link}"
+                )
+        else:
+            # Rest of cases.
+            msg = error["msg"]
+            msg += f" [type={error['type']}, input_value={error['input']},"
+            msg += f" input_type={error.get('type', 'unknown')}]"
+
+            msg += (
+                f"\n  For the documentation of '{field}', see:"
+                f"\n    {arch_link}.{field}"
+                "\n  To understand this pydantic validation error in general, see:"
+                f"\n    {error['url']}"
+            )
+        return msg
+
+    def __str__(self) -> str:
+        """Return a string representation of all validation errors.
+
+        :return: The formatted error string to display to the user.
+        """
+        errors = self.errors
+
+        # Organize errors by their top-level location (model vs training)
+        error_dict: dict[Literal["model", "training"], list[dict]] = {}
+        for err in errors:
+            top_level = err["loc"][0]
+            if top_level not in error_dict:
+                error_dict[top_level] = []
+            error_dict[top_level].append(err)
+
+        error_str = (
+            f"{len(errors)} validation errors occurred for the  {self._architecture} "
+            if self._architecture
+            else " architecture options:\n"
+        )
+
+        # Log errors for the model hyperparameters
+        if "model" in error_dict:
+            n_errors = len(error_dict["model"])
+            error_str += f"\n==== Errors in model hyperparameters ({n_errors}):\n"
+            for i, err in enumerate(error_dict["model"]):
+                error_str += (
+                    f"\n---- [Error {i}] {self.get_loc_path(err['loc'])}"
+                    f"\n\n  {self.get_error_string(err)}\n"
+                )
+        # Log errors for the training hyperparameters
+        if "training" in error_dict:
+            n_errors = len(error_dict["training"])
+            error_str += f"\n==== Errors in training hyperparameters ({n_errors}):\n"
+            for i, err in enumerate(error_dict["training"]):
+                error_str += (
+                    f"\n---- [Error {i}] {self.get_loc_path(err['loc'])}"
+                    f"\n\n  {self.get_error_string(err)}\n"
+                )
+
+        return error_str
+
+
 def validate_architecture_options(
-    options: dict, model_hypers: type, trainer_hypers: type
+    options: dict,
+    model_hypers: type,
+    trainer_hypers: type,
+    architecture_name: str | None = None,
 ) -> dict:
     """Validate architecture-specific options using Pydantic.
 
     :param options: The architecture options to validate.
     :param model_hypers: The ModelHypers class of the architecture.
     :param trainer_hypers: The TrainerHypers class of the architecture.
+    :param architecture_name: The name of the architecture. If provided, it is
+      used to give more specific error messages with links to the
+      architecture documentation.
 
     :return: The validated options, which have been sanitized.
     :raises MetatrainValidationError: If validation fails.
@@ -134,12 +281,143 @@ def validate_architecture_options(
         options["atomic_types"] = []
         added_atomic_types = True
 
-    validated = validate(ArchitectureOptions, options)
+    validated = validate(
+        ArchitectureOptions,
+        options,
+        error_cls=MetatrainArchitectureValidationError.for_architecture(
+            architecture_name
+        ),
+    )
 
     if added_atomic_types:
         del options["atomic_types"]
 
     return validated
+
+
+class MetatrainBaseValidationError(MetatrainValidationError):
+    """Custom validation error for base options."""
+
+    _known_base_hypers_classes = [
+        name for name in dir(base_hypers) if not name.startswith("_")
+    ]
+
+    def get_error_string(self, error: dict) -> str:
+        """Given an individual error from Pydantic, return a user-friendly string.
+
+        :param error: The Pydantic error dictionary.
+        :return: The formatted error string to display to the user.
+        """
+        cls = None
+        if len(error["loc"]) > 1 and error["loc"][0] == "architecture":
+            cls = "ArchitectureBaseHypers"
+
+        if error["type"] == "extra_forbidden":
+            # This is a field that was not expected
+            error_loc = error["loc"]
+
+            field = error_loc[-1]
+
+            if len(error_loc) == 1:
+                cls = "BaseHypers"
+            else:
+                cls = cls or error_loc[-2]
+
+            readable_cls = {
+                "ArchitectureBaseHypers": "architecture hyperparameters",
+                "BaseHypers": "base hyperparameters",
+            }.get(cls, cls)
+
+            if cls in self._known_base_hypers_classes:
+                return (
+                    f"Unrecognized option '{field}' for {readable_cls}."
+                    f"\n  For the available options of {readable_cls} see:"
+                    f"\n    https://docs.metatensor.org/metatrain/latest/dev-docs/base-hypers.html#metatrain.share.base_hypers.{cls}"
+                )
+            else:
+                return f"Unrecognized option '{field}'"
+        elif (
+            error["type"] == "union_tag_not_found"
+            and error["ctx"]["discriminator"] == "target_type_discriminator()"
+        ):
+            # Unable to determine the target type.
+            target = error["loc"][-3]
+            return (
+                f"Unable to determine the target type for target '{target}'."
+                f"\n  Received target type: {error['input']}."
+                f"\n  For the available type specifications see:"
+                f"\n    https://docs.metatensor.org/metatrain/latest/dev-docs/base-hypers.html#metatrain.share.base_hypers.TargetHypers.type"
+                f"\n  For an accessible tutorial on target types, see:"
+                f"\n    https://docs.metatensor.org/metatrain/latest/generated_examples/1-advanced/03-fitting-generic-targets.html"
+            )
+        elif error["type"] == "union_tag_not_found" and error["ctx"][
+            "discriminator"
+        ] in (
+            "training_set_discriminator()",
+            "val_or_test_set_discriminator()",
+        ):
+            # Unable to identify the kind of dataset specification provided.
+            dataset_name = error["loc"][-1]
+            base_hypers_link = ""
+            if len(error["loc"]) == 1:
+                base_hypers_link = (
+                    f"\n  For the definition of '{dataset_name}', see:"
+                    f"\n    https://docs.metatensor.org/metatrain/latest/dev-docs/base-hypers.html#metatrain.share.base_hypers.BaseHypers.{dataset_name}"
+                )
+            return (
+                f"Unable to process '{dataset_name}'."
+                f"\n  Received value: {error['input']}."
+                f"{base_hypers_link}"
+                f"\n  For a description on how to input datasets, see:"
+                f"\n    https://docs.metatensor.org/metatrain/latest/getting-started/train_yaml_config.html#data"
+            )
+        else:
+            # Rest of cases.
+            field = error["loc"][-1]
+
+            if len(error["loc"]) == 1:
+                cls = "BaseHypers"
+            else:
+                cls = cls or error["loc"][-2]
+
+            if error["type"] == "missing":
+                msg = f"Missing required option '{field}' for '{cls}'."
+            else:
+                msg = error["msg"]
+                msg += f" [type={error['type']}, input_value={error['input']},"
+                msg += f" input_type={error.get('type', 'unknown')}]"
+
+            if cls in self._known_base_hypers_classes:
+                if error["type"] == "invalid_key":
+                    msg += (
+                        f"\n  For the available options of {cls}, see:"
+                        f"\n    https://docs.metatensor.org/metatrain/latest/dev-docs/base-hypers.html#metatrain.share.base_hypers.{cls}"
+                    )
+                else:
+                    msg += (
+                        f"\n  For the documentation of '{field}', see:"
+                        f"\n    https://docs.metatensor.org/metatrain/latest/dev-docs/base-hypers.html#metatrain.share.base_hypers.{cls}.{field}"
+                    )
+
+            msg += (
+                "\n  To understand this pydantic validation error in general, see:"
+                f"\n    {error['url']}"
+            )
+            return msg
+
+    def __str__(self) -> str:
+        """Return a string representation of all validation errors.
+
+        :return: The formatted error string to display to the user.
+        """
+        errors = self.errors
+        error_str = f"{len(errors)} validation errors occurred for the base hypers:\n"
+        for i, err in enumerate(errors):
+            error_str += (
+                f"\n---- [Error {i}] {self.get_loc_path(err['loc'])}"
+                f"\n\n  {self.get_error_string(err)}\n"
+            )
+        return error_str
 
 
 def validate_base_options(options: dict) -> dict:
@@ -151,7 +429,7 @@ def validate_base_options(options: dict) -> dict:
 
     :raises MetatrainValidationError: If the options are invalid.
     """
-    return validate(BaseHypers, options)
+    return validate(BaseHypers, options, error_cls=MetatrainBaseValidationError)
 
 
 def validate_eval_options(options: dict) -> dict:

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -241,7 +241,7 @@ def test_train_unknown_arch_options(monkeypatch, tmp_path):
     """
     options = OmegaConf.create(options_str)
 
-    match = r"Unrecognized option 'training\.num_epoch'"
+    match = r"Unrecognized option 'num_epoch' for training hyperparameters"
     with pytest.raises(MetatrainValidationError, match=match):
         train_model(options)
 

--- a/tests/utils/test_architectures.py
+++ b/tests/utils/test_architectures.py
@@ -121,7 +121,7 @@ def test_check_architecture_options_error_raise():
     # Add an unknown parameter
     options["training"]["num_epochxxx"] = 10
 
-    match = r"Unrecognized option 'training\.num_epochxxx'"
+    match = r"Unrecognized option 'num_epochxxx' for training hyperparameters"
     with pytest.raises(MetatrainValidationError, match=match):
         check_architecture_options(name=name, options=options)
 

--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -2,10 +2,12 @@
 # Satisfying mypy in this file is hard because the fixtures
 # define different classes depending on the parametrization.
 import pytest
+import requests
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
 from metatrain.utils.pydantic import (
+    MetatrainArchitectureValidationError,
     MetatrainValidationError,
     validate,
     validate_architecture_options,
@@ -138,3 +140,19 @@ def test_indices_in_full_dataset_config():
         "validation_set": 0.1,
     }
     validate_base_options(config)  # should not raise
+
+
+def test_validation_error_doc_link():
+    error_cls = MetatrainArchitectureValidationError.for_architecture("pet")
+
+    error = error_cls(model=None, errors=[])
+
+    modelhypers_link = error.architecture_link("ModelHypers")
+    trainerhypers_link = error.architecture_link("TrainerHypers")
+
+    # Check that links are reachable.
+    # This does not check that the fragment identifier (thing after #)
+    # exists, but it is the best we can do without parsing the HTML.
+    for link in [modelhypers_link, trainerhypers_link]:
+        response = requests.head(link)
+        assert response.status_code == 200, f"Link {link} is not reachable"


### PR DESCRIPTION
With the last documentation refactor, documentation became better and more streamlined, but some validation errors became terrible to read.

The main issue is that when `Union`s fail to validate, there is no well-defined way of consistently telling which option was closest to passing, and therefore pydantic by default prints the reason why all the possible options failed. This affected mostly error messages on the dataset and target types, which are the most convoluted inputs in metatrain.

This PR:
- Adds discriminators to help pydantic understand which error to raise, reducing the amount of validation errors.
- For architecture options validation, it separates `model` from `training` errors so that it is visually easier to distinguish the errors.
- Whenever possible, adds links to metatrain documentation that might help the user.
