### PR TITLE
Make MACE tests faster

### DIFF
--- a/src/metatrain/experimental/mace/tests/__init__.py
+++ b/src/metatrain/experimental/mace/tests/__init__.py
@@ -1,9 +1,0 @@
-import urllib.request
-from pathlib import Path
-
-
-mace_model_url = "https://github.com/ACEsuit/mace-mp/releases/download/mace_mp_0/2023-12-10-mace-128-L0_energy_epoch-249.model"
-model_path = Path(__file__).parent / "mace_small.model"
-
-if not model_path.exists():
-    urllib.request.urlretrieve(mace_model_url, model_path)

--- a/src/metatrain/experimental/mace/tests/test_basic.py
+++ b/src/metatrain/experimental/mace/tests/test_basic.py
@@ -1,9 +1,11 @@
 # mypy: disable-error-code="override"
 import copy
+import warnings
 from pathlib import Path
 from typing import Any
 
 import e3nn.util.jit
+import mace.modules as mace_modules
 import pytest
 import torch
 from e3nn import o3
@@ -35,13 +37,73 @@ class MACETests(ArchitectureTests):
         return Path(__file__).parent / "mace_small.model"
 
     @pytest.fixture(params=["from_hypers", "from_file"])
-    def mace_init_mode(self, request: pytest.FixtureRequest) -> str:
+    def mace_init_mode(
+        self, request: pytest.FixtureRequest, mace_model_path: Path
+    ) -> str:
         """Type of MACE model to use: loaded from file or built from hypers.
 
         :param request: Pytest fixture request.
 
         :return: Whether to load the MACE model from file.
         """
+
+        if request.param == "from_file" and not mace_model_path.exists():
+            # Save a small MACE model to disk
+            with warnings.catch_warnings():
+                # Don't show warnings from e3nn to user (these warnings
+                # only appear in old versions of e3nn)
+                warnings.filterwarnings(
+                    "ignore", "To copy construct from a tensor", UserWarning
+                )
+                warnings.filterwarnings(
+                    "ignore",
+                    "The TorchScript type system",
+                    UserWarning,
+                )
+                torch.manual_seed(0)
+                species = [1, 6, 7, 8]
+                hypers = copy.deepcopy(get_default_hypers("experimental.mace")["model"])
+                hypers["hidden_irreps"] = "10x0e + 10x1o + 10x2e"
+                hypers["correlation"] = 2
+                mace_model = mace_modules.ScaleShiftMACE(
+                    r_max=hypers["r_max"],
+                    num_bessel=hypers["num_radial_basis"],
+                    num_polynomial_cutoff=hypers["num_cutoff_basis"],
+                    max_ell=hypers["max_ell"],
+                    interaction_cls=mace_modules.interaction_classes[
+                        hypers["interaction"]
+                    ],
+                    num_interactions=hypers["num_interactions"],
+                    num_elements=len(species),
+                    hidden_irreps=o3.Irreps(hypers["hidden_irreps"]),
+                    edge_irreps=o3.Irreps(hypers["edge_irreps"])
+                    if hypers["edge_irreps"] is not None
+                    else None,
+                    atomic_energies=torch.linspace(-1, 1, len(species)),
+                    apply_cutoff=hypers["apply_cutoff"],
+                    avg_num_neighbors=hypers["avg_num_neighbors"],
+                    atomic_numbers=torch.tensor(species),
+                    pair_repulsion=hypers["pair_repulsion"],
+                    distance_transform=hypers["distance_transform"],
+                    correlation=hypers["correlation"],
+                    gate=mace_modules.gate_dict[hypers["gate"]]
+                    if hypers["gate"] is not None
+                    else None,
+                    interaction_cls_first=mace_modules.interaction_classes[
+                        hypers["interaction_first"]
+                    ],
+                    MLP_irreps=o3.Irreps(hypers["MLP_irreps"]),
+                    radial_MLP=hypers["radial_MLP"],
+                    radial_type=hypers["radial_type"],
+                    use_embedding_readout=hypers["use_embedding_readout"],
+                    use_last_readout_only=hypers["use_last_readout_only"],
+                    use_agnostic_product=hypers["use_agnostic_product"],
+                    atomic_inter_scale=0.4,
+                    atomic_inter_shift=2.8,
+                )
+
+                torch.save(mace_model, mace_model_path)
+
         return request.param
 
     @pytest.fixture
@@ -59,7 +121,7 @@ class MACETests(ArchitectureTests):
         return defaults
 
     @pytest.fixture
-    def minimal_model_hypers(self, mace_init_mode: str) -> dict:
+    def minimal_model_hypers(self, mace_init_mode: str, mace_model_path: Path) -> dict:
         """Minimal hyperparameters for the MACE model for fastest testing.
 
         :param mace_init_mode: How to initialize the MACE model.
@@ -73,7 +135,7 @@ class MACETests(ArchitectureTests):
             hypers["correlation"] = 1
             hypers["radial_MLP"] = [1, 1, 1]
         else:
-            hypers["mace_model"] = Path(__file__).parent / "mace_small.model"
+            hypers["mace_model"] = mace_model_path
         return hypers
 
 

--- a/src/metatrain/experimental/mace/tests/test_basic.py
+++ b/src/metatrain/experimental/mace/tests/test_basic.py
@@ -114,9 +114,9 @@ class MACETests(ArchitectureTests):
         :return: Hyperparameters for the model.
         """
         defaults = copy.deepcopy(get_default_hypers(self.architecture)["model"])
-        if mace_init_mode == "from_hypers":
-            defaults["hidden_irreps"] = "20x0e + 20x1o + 20x2e"
-        else:
+        defaults["hidden_irreps"] = "10x0e + 10x1o + 10x2e"
+        defaults["correlation"] = 2
+        if mace_init_mode == "from_file":
             defaults["mace_model"] = mace_model_path
         return defaults
 

--- a/src/metatrain/experimental/mace/tests/test_foundation.py
+++ b/src/metatrain/experimental/mace/tests/test_foundation.py
@@ -50,5 +50,9 @@ class TestFoundation(MACETests):
         mace_energy = atoms.get_potential_energy()
         mace_forces = atoms.get_forces()
 
-        assert abs(mta_energy - mace_energy) < 1e-9
-        assert ((mta_forces - mace_forces) ** 2).sum() < 1e-20
+        # Check that the energy and forces are the same
+        # The thresholds are fairly high because we are testing an untrained
+        # model, which is probably numerically unstable.
+        # If using a foundation model we can use here 1e-9 and 1e-20 respectively.
+        assert abs(mta_energy - mace_energy) < 1e-3
+        assert ((mta_forces - mace_forces) ** 2).sum() < 1e-9

--- a/src/metatrain/utils/testing/output.py
+++ b/src/metatrain/utils/testing/output.py
@@ -422,7 +422,7 @@ class OutputTests(ArchitectureTests):
         torch.set_default_dtype(torch.float64)
 
         try:
-            model = self.model_cls(model_hypers, dataset_info)
+            model = self.model_cls(model_hypers, dataset_info).to(torch.float64)
 
             # Since we don't yet support atomic predictions, we will test this by
             # predicting on a system with two monomers at a large distance


### PR DESCRIPTION
I realised that MACE tests were the ones taking the most time, and this PR reduces the time by a couple of minutes. They are still slow unfortunately, I think mainly because MACE takes a while to initialize and `torch.jit.script`, I will see if I can do something at some point later.

What I do in this PR is to avoid testing on a foundation model, I thought it was a nice idea but the model is quite big so things are very slow. Instead, I just write a small model to file, using the same structure that the foundation model had (i.e. the `ScaleShiftMACE` class).