### PR TITLE
Fix Symplectic FlashMD Aftermath

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,7 @@
 **/phace                @frostedoyster
 **/llpr                 @frostedoyster @SanggyuChong
 **/flashmd              @johannes-spies @frostedoyster
+**/flashmd_symplectic   @frostedoyster @johannes-spies
 **/classifier           @frostedoyster
 **/mace                 @pfebrer @jwa7
 **/dpa3                 @HaoZeke

--- a/README.md
+++ b/README.md
@@ -32,15 +32,16 @@ compatibility with various MD engines.
 Currently `metatrain` supports the following architectures for building an atomistic
 model:
 
-| Name                                     | Description                                                                                                                          |
-|------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| [PET][arch-pet]                          | Point Edge Transformer (PET), interatomic machine learning potential                                                                 |
-| [SOAP-BPNN][arch-soap_bpnn]              | A Behler-Parrinello neural network with SOAP features                                                                                |
-| [MACE][arch-mace]                        | A higher order equivariant message passing neural network.                                                                           |
-| [PhACE][arch-phace]                      | SO(3)-equivariant message-passing model with physical radial functions and fast tensor products.                                     |
-| [GAP][arch-gap]                          | Sparse Gaussian Approximation Potential (GAP) using Smooth Overlap of Atomic Positions (SOAP).                                       |
-| [FlashMD][arch-flashmd]                  | An architecture for the direct prediction of molecular dynamics                                                                      |
-| [DPA3][arch-dpa3]                        | An invariant graph neural network based on line graph series representations                                                         |
+| Name                                          | Description                                                                                                                          |
+|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| [PET][arch-pet]                               | Point Edge Transformer (PET), interatomic machine learning potential                                                                 |
+| [SOAP-BPNN][arch-soap_bpnn]                   | A Behler-Parrinello neural network with SOAP features                                                                                |
+| [MACE][arch-mace]                             | A higher order equivariant message passing neural network.                                                                           |
+| [PhACE][arch-phace]                           | SO(3)-equivariant message-passing model with physical radial functions and fast tensor products.                                     |
+| [GAP][arch-gap]                               | Sparse Gaussian Approximation Potential (GAP) using Smooth Overlap of Atomic Positions (SOAP).                                       |
+| [FlashMD][arch-flashmd]                       | An architecture for the direct prediction of molecular dynamics                                                                      |
+| [DPA3][arch-dpa3]                             | An invariant graph neural network based on line graph series representations                                                         |
+| [Symplectic FlashMD][arch-flashmd_symplectic] | A symplectic variant of FlashMD for the direct prediction of molecular dynamics.                                                     |
 
 <!-- marker-arch-links -->
 
@@ -53,6 +54,7 @@ on a PR, since the docs use this README file directly.-->
 [arch-pet]: https://docs.metatensor.org/metatrain/latest/architectures/generated/pet.html
 [arch-phace]: https://docs.metatensor.org/metatrain/latest/architectures/generated/phace.html
 [arch-soap_bpnn]: https://docs.metatensor.org/metatrain/latest/architectures/generated/soap_bpnn.html
+[arch-flashmd_symplectic]: https://docs.metatensor.org/metatrain/latest/architectures/generated/flashmd_symplectic.html
 
 <!-- marker-documentation -->
 

