### PR TITLE
More complete dpa3 docs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -60,6 +60,11 @@ component_management:
       paths:
         - "src/metatrain/experimental/phace/.*"
 
+    - component_id: dpa3
+      name: DPA3
+      paths:
+        - "src/metatrain/experimental/dpa3/.*"
+
 ignore:
   # no need to report coverage of the test code themself
   - "src/metatrain/utils/testing/.*"

--- a/src/metatrain/experimental/dpa3/documentation.py
+++ b/src/metatrain/experimental/dpa3/documentation.py
@@ -1,5 +1,5 @@
 """
-DPA3 (experimental)
+DPA3 (Experimental)
 ======================
 
 This is an interface to the DPA3 (Deep Potential Attention 3) architecture
@@ -57,10 +57,21 @@ weights instead of training from scratch:
 Energy biases and standard deviations are extracted from the loaded model and
 handed to metatrain's composition model and scaler automatically.
 
-References
-----------
+{{SECTION_MODEL_HYPERS}}
 
-.. footbibliography::
+with the following definitions needed to fully understand some of the parameters:
+
+.. autoclass:: {{architecture_path}}.documentation.DescriptorHypers
+    :members:
+    :undoc-members:
+
+.. autoclass:: {{architecture_path}}.documentation.RepflowHypers
+    :members:
+    :undoc-members:
+
+.. autoclass:: {{architecture_path}}.documentation.FittingNetHypers
+    :members:
+    :undoc-members:
 
 """
 

--- a/tests/test_registered_archs.py
+++ b/tests/test_registered_archs.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import tomllib
+from omegaconf import OmegaConf
+
+from metatrain.utils.architectures import find_all_architectures
+
+
+def test_architecture_in_codecov():
+    """Test that all architectures are in codecov.yml for coverage reporting."""
+    all_arches = find_all_architectures()
+
+    # Parse codecov.yml
+    codecov_path = Path(__file__).parent.parent / ".codecov.yml"
+    conf = OmegaConf.load(codecov_path)
+
+    components = conf["component_management"]["individual_components"]
+    for arch in all_arches:
+        arch_name = arch.split(".")[-1]
+        for comp in components:
+            if comp["component_id"].lower() == arch_name.lower():
+                break
+        else:
+            raise ValueError(
+                f"Architecture '{arch}' is not included in .codecov.yml."
+                f" Please add it to the list of components in the file."
+            )
+
+
+def test_architecture_in_tox():
+    """Test that all architectures are in tox.ini for testing."""
+    all_arches = find_all_architectures()
+
+    tox_ini = Path(__file__).parent.parent / "tox.ini"
+    with open(tox_ini, "r") as f:
+        ini_content = f.readlines()
+
+    envlist = ini_content[
+        ini_content.index("envlist =\n") + 1 : ini_content.index("[testenv]\n")
+    ]
+    envlist = [line.strip() for line in envlist if line.strip()]
+
+    for arch in all_arches:
+        arch_tests = f"{arch.split('.')[-1].replace('_', '-')}-tests"
+        if arch_tests not in envlist:
+            raise ValueError(
+                f"Architecture tests for '{arch}' are not included in tox.ini"
+                f" of tox.ini. Please add a {arch_tests} environment and make"
+                " sure that the architecture tests are ran."
+            )
+
+
+def test_pyproject_toml_extras():
+    """Test that all architectures are included in pyproject.toml extras."""
+    all_arches = find_all_architectures()
+
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+    with open(pyproject_path, "rb") as f:
+        toml = tomllib.load(f)
+
+    for arch in all_arches:
+        arch_name = arch.split(".")[-1].replace("_", "-")
+        if arch_name not in toml["project"]["optional-dependencies"]:
+            raise ValueError(
+                f"Architecture '{arch}' is not included in pyproject.toml extras."
+                f" Please add it to the list of extras in the file."
+            )

--- a/tests/test_registered_archs.py
+++ b/tests/test_registered_archs.py
@@ -1,9 +1,16 @@
 from pathlib import Path
 
-import tomllib
+import pytest
 from omegaconf import OmegaConf
 
 from metatrain.utils.architectures import find_all_architectures
+
+
+TOML_AVAILABLE = True
+try:
+    import tomllib
+except ModuleNotFoundError:
+    TOML_AVAILABLE = False
 
 
 def test_architecture_in_codecov():
@@ -52,6 +59,9 @@ def test_architecture_in_tox():
 
 def test_pyproject_toml_extras():
     """Test that all architectures are included in pyproject.toml extras."""
+    if not TOML_AVAILABLE:
+        pytest.skip("tomllib is not available in this Python version")
+
     all_arches = find_all_architectures()
 
     pyproject_path = Path(__file__).parent.parent / "pyproject.toml"


### PR DESCRIPTION
I realised that the documentation was not showing the docs for the parameters of the descriptor and the fitting net.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1104.org.readthedocs.build/en/1104/

<!-- readthedocs-preview metatrain end -->