### PR TITLE
Avoid overriding successive target regularizers in LLPR Cholesky decomposition

### DIFF
--- a/src/metatrain/llpr/model.py
+++ b/src/metatrain/llpr/model.py
@@ -686,19 +686,6 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
             regularization parameter until the matrix is positive-definite.
         """
 
-    def compute_cholesky_decomposition(
-        self, regularizer: Optional[float] = None
-    ) -> None:
-        """A function to compute the Cholesky decomposition of the covariance matrix.
-
-        The Cholesky decomposition is stored as a buffer in the model.
-
-        :param regularizer: A regularization parameter to ensure the matrix is
-            positive-definite. If not provided, the function will try to compute the
-            Cholesky decomposition without regularization and increase the
-            regularization parameter until the matrix is positive-definite.
-        """
-
         for name in self.outputs_list:
             print(name)
             uncertainty_name = _get_uncertainty_name(name)

--- a/src/metatrain/llpr/model.py
+++ b/src/metatrain/llpr/model.py
@@ -686,7 +686,21 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
             regularization parameter until the matrix is positive-definite.
         """
 
+    def compute_cholesky_decomposition(
+        self, regularizer: Optional[float] = None
+    ) -> None:
+        """A function to compute the Cholesky decomposition of the covariance matrix.
+
+        The Cholesky decomposition is stored as a buffer in the model.
+
+        :param regularizer: A regularization parameter to ensure the matrix is
+            positive-definite. If not provided, the function will try to compute the
+            Cholesky decomposition without regularization and increase the
+            regularization parameter until the matrix is positive-definite.
+        """
+
         for name in self.outputs_list:
+            print(name)
             uncertainty_name = _get_uncertainty_name(name)
             covariance = self._get_covariance(uncertainty_name).to(dtype=torch.float64)
             cholesky = self._get_cholesky(uncertainty_name)
@@ -702,12 +716,12 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
                 # Try with an increasingly high regularization parameter until
                 # the matrix is invertible
                 is_not_pd = True
-                regularizer = 1e-20
-                while is_not_pd and regularizer < 1e16:
+                r = 1e-20
+                while is_not_pd and r < 1e16:
                     try:
                         cholesky[:] = torch.linalg.cholesky(
                             0.5 * (covariance + covariance.T)
-                            + regularizer
+                            + r
                             * torch.eye(
                                 self.ll_feat_size,
                                 device=covariance.device,
@@ -716,7 +730,7 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
                         ).to(cholesky.dtype)
                         is_not_pd = False
                     except RuntimeError:
-                        regularizer *= 10.0
+                        r *= 10.0
                 if is_not_pd:
                     raise RuntimeError(
                         "Could not compute Cholesky decomposition. Something went "
@@ -724,8 +738,8 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
                     )
                 else:
                     logging.info(
-                        f"Used regularization parameter of {regularizer:.1e} to "
-                        "compute the Cholesky decomposition"
+                        f"Used regularization parameter of {r:.1e} to "
+                        f"compute the Cholesky decomposition for `{uncertainty_name}`"
                     )
 
     def calibrate(

--- a/src/metatrain/llpr/model.py
+++ b/src/metatrain/llpr/model.py
@@ -687,7 +687,6 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
         """
 
         for name in self.outputs_list:
-            print(name)
             uncertainty_name = _get_uncertainty_name(name)
             covariance = self._get_covariance(uncertainty_name).to(dtype=torch.float64)
             cholesky = self._get_cholesky(uncertainty_name)
@@ -726,7 +725,7 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
                 else:
                     logging.info(
                         f"Used regularization parameter of {r:.1e} to "
-                        f"compute the Cholesky decomposition for `{uncertainty_name}`"
+                        f"compute the Cholesky decomposition for `{name}`"
                     )
 
     def calibrate(


### PR DESCRIPTION
This fixes a bug which made successive targets all use the same regularizer

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1100.org.readthedocs.build/en/1100/

<!-- readthedocs-preview metatrain end -->