--- a/src/metatrain/experimental/flashmd_symplectic/documentation.py
+++ b/src/metatrain/experimental/flashmd_symplectic/documentation.py
@@ -1,6 +1,6 @@
 """
-Symplectic FlashMD
-==================
+Symplectic FlashMD (Experimental)
+=================================
 
 The symplectic variant of :ref:`FlashMD <arch-flashmd>`.
 

--- a/tests/test_registered_archs.py
+++ b/tests/test_registered_archs.py
@@ -60,7 +60,7 @@ def test_architecture_in_readme():
     all_arches = find_all_architectures()
 
     readme_path = Path(__file__).parent.parent / "README.md"
-    readme_content = readme_path.read_text()
+    readme_content = readme_path.read_text(encoding="utf-8")
 
     for arch in all_arches:
         # Strip experimental./deprecated. prefix — README lists bare names

--- a/tests/test_registered_archs.py
+++ b/tests/test_registered_archs.py
@@ -52,6 +52,24 @@ def test_codeowners_there():
         )
 
 
+def test_architecture_in_readme():
+    """Test that all architectures are mentioned in the README."""
+    all_arches = find_all_architectures()
+
+    readme_path = Path(__file__).parent.parent / "README.md"
+    readme_content = readme_path.read_text()
+
+    for arch in all_arches:
+        # Strip experimental./deprecated. prefix — README lists bare names
+        bare_name = arch.split(".")[-1]
+        # Match the anchor definition line, e.g. [arch-soap_bpnn]:
+        if f"[arch-{bare_name}]:" not in readme_content:
+            raise ValueError(
+                f"Architecture '{arch}' is not mentioned in README.md."
+                f" Please add an entry with an '[arch-{bare_name}]:' anchor."
+            )
+
+
 def test_architecture_in_codecov():
     """Test that all architectures are in codecov.yml for coverage reporting."""
     all_arches = find_all_architectures()

--- a/tests/test_registered_archs.py
+++ b/tests/test_registered_archs.py
@@ -24,6 +24,11 @@ def test_codeowners_there():
     # architecture setup, we can change this test.
 
     architectures = find_all_architectures()
+    # Strip any "experimental." or "deprecated." prefixes to get the directory names.
+    architectures = [
+        a.split(".")[-1] if "." in a else a for a in architectures
+    ]
+
     with open(codeowners_path, "r") as f:
         for line in f:
             if line.startswith("#") or not line.strip():
@@ -32,16 +37,13 @@ def test_codeowners_there():
 
             # Fortunately, the architecture names match the directory names.
             path = path[3:]  # Remove leading "**/"
-            if not (path in architectures or "experimental." + path in architectures):
+            if path not in architectures:
                 raise ValueError(
                     "Found architecture path in CODEOWNERS that does not match any "
                     "architecture: %s. Was it removed but you forgot to update the "
                     "CODEOWNERS file?" % path
                 )
-            if path in architectures:
-                architectures.remove(path)
-            else:
-                architectures.remove("experimental." + path)
+            architectures.remove(path)
 
             assert len(owners) > 0, (
                 f"No owners specified for architecture path '{path}' in CODEOWNERS. "

--- a/tests/test_registered_archs.py
+++ b/tests/test_registered_archs.py
@@ -64,6 +64,11 @@ def test_architecture_in_readme():
         bare_name = arch.split(".")[-1]
         # Match the anchor definition line, e.g. [arch-soap_bpnn]:
         if f"[arch-{bare_name}]:" not in readme_content:
+            # TODO: Decide whether we want to include `classifier` and `llpr` in the
+            # README.
+            if bare_name in ["classifier", "llpr"]:
+                continue
+
             raise ValueError(
                 f"Architecture '{arch}' is not mentioned in README.md."
                 f" Please add an entry with an '[arch-{bare_name}]:' anchor."

--- a/tests/test_registered_archs.py
+++ b/tests/test_registered_archs.py
@@ -25,9 +25,7 @@ def test_codeowners_there():
 
     architectures = find_all_architectures()
     # Strip any "experimental." or "deprecated." prefixes to get the directory names.
-    architectures = [
-        a.split(".")[-1] if "." in a else a for a in architectures
-    ]
+    architectures = [a.split(".")[-1] if "." in a else a for a in architectures]
 
     with open(codeowners_path, "r") as f:
         for line in f:

--- a/tests/test_registered_archs.py
+++ b/tests/test_registered_archs.py
@@ -13,6 +13,45 @@ except ModuleNotFoundError:
     TOML_AVAILABLE = False
 
 
+def test_codeowners_there():
+    """Test that an architeture has owners specified in CODEOWNERS."""
+    codeowners_path = Path(__file__).parent.parent / "CODEOWNERS"
+
+    # NOTE: For simplicity, this is a very basic parser. If there is a more complex
+    # architecture setup, we can change this test.
+
+    architectures = find_all_architectures()
+    with open(codeowners_path, "r") as f:
+        for line in f:
+            if line.startswith("#") or not line.strip():
+                continue
+            path, *owners = line.split()
+
+            # Fortunately, the architecture names match the directory names.
+            path = path[3:]  # Remove leading "**/"
+            if not (path in architectures or "experimental." + path in architectures):
+                raise ValueError(
+                    "Found architecture path in CODEOWNERS that does not match any "
+                    "architecture: %s. Was it removed but you forgot to update the "
+                    "CODEOWNERS file?" % path
+                )
+            if path in architectures:
+                architectures.remove(path)
+            else:
+                architectures.remove("experimental." + path)
+
+            assert len(owners) > 0, (
+                f"No owners specified for architecture path '{path}' in CODEOWNERS. "
+                "Please add at least one owner."
+            )
+
+    for architecture in architectures:
+        raise ValueError(
+            f"Architecture '{architecture}' does not have an entry in CODEOWNERS. "
+            "Please add an entry for it with at least one owner."
+        )
+
+
 def test_architecture_in_codecov():
     """Test that all architectures are in codecov.yml for coverage reporting."""
     all_arches = find_all_architectures()

--- a/tests/test_registered_archs.py
+++ b/tests/test_registered_archs.py
@@ -3,7 +3,10 @@ from pathlib import Path
 import pytest
 from omegaconf import OmegaConf
 
-from metatrain.utils.architectures import find_all_architectures
+from metatrain.utils.architectures import (
+    find_all_architectures,
+    preload_documentation_module,
+)
 
 
 TOML_AVAILABLE = True
@@ -137,3 +140,18 @@ def test_pyproject_toml_extras():
                 f"Architecture '{arch}' is not included in pyproject.toml extras."
                 f" Please add it to the list of extras in the file."
             )
+
+
+def test_experimental_archs_have_experimental_in_title():
+    """Test that experimental architectures have '(Experimental)' in their doc title."""
+    all_arches = find_all_architectures()
+    experimental_arches = [a for a in all_arches if a.startswith("experimental.")]
+
+    for arch in experimental_arches:
+        doc_module = preload_documentation_module(arch)
+        docstring = doc_module.__doc__ or ""
+        first_line = next((line for line in docstring.splitlines() if line.strip()), "")
+        assert "(Experimental)" in first_line, (
+            f"Architecture '{arch}' is experimental but its documentation title "
+            f"does not contain '(Experimental)'. First line was: {first_line!r}"
+        )


### PR DESCRIPTION
In the symplectic FlashMD PR (#1010), we forgot the following things:

* Add the architecture to the `CODEOWNERS` files
* Update `README.md` such that the architecture is mentioned there
* Make sure that the experimental architecture is marked as such in the docs (add `(Experimental)` to the doc string)

In addition to changing these things for symplectic FlashMD, this PR also adds tests to enforce the three points for all architectures.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1111.org.readthedocs.build/en/1111/

<!-- readthedocs-preview metatrain end -->