### PR TITLE
Unpin mace version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ phace = [
 llpr = []
 classifier = []
 mace = [
-    "mace-torch >=0.3.14, <0.3.15",
+    "mace-torch >=0.3.14",
     "e3nn"
 ]
 flashmd = []

--- a/src/metatrain/experimental/mace/documentation.py
+++ b/src/metatrain/experimental/mace/documentation.py
@@ -319,6 +319,8 @@ class TrainerHypers(TypedDict):
         - "readouts_lr_factor"
     
     Any missing keys are set to 1.0.
+
+    Only used if the mace version is >= 0.3.15. Otherwise ignored.
     """
 
     freeze: int = 0
@@ -326,6 +328,8 @@ class TrainerHypers(TypedDict):
 
     Can be positive or negative, e.g. -1 means the last layer is frozen.
     0 means all layers are active.
+
+    Only used if the mace version is >= 0.3.15. Otherwise ignored.
     """
 
     # General training parameters that are shared across architectures

--- a/src/metatrain/experimental/mace/documentation.py
+++ b/src/metatrain/experimental/mace/documentation.py
@@ -309,6 +309,24 @@ class TrainerHypers(TypedDict):
     """Learning rate factor"""
     lr_scheduler_patience: int = 50  # Named "scheduler_patience" in MACE
     """Scheduler patience."""
+    lr_params_factors: dict[str, float] = {}
+    """Learning rate factors to multiply on the original lr.
+    
+    Possible keys of the dictionary are:
+        - "embedding_lr_factor"
+        - "interactions_lr_factor"
+        - "products_lr_factor"
+        - "readouts_lr_factor"
+    
+    Any missing keys are set to 1.0.
+    """
+
+    freeze: int = 0
+    """Freeze layers from 1 to N (don't update their parameters during training).
+
+    Can be positive or negative, e.g. -1 means the last layer is frozen.
+    0 means all layers are active.
+    """
 
     # General training parameters that are shared across architectures
     distributed: bool = False

--- a/src/metatrain/experimental/mace/trainer.py
+++ b/src/metatrain/experimental/mace/trainer.py
@@ -3,6 +3,7 @@ import copy
 import logging
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
+import json
 
 import torch
 from mace.tools.scripts_utils import (
@@ -78,6 +79,8 @@ def get_optimizer_and_scheduler(
         lr_scheduler_gamma=trainer_hypers["lr_scheduler_gamma"],
         lr_factor=trainer_hypers["lr_factor"],
         scheduler_patience=trainer_hypers["lr_scheduler_patience"],
+        lr_params_factors=json.dumps(trainer_hypers["lr_params_factors"]),
+        freeze=trainer_hypers["freeze"],
     )
 
     # Take into account distributed training


### PR DESCRIPTION
Since #1050 , the MACE version was pinned because the new version of MACE resulted in errors.

This was because MACE introduced extra parameters that were not supported by the metatrain interface.

In this PR we support the new version and therefore unpin the dependency.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1094.org.readthedocs.build/en/1094/

<!-- readthedocs-preview metatrain end -->