### PR TITLE
Forgot to activate atomic basis tests in phace

### DIFF
--- a/src/metatrain/experimental/phace/tests/test_basic.py
+++ b/src/metatrain/experimental/phace/tests/test_basic.py
@@ -34,7 +34,7 @@ class PhACETests(ArchitectureTests):
 class TestOutput(OutputTests, PhACETests):
     is_equivariant_reflections = False
     equivariance_error_tolerance = 1e-4  # due to many layers in the default hypers
-    supports_spherical_atomic_basis_outputs = False
+    supports_spherical_atomic_basis_outputs = True
 
     @pytest.fixture
     def n_last_layer_features(self) -> int:


### PR DESCRIPTION
I forgot to do this in #1098 


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1110.org.readthedocs.build/en/1110/

<!-- readthedocs-preview metatrain end -->