### PR TITLE
Added JSON schema to the docs

### DIFF
--- a/docs/src/architectures/generate.py
+++ b/docs/src/architectures/generate.py
@@ -1,4 +1,5 @@
 import ast
+import json
 import warnings
 from pathlib import Path
 from typing import TypedDict
@@ -13,6 +14,7 @@ from metatrain.utils.architectures import (
     write_hypers_yaml,
 )
 from metatrain.utils.hypers import get_hypers_list
+from metatrain.utils.pydantic import get_train_json_schema
 
 
 ARCHITECTURES_DIR = Path(__file__).parent
@@ -165,6 +167,11 @@ def setup_architectures_docs():
         write_hypers_yaml(architecture_name, yaml_path)
 
         generate_rst(architecture_name, yaml_path=yaml_path)
+
+    # Write JSON schema for the yaml options of mtt train
+    mtt_train_json_schema = get_train_json_schema(allow_missing_hypers=True)
+    with open(GENERATED_DIR / "mtt_train_schema.json", "w") as f:
+        json.dump(mtt_train_json_schema, f, indent=2)
 
 
 def generate_rst(

--- a/docs/src/architectures/generate.py
+++ b/docs/src/architectures/generate.py
@@ -1,4 +1,5 @@
 import ast
+import json
 import warnings
 from pathlib import Path
 from typing import TypedDict
@@ -13,12 +14,14 @@ from metatrain.utils.architectures import (
     write_hypers_yaml,
 )
 from metatrain.utils.hypers import get_hypers_list
+from metatrain.utils.pydantic import get_train_json_schema
 
 
 ARCHITECTURES_DIR = Path(__file__).parent
 TEMPLATES_DIR = ARCHITECTURES_DIR / "templates"
 DEFAULT_HYPERS_DIR = ARCHITECTURES_DIR / "default_hypers"
 GENERATED_DIR = ARCHITECTURES_DIR / "generated"
+SCHEMAS_DIR = GENERATED_DIR / "schemas"
 
 
 JINJA_ENV = Environment(
@@ -165,6 +168,12 @@ def setup_architectures_docs():
         write_hypers_yaml(architecture_name, yaml_path)
 
         generate_rst(architecture_name, yaml_path=yaml_path)
+
+    # Write JSON schema for the yaml options of mtt train
+    SCHEMAS_DIR.mkdir(exist_ok=True)
+    mtt_train_json_schema = get_train_json_schema(allow_missing_hypers=True)
+    with open(SCHEMAS_DIR / "mtt_train_schema.json", "w") as f:
+        json.dump(mtt_train_json_schema, f, indent=2)
 
 
 def generate_rst(

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -147,7 +147,10 @@ bibtex_reference_style = "author_year"
 # sitemap/SEO settings
 html_baseurl = "https://docs.metatensor.org/metatrain/latest/"  # prefix for the sitemap
 sitemap_url_scheme = "{link}"  # avoids language settings
-html_extra_path = ["robots.txt"]  # extra files to move
+html_extra_path = [
+    "robots.txt",
+    "architectures/generated/schemas",
+]  # extra files to move
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/src/getting-started/train_yaml_config.rst
+++ b/docs/src/getting-started/train_yaml_config.rst
@@ -3,6 +3,8 @@
 Training YAML Reference
 ***********************
 
+Download the :download:`JSON schema <../architectures/generated/mtt_train_schema.json>`.
+
 Overview
 ========
 

--- a/docs/src/getting-started/train_yaml_config.rst
+++ b/docs/src/getting-started/train_yaml_config.rst
@@ -3,6 +3,8 @@
 Training YAML Reference
 ***********************
 
+VS code can help you write metatrain YAML files, see :ref:`validation-vscode`!
+
 Overview
 ========
 
@@ -480,3 +482,40 @@ run so you don't have to set the ``config`` parameter.
     **Before** running also set up your credentials with ``wandb login`` from the
     command line. See `wandb login documentation
     <https://docs.wandb.ai/ref/cli/wandb-login>`_ for details on the setup.
+
+JSON Schema
+===========
+
+JSON schemas are a powerful tool to validate input files.
+The full ``metatrain`` training JSON schema can be downloaded by clicking :download:`this link <../architectures/generated/schemas/mtt_train_schema.json>`.
+
+.. _validation-vscode:
+
+Validation in VS code
+---------------------
+
+It is very easy to set up VS code to help you with writing metatrain YAML files.
+
+**Step 1**: Download the YAML extension (by Red Hat) from the marketplace.
+
+**Step 2**: Go to ``File > Preferences > Settings``, search for "yaml schemas", then click on "Edit in settings.json".
+There, add the following entry:
+
+.. code-block:: json
+
+    "yaml.schemas": {
+        "https://docs.metatensor.org/metatrain/latest/mtt_train_schema.json": "options.yaml"
+    }
+
+.. note::
+
+    If you are using a particular metatrain released version, you can replace ``latest`` with ``v<VERSION>``,
+    where ``<VERSION>`` is the version of metatrain you are using, which can be obtained with ``mtt --version``.
+    You can also just :download:`download the schema <../architectures/generated/schemas/mtt_train_schema.json>`
+    to a local file and replace the URL with the path to the local file.
+
+    If your input yaml files are not called ``options.yaml``, you can modify the right hand side of
+    the entry to match whatever you need, e.g. ``["mtt_*.yaml", "train.yaml"]`` to apply the schema
+    validation to all yaml files starting with ``mtt_`` or named ``train.yaml``.
+
+**Step 3**: Enjoy autocompletion, hyperparameter descriptions and error highlighting.

--- a/src/metatrain/utils/pydantic.py
+++ b/src/metatrain/utils/pydantic.py
@@ -155,16 +155,20 @@ def get_train_json_schema(allow_missing_hypers: bool) -> dict:
       have default values. If you want to use the JSON schema for
       validating the input once filled in with defaults, you should set
       this to ``False``.
+    :return: The JSON schema as a dictionary.
     """
     from .architectures import find_all_architectures, preload_documentation_module
 
-    def set_not_required_and_defaults(cls):
+    def set_not_required_and_defaults(cls: type) -> type:
         """Helper function to set all fields of a class as NotRequired
         and add default values if they exist.
 
         This is because ModelHypers and TrainerHypers are written to validate the
         options once all defaults have been filled in, but for a JSON schema to
         validate user input, we want to allow missing fields.
+
+        :param cls: The class to modify.
+        :return: The modified class.
         """
         annotations = {}
         for k, v in cls.__annotations__.items():

--- a/src/metatrain/utils/pydantic.py
+++ b/src/metatrain/utils/pydantic.py
@@ -1,9 +1,11 @@
 import logging
-from typing import Any
+from typing import Annotated, Any, Literal, Union
 
-from pydantic import BaseModel, TypeAdapter, ValidationError, create_model
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError, create_model
+from typing_extensions import NotRequired
 
 from ..share.base_hypers import BaseHypers
+from .hypers import init_with_defaults
 
 
 class MetatrainValidationError(Exception):
@@ -139,3 +141,88 @@ def validate_base_options(options: dict) -> None:
     :raises ValueError: If the options are invalid.
     """
     validate(BaseHypers, options)
+
+
+def get_train_json_schema(allow_missing_hypers: bool) -> dict:
+    """Generate a JSON schema for the training options.
+
+    This JSON schema is a full specification for the input yaml files of
+    ``mtt train``. Therefore, it includes all possible architectures.
+
+    :param allow_missing_hypers: Whether to allow missing hyperparameters.
+      If you want to use the JSON schema for validating user input, you
+      should set this to ``True``, as it will allow users to omit fields that
+      have default values. If you want to use the JSON schema for
+      validating the input once filled in with defaults, you should set
+      this to ``False``.
+    """
+    from .architectures import find_all_architectures, preload_documentation_module
+
+    def set_not_required_and_defaults(cls):
+        """Helper function to set all fields of a class as NotRequired
+        and add default values if they exist.
+
+        This is because ModelHypers and TrainerHypers are written to validate the
+        options once all defaults have been filled in, but for a JSON schema to
+        validate user input, we want to allow missing fields.
+        """
+        annotations = {}
+        for k, v in cls.__annotations__.items():
+            if allow_missing_hypers:
+                annotations[k] = NotRequired[v]
+            if hasattr(cls, k):
+                annotations[k] = Annotated[
+                    annotations[k], Field(default=getattr(cls, k))
+                ]
+        cls.__annotations__ = annotations
+        return cls
+
+    # Get the model for the architecture options of each architecture.
+    arch_models = []
+    for arch_name in find_all_architectures():
+        arch_doc = preload_documentation_module(arch_name)
+
+        ModelHypers = set_not_required_and_defaults(arch_doc.ModelHypers)
+        TrainerHypers = set_not_required_and_defaults(arch_doc.TrainerHypers)
+
+        ArchModel = create_model(
+            f"{arch_name}Architecture",
+            name=(
+                Literal[arch_name],
+                Field(
+                    description="Name of the architecture. The architecure options "
+                    "will depend on the chosen architecture."
+                ),
+            ),
+            atomic_types=(list[int], Field(default=None)),
+            model=(
+                ModelHypers,
+                Field(
+                    default=init_with_defaults(ModelHypers),
+                    description=ModelHypers.__doc__,
+                ),
+            ),
+            training=(
+                TrainerHypers,
+                Field(
+                    default=init_with_defaults(TrainerHypers),
+                    description=TrainerHypers.__doc__,
+                ),
+            ),
+            __config__={
+                "extra": "forbid",
+                "strict": True,
+                "use_attribute_docstrings": True,
+            },
+        )
+
+        arch_models.append(ArchModel)
+
+    # Build the global model for the training options, setting the
+    # architecture field to be a union of all the possible architectures.
+    _baseHypers = set_not_required_and_defaults(BaseHypers)
+    _baseHypers.__annotations__["architecture"] = Union[tuple(arch_models)]
+
+    mtttrain_model = TypeAdapter(_baseHypers)
+
+    return mtttrain_model.json_schema()

--- a/src/metatrain/utils/pydantic.py
+++ b/src/metatrain/utils/pydantic.py
@@ -1,10 +1,12 @@
 import inspect
 import logging
-from typing import Any
+from typing import Annotated, Any, Literal, Union
 
-from pydantic import BaseModel, TypeAdapter, ValidationError, create_model
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError, create_model
+from typing_extensions import NotRequired
 
 from ..share.base_hypers import BaseHypers, EvalHypers
+from .hypers import init_with_defaults
 
 
 class MetatrainValidationError(Exception):
@@ -162,3 +164,92 @@ def validate_eval_options(options: dict) -> dict:
     :raises MetatrainValidationError: If the options are invalid.
     """
     return validate(EvalHypers, options)
+
+
+def get_train_json_schema(allow_missing_hypers: bool) -> dict:
+    """Generate a JSON schema for the training options.
+
+    This JSON schema is a full specification for the input yaml files of
+    ``mtt train``. Therefore, it includes all possible architectures.
+
+    :param allow_missing_hypers: Whether to allow missing hyperparameters.
+      If you want to use the JSON schema for validating user input, you
+      should set this to ``True``, as it will allow users to omit fields that
+      have default values. If you want to use the JSON schema for
+      validating the input once filled in with defaults, you should set
+      this to ``False``.
+    :return: The JSON schema as a dictionary.
+    """
+    from .architectures import find_all_architectures, preload_documentation_module
+
+    def set_not_required_and_defaults(cls: type) -> type:
+        """Helper function to set all fields of a class as NotRequired
+        and add default values if they exist.
+
+        This is because ModelHypers and TrainerHypers are written to validate the
+        options once all defaults have been filled in, but for a JSON schema to
+        validate user input, we want to allow missing fields.
+
+        :param cls: The class to modify.
+        :return: The modified class.
+        """
+        annotations = {}
+        for k, v in cls.__annotations__.items():
+            if allow_missing_hypers:
+                annotations[k] = NotRequired[v]
+            if hasattr(cls, k):
+                annotations[k] = Annotated[
+                    annotations[k], Field(default=getattr(cls, k))
+                ]
+        cls.__annotations__ = annotations
+        return cls
+
+    # Get the model for the architecture options of each architecture.
+    arch_models = []
+    for arch_name in find_all_architectures():
+        arch_doc = preload_documentation_module(arch_name)
+
+        ModelHypers = set_not_required_and_defaults(arch_doc.ModelHypers)
+        TrainerHypers = set_not_required_and_defaults(arch_doc.TrainerHypers)
+
+        ArchModel = create_model(
+            f"{arch_name}Architecture",
+            name=(
+                Literal[arch_name],
+                Field(
+                    description="Name of the architecture. The architecure options "
+                    "will depend on the chosen architecture."
+                ),
+            ),
+            atomic_types=(list[int], Field(default=None)),
+            model=(
+                ModelHypers,
+                Field(
+                    default=init_with_defaults(ModelHypers),
+                    description=ModelHypers.__doc__,
+                ),
+            ),
+            training=(
+                TrainerHypers,
+                Field(
+                    default=init_with_defaults(TrainerHypers),
+                    description=TrainerHypers.__doc__,
+                ),
+            ),
+            __config__={
+                "extra": "forbid",
+                "strict": True,
+                "use_attribute_docstrings": True,
+            },
+        )
+
+        arch_models.append(ArchModel)
+
+    # Build the global model for the training options, setting the
+    # architecture field to be a union of all the possible architectures.
+    _baseHypers = set_not_required_and_defaults(BaseHypers)
+    _baseHypers.__annotations__["architecture"] = Union[tuple(arch_models)]
+
+    mtttrain_model = TypeAdapter(_baseHypers)
+
+    return mtttrain_model.json_schema()


### PR DESCRIPTION
This PR adds a full JSON schema for `mtt train` to the documentation website. Then services can download it to validate and autocomplete metatrain `options.yaml`.

Once the documentation is built I will write here an example of how to use it with VScode.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1105.org.readthedocs.build/en/1105/

<!-- readthedocs-preview metatrain end -->