### PR TITLE
Densify computation of composition and scaler weights for atomic basis targets

### DIFF
--- a/src/metatrain/experimental/mace/model.py
+++ b/src/metatrain/experimental/mace/model.py
@@ -26,7 +26,6 @@ from metatrain.utils.additive import CompositionModel
 from metatrain.utils.data import DatasetInfo, TargetInfo
 from metatrain.utils.data.atomic_basis_helpers import (
     densify_atomic_basis_dataset_info,
-    densify_atomic_basis_target,
     sparsify_atomic_basis_target,
 )
 from metatrain.utils.dtype import dtype_to_str
@@ -241,11 +240,14 @@ class MetaMACE(ModelInterface[ModelHypers]):
         # ---------------------------
         #    Add heads for targets
         # ---------------------------
+        # Modified dataset_info with the targets as they will be seen by
+        # the model during training.
+        train_dataset_info = self._train_dataset_info(dataset_info)
 
         # Create heads for each target, store the layout for each of them.
         self.heads = torch.nn.ModuleDict()
         self.layouts: Dict[str, TensorMap] = {}
-        for target_name, target_info in dataset_info.targets.items():
+        for target_name, target_info in train_dataset_info.targets.items():
             self._add_output(target_name, target_info)
 
         self.layouts["mtt::aux::mace_features"] = get_e3nn_mts_layout(
@@ -271,11 +273,6 @@ class MetaMACE(ModelInterface[ModelHypers]):
         # Data preprocessing modules
         # ---------------------------
 
-        # as MACE handles atomic basis targets in the densified form, we modify the
-        # layouts of the atomic basis targets in dataset_info, specifically for passing
-        # to the composition model and scaler. This only modifies atomic basis targets.
-        dataset_info_dense = densify_atomic_basis_dataset_info(dataset_info)
-
         # The composition model and scaler are handled by the trainer during training.
         # Their purpose is to adapt the data for optimal training.
         # At evaluation time, the model applies them on forward.
@@ -286,14 +283,14 @@ class MetaMACE(ModelInterface[ModelHypers]):
                 atomic_types=self.atomic_types,
                 targets={
                     target_name: target_info
-                    for target_name, target_info in dataset_info_dense.targets.items()
+                    for target_name, target_info in train_dataset_info.targets.items()
                     if CompositionModel.is_valid_target(target_name, target_info)
                 },
             ),
         )
         self.additive_models = torch.nn.ModuleList([composition_model])
 
-        self.scaler = Scaler(hypers={}, dataset_info=dataset_info_dense)
+        self.scaler = Scaler(hypers={}, dataset_info=train_dataset_info)
 
         self.finetune_config: Dict[str, Any] = {}
 
@@ -318,25 +315,29 @@ class MetaMACE(ModelInterface[ModelHypers]):
         }
         self.has_new_targets = len(new_targets) > 0
 
+        # Modified dataset_info with the targets as they will be seen by
+        # the model during training.
+        train_dataset_info = self._train_dataset_info(dataset_info)
+
         # Add extra heads for the new targets
-        for target_name, target in new_targets.items():
-            self._add_output(target_name, target)
+        for target_name in new_targets:
+            self._add_output(target_name, train_dataset_info.targets[target_name])
 
         self.dataset_info = merged_info
 
         # restart the composition and scaler models
         self.additive_models[0] = self.additive_models[0].restart(
             dataset_info=DatasetInfo(
-                length_unit=dataset_info.length_unit,
+                length_unit=train_dataset_info.length_unit,
                 atomic_types=self.dataset_info.atomic_types,
                 targets={
                     target_name: target_info
-                    for target_name, target_info in dataset_info.targets.items()
+                    for target_name, target_info in train_dataset_info.targets.items()
                     if CompositionModel.is_valid_target(target_name, target_info)
                 },
             ),
         )
-        self.scaler = self.scaler.restart(dataset_info)
+        self.scaler = self.scaler.restart(train_dataset_info)
 
         return self
 
@@ -643,6 +644,18 @@ class MetaMACE(ModelInterface[ModelHypers]):
 
         return model
 
+    def _train_dataset_info(self, dataset_info: DatasetInfo) -> DatasetInfo:
+        """Converts the original dataset info to one corresponding to what the
+        model will see during training, which depends on transforms applied to
+        the targets during data loading.
+
+        :param dataset_info: Original dataset info describing the targets as
+            they are in the raw data.
+        :return: Modified dataset info describing the targets as they will be
+            seen by the model during training.
+        """
+        return densify_atomic_basis_dataset_info(dataset_info)
+
     def _add_output(self, target_name: str, target_info: TargetInfo) -> None:
         """
         Register a new output target by creating corresponding heads and last layers.
@@ -657,11 +670,7 @@ class MetaMACE(ModelInterface[ModelHypers]):
                     "MetaMACE does not support Cartesian tensors with rank > 1."
                 )
 
-        output_layout = target_info.layout
-        if target_info.is_atomic_basis:
-            output_layout = densify_atomic_basis_target(output_layout, output_layout)
-
-        self.layouts[target_name] = output_layout
+        self.layouts[target_name] = target_info.layout
 
         if target_name == self.hypers["mace_head_target"]:
             # Fake head that will not compute the target, but will help
@@ -671,7 +680,7 @@ class MetaMACE(ModelInterface[ModelHypers]):
             )
         else:
             output_info = copy.deepcopy(target_info)
-            output_info.layout = output_layout
+            output_info.layout = target_info.layout
             head = NonLinearHead(
                 irreps_in=self.features_irreps,
                 irreps_out=target_info_to_e3nn_irreps(output_info),

--- a/src/metatrain/experimental/mace/model.py
+++ b/src/metatrain/experimental/mace/model.py
@@ -25,6 +25,7 @@ from metatrain.utils.abc import ModelInterface
 from metatrain.utils.additive import CompositionModel
 from metatrain.utils.data import DatasetInfo, TargetInfo
 from metatrain.utils.data.atomic_basis_helpers import (
+    densify_atomic_basis_dataset_info,
     densify_atomic_basis_target,
     sparsify_atomic_basis_target,
 )
@@ -270,6 +271,11 @@ class MetaMACE(ModelInterface[ModelHypers]):
         # Data preprocessing modules
         # ---------------------------
 
+        # as MACE handles atomic basis targets in the densified form, we modify the
+        # layouts of the atomic basis targets in dataset_info, specifically for passing
+        # to the composition model and scaler. This only modifies atomic basis targets.
+        dataset_info_dense = densify_atomic_basis_dataset_info(dataset_info)
+
         # The composition model and scaler are handled by the trainer during training.
         # Their purpose is to adapt the data for optimal training.
         # At evaluation time, the model applies them on forward.
@@ -280,14 +286,14 @@ class MetaMACE(ModelInterface[ModelHypers]):
                 atomic_types=self.atomic_types,
                 targets={
                     target_name: target_info
-                    for target_name, target_info in dataset_info.targets.items()
+                    for target_name, target_info in dataset_info_dense.targets.items()
                     if CompositionModel.is_valid_target(target_name, target_info)
                 },
             ),
         )
         self.additive_models = torch.nn.ModuleList([composition_model])
 
-        self.scaler = Scaler(hypers={}, dataset_info=dataset_info)
+        self.scaler = Scaler(hypers={}, dataset_info=dataset_info_dense)
 
         self.finetune_config: Dict[str, Any] = {}
 
@@ -447,6 +453,10 @@ class MetaMACE(ModelInterface[ModelHypers]):
 
         # At evaluation, we also introduce the scaler and additive contributions
         if not self.training:
+            return_dict = self.scaler(systems, return_dict)
+            self.add_additive_contributions(
+                return_dict, systems, outputs, selected_atoms
+            )
             # For atomic basis targets, sparsify to create blocks with "atom_type"
             # in the key dimensions, and ensure properties are unpadded.
             targets = self.dataset_info.targets
@@ -457,10 +467,6 @@ class MetaMACE(ModelInterface[ModelHypers]):
                         v,
                         targets[k].layout,
                     )
-            return_dict = self.scaler(systems, return_dict)
-            self.add_additive_contributions(
-                return_dict, systems, outputs, selected_atoms
-            )
 
         return return_dict
 

--- a/src/metatrain/experimental/mace/trainer.py
+++ b/src/metatrain/experimental/mace/trainer.py
@@ -209,6 +209,16 @@ class Trainer(TrainerInterface):
             additive_model.to(dtype=torch.float64)
         model.scaler.to(dtype=torch.float64)
 
+        # Set up transformations
+        dataset_info = model.dataset_info
+        train_targets = dataset_info.targets
+        requested_neighbor_lists = get_requested_neighbor_lists(model)
+        atomic_basis_transform, atomic_basis_reverse_transform = (
+            get_prepare_atomic_basis_targets_transform(
+                train_targets, dataset_info.extra_data
+            )
+        )
+
         logging.info("Calculating composition weights")
         model.additive_models[0].train_model(  # this is the composition model
             train_datasets,
@@ -216,6 +226,7 @@ class Trainer(TrainerInterface):
             self.hypers["batch_size"],
             is_distributed,
             {**model.get_fixed_composition_weights(), **self.hypers["atomic_baseline"]},
+            initial_transforms=[atomic_basis_transform],
         )
 
         if self.hypers["scale_targets"]:
@@ -229,6 +240,7 @@ class Trainer(TrainerInterface):
                     **model.get_fixed_scaling_weights(),
                     **self.hypers["fixed_scaling_weights"],
                 },
+                initial_transforms=[atomic_basis_transform],
             )
 
         logging.info("Setting up data loaders")
@@ -272,21 +284,13 @@ class Trainer(TrainerInterface):
         model.scaler.scales_to(device=device, dtype=torch.float64)
 
         # Create a collate function:
-        dataset_info = model.dataset_info
-        train_targets = dataset_info.targets
-        requested_neighbor_lists = get_requested_neighbor_lists(model)
-        atomic_basis_transform, atomic_basis_reverse_transform = (
-            get_prepare_atomic_basis_targets_transform(
-                train_targets, dataset_info.extra_data
-            )
-        )
         collate_fn = CollateFn(
             target_keys=list(train_targets.keys()),
             callables=[
+                atomic_basis_transform,
                 get_system_with_neighbor_lists_transform(requested_neighbor_lists),
                 get_remove_additive_transform(additive_models, train_targets),
                 get_remove_scale_transform(scaler),
-                atomic_basis_transform,
             ],
             batch_atom_bounds=self.hypers["batch_atom_bounds"],
         )
@@ -450,21 +454,26 @@ class Trainer(TrainerInterface):
                     torch.distributed.all_reduce(train_loss_batch)
                 train_loss += train_loss_batch.item()
 
-                # if any atomic basis outputs are present, reverse the transform
-                # before calculating metrics
-                systems, targets, extra_data = atomic_basis_reverse_transform(
-                    systems, targets, extra_data
-                )
-                systems, predictions, _ = atomic_basis_reverse_transform(
-                    systems, predictions, {}
-                )
-
                 scaled_predictions = (model.module if is_distributed else model).scaler(
                     systems, predictions
                 )
                 scaled_targets = (model.module if is_distributed else model).scaler(
                     systems, targets
                 )
+
+                if self.hypers["log_separate_blocks"]:
+                    # if any atomic basis outputs are present and metrics are to be
+                    # reported per-block, reverse the transform (i.e. sparsify)
+                    # before calculating metrics
+                    systems, scaled_targets, extra_data = (
+                        atomic_basis_reverse_transform(
+                            systems, scaled_targets, extra_data
+                        )
+                    )
+                    systems, scaled_predictions, _ = atomic_basis_reverse_transform(
+                        systems, scaled_predictions, {}
+                    )
+
                 train_rmse_calculator.update(
                     scaled_predictions, scaled_targets, extra_data
                 )
@@ -521,21 +530,26 @@ class Trainer(TrainerInterface):
                         torch.distributed.all_reduce(val_loss_batch)
                     val_loss += val_loss_batch.item()
 
-                    # if any atomic basis outputs are present, reverse the transform
-                    # before calculating metrics
-                    systems, targets, extra_data = atomic_basis_reverse_transform(
-                        systems, targets, extra_data
-                    )
-                    systems, predictions, _ = atomic_basis_reverse_transform(
-                        systems, predictions, {}
-                    )
-
                     scaled_predictions = (
                         model.module if is_distributed else model
                     ).scaler(systems, predictions)
                     scaled_targets = (model.module if is_distributed else model).scaler(
                         systems, targets
                     )
+
+                    if self.hypers["log_separate_blocks"]:
+                        # if any atomic basis outputs are present and metrics are to be
+                        # reported per-block, reverse the transform (i.e. sparsify)
+                        # before calculating metrics
+                        systems, scaled_targets, extra_data = (
+                            atomic_basis_reverse_transform(
+                                systems, scaled_targets, extra_data
+                            )
+                        )
+                        systems, scaled_predictions, _ = atomic_basis_reverse_transform(
+                            systems, scaled_predictions, {}
+                        )
+
                     val_rmse_calculator.update(
                         scaled_predictions, scaled_targets, extra_data
                     )

--- a/src/metatrain/experimental/phace/model.py
+++ b/src/metatrain/experimental/phace/model.py
@@ -27,7 +27,6 @@ from metatrain.utils.abc import ModelInterface
 from metatrain.utils.additive import ZBL, CompositionModel
 from metatrain.utils.data.atomic_basis_helpers import (
     densify_atomic_basis_dataset_info,
-    densify_atomic_basis_target,
     sparsify_atomic_basis_target,
 )
 from metatrain.utils.data.dataset import DatasetInfo, TargetInfo
@@ -74,9 +73,13 @@ class PhACE(ModelInterface[ModelHypers]):
         self.dataset_info = dataset_info
         self.hypers = hypers
 
+        # Modified dataset_info with the targets as they will be seen by
+        # the model during training.
+        train_dataset_info = self._train_dataset_info(dataset_info)
+
         # Two types of model wrapper: one with gradients (training) and one without
         # (torchscript-based export).
-        base_model = BaseModel(hypers, dataset_info)
+        base_model = BaseModel(hypers, train_dataset_info)
         self.fake_gradient_model = FakeGradientModel(base_model)
         self.gradient_model = GradientModel(base_model)
         self.module = self.fake_gradient_model
@@ -116,50 +119,46 @@ class PhACE(ModelInterface[ModelHypers]):
         self._sph_to_cart_rank2 = W
 
         self.mlp_head_num_layers = self.hypers["mlp_head_num_layers"]
-        for target_name, target_info in dataset_info.targets.items():
+        for target_name, target_info in train_dataset_info.targets.items():
             self._add_output(target_name, target_info)
 
         self.last_layer_feature_size = self.k_max_l[0]
-
-        # as PhACE handles atomic basis targets in the densified form, we modify the
-        # layouts of the atomic basis targets in dataset_info, specifically for passing
-        # to the composition model and scaler. This only modifies atomic basis targets.
-        dataset_info_dense = densify_atomic_basis_dataset_info(dataset_info)
 
         # additive models: these are handled by the trainer at training
         # time, and they are added to the output at evaluation time
         composition_model = CompositionModel(
             hypers={},
             dataset_info=DatasetInfo(
-                length_unit=dataset_info.length_unit,
+                length_unit=train_dataset_info.length_unit,
                 atomic_types=self.atomic_types,
                 targets={
                     target_name: target_info
-                    for target_name, target_info in dataset_info_dense.targets.items()
+                    for target_name, target_info in train_dataset_info.targets.items()
                     if CompositionModel.is_valid_target(target_name, target_info)
                 },
             ),
         )
         additive_models = [composition_model]
         if self.hypers["zbl"]:
+            zbl_targets = {
+                target_name: target_info
+                for target_name, target_info in train_dataset_info.targets.items()
+                if ZBL.is_valid_target(target_name, target_info)
+            }
             additive_models.append(
                 ZBL(
                     {},
                     dataset_info=DatasetInfo(
-                        length_unit=dataset_info.length_unit,
+                        length_unit=train_dataset_info.length_unit,
                         atomic_types=self.atomic_types,
-                        targets={
-                            target_name: target_info
-                            for target_name, target_info in dataset_info.targets.items()
-                            if ZBL.is_valid_target(target_name, target_info)
-                        },
+                        targets=zbl_targets,
                     ),
                 )
             )
         self.additive_models = torch.nn.ModuleList(additive_models)
 
         # scaler: this is also handled by the trainer at training time
-        self.scaler = Scaler(hypers={}, dataset_info=dataset_info_dense)
+        self.scaler = Scaler(hypers={}, dataset_info=train_dataset_info)
 
         self.single_label = Labels.single()
 
@@ -186,25 +185,29 @@ class PhACE(ModelInterface[ModelHypers]):
                 "The PhACE model does not support adding new atomic types."
             )
 
+        # Modified dataset_info with the targets as they will be seen by
+        # the model during training.
+        train_dataset_info = self._train_dataset_info(dataset_info)
+
         # register new outputs as new last layers
-        for target_name, target in new_targets.items():
-            self._add_output(target_name, target)
+        for target_name in new_targets:
+            self._add_output(target_name, train_dataset_info.targets[target_name])
 
         self.dataset_info = merged_info
 
         # restart the composition and scaler models
         self.additive_models[0].restart(
             dataset_info=DatasetInfo(
-                length_unit=dataset_info.length_unit,
+                length_unit=train_dataset_info.length_unit,
                 atomic_types=self.atomic_types,
                 targets={
                     target_name: target_info
-                    for target_name, target_info in dataset_info.targets.items()
+                    for target_name, target_info in train_dataset_info.targets.items()
                     if CompositionModel.is_valid_target(target_name, target_info)
                 },
             ),
         )
-        self.scaler.restart(dataset_info)
+        self.scaler.restart(train_dataset_info)
 
         return self
 
@@ -596,6 +599,18 @@ class PhACE(ModelInterface[ModelHypers]):
 
         return AtomisticModel(self.eval(), metadata, capabilities)
 
+    def _train_dataset_info(self, dataset_info: DatasetInfo) -> DatasetInfo:
+        """Converts the original dataset info to one corresponding to what the
+        model will see during training, which depends on transforms applied to
+        the targets during data loading.
+
+        :param dataset_info: Original dataset info describing the targets as
+            they are in the raw data.
+        :return: Modified dataset info describing the targets as they will be
+            seen by the model during training.
+        """
+        return densify_atomic_basis_dataset_info(dataset_info)
+
     def _add_output(self, target_name: str, target_info: TargetInfo) -> None:
         self.outputs[target_name] = ModelOutput(
             quantity=target_info.quantity,
@@ -603,9 +618,7 @@ class PhACE(ModelInterface[ModelHypers]):
             per_atom=True,
         )
 
-        output_layout = target_info.layout
-
-        if target_info.is_cartesian and len(output_layout.block().components) == 2:
+        if target_info.is_cartesian and len(target_info.layout.block().components) == 2:
             # rank-2 Cartesian: store internal spherical layout (l=0, l=1, l=2)
             # so that the forward pass constructs the spherical TensorMap, which
             # is then converted to Cartesian by _to_cartesian_rank_2.
@@ -625,21 +638,17 @@ class PhACE(ModelInterface[ModelHypers]):
                         )
                     ]
                 )
-                internal_property_labels.append(output_layout.block().properties)
+                internal_property_labels.append(target_info.layout.block().properties)
             self.key_labels[target_name] = internal_keys
             self.component_labels[target_name] = internal_component_labels
             self.property_labels[target_name] = internal_property_labels
         else:
-            if target_info.is_atomic_basis:
-                output_layout = densify_atomic_basis_target(
-                    output_layout, output_layout
-                )
-            self.key_labels[target_name] = output_layout.keys
+            self.key_labels[target_name] = target_info.layout.keys
             self.component_labels[target_name] = [
-                block.components for block in output_layout.blocks()
+                block.components for block in target_info.layout.blocks()
             ]
             self.property_labels[target_name] = [
-                block.properties for block in output_layout.blocks()
+                block.properties for block in target_info.layout.blocks()
             ]
 
     def requested_neighbor_lists(

--- a/src/metatrain/experimental/phace/model.py
+++ b/src/metatrain/experimental/phace/model.py
@@ -26,6 +26,7 @@ from metatrain.experimental.phace.utils import systems_to_batch
 from metatrain.utils.abc import ModelInterface
 from metatrain.utils.additive import ZBL, CompositionModel
 from metatrain.utils.data.atomic_basis_helpers import (
+    densify_atomic_basis_dataset_info,
     densify_atomic_basis_target,
     sparsify_atomic_basis_target,
 )
@@ -120,6 +121,11 @@ class PhACE(ModelInterface[ModelHypers]):
 
         self.last_layer_feature_size = self.k_max_l[0]
 
+        # as PhACE handles atomic basis targets in the densified form, we modify the
+        # layouts of the atomic basis targets in dataset_info, specifically for passing
+        # to the composition model and scaler. This only modifies atomic basis targets.
+        dataset_info_dense = densify_atomic_basis_dataset_info(dataset_info)
+
         # additive models: these are handled by the trainer at training
         # time, and they are added to the output at evaluation time
         composition_model = CompositionModel(
@@ -129,7 +135,7 @@ class PhACE(ModelInterface[ModelHypers]):
                 atomic_types=self.atomic_types,
                 targets={
                     target_name: target_info
-                    for target_name, target_info in dataset_info.targets.items()
+                    for target_name, target_info in dataset_info_dense.targets.items()
                     if CompositionModel.is_valid_target(target_name, target_info)
                 },
             ),
@@ -153,7 +159,7 @@ class PhACE(ModelInterface[ModelHypers]):
         self.additive_models = torch.nn.ModuleList(additive_models)
 
         # scaler: this is also handled by the trainer at training time
-        self.scaler = Scaler(hypers={}, dataset_info=dataset_info)
+        self.scaler = Scaler(hypers={}, dataset_info=dataset_info_dense)
 
         self.single_label = Labels.single()
 
@@ -462,16 +468,6 @@ class PhACE(ModelInterface[ModelHypers]):
             )
 
         if not self.training:
-            # For atomic basis targets, sparsify to create blocks with "atom_type"
-            # in the key dimensions, and ensure properties are unpadded.
-            targets = self.dataset_info.targets
-            for k, v in return_dict.items():
-                if k in targets and targets[k].is_atomic_basis:
-                    return_dict[k] = sparsify_atomic_basis_target(
-                        systems,
-                        v,
-                        targets[k].layout,
-                    )
             # at evaluation, we also introduce the scaler and additive contributions
             return_dict = self.scaler(systems, return_dict)
             for additive_model in self.additive_models:
@@ -510,6 +506,17 @@ class PhACE(ModelInterface[ModelHypers]):
                         else:
                             output_blocks.append(b)
                     return_dict[name] = TensorMap(return_dict[name].keys, output_blocks)
+
+            # For atomic basis targets, sparsify to create blocks with "atom_type"
+            # in the key dimensions, and ensure properties are unpadded.
+            targets = self.dataset_info.targets
+            for k, v in return_dict.items():
+                if k in targets and targets[k].is_atomic_basis:
+                    return_dict[k] = sparsify_atomic_basis_target(
+                        systems,
+                        v,
+                        targets[k].layout,
+                    )
 
         return return_dict
 

--- a/src/metatrain/experimental/phace/modules/base_model.py
+++ b/src/metatrain/experimental/phace/modules/base_model.py
@@ -4,10 +4,6 @@ import numpy as np
 import torch
 from torch.func import functional_call, grad
 
-from metatrain.utils.data.atomic_basis_helpers import (
-    densify_atomic_basis_target,
-)
-
 from .cg_coefficients import get_cg_coefficients
 from .cg_iterator import CGIterator
 from .layers import Linear
@@ -280,8 +276,6 @@ class BaseModel(torch.nn.Module):
             # specified by the user
             use_mlp = self.head_types[target_name] == "mlp"
 
-        output_layout = target_info.layout
-
         if use_mlp:
             if target_info.is_spherical or target_info.is_cartesian:
                 # (in the future, one could consider enabling the MLP for the scalar
@@ -303,25 +297,29 @@ class BaseModel(torch.nn.Module):
 
         if target_info.is_scalar:
             self.last_layers[target_name] = torch.nn.ModuleDict(
-                {"0": Linear(self.k_max_l[0], len(output_layout.block().properties))}
+                {
+                    "0": Linear(
+                        self.k_max_l[0], len(target_info.layout.block().properties)
+                    )
+                }
             )
         elif target_info.is_cartesian:
             # here, we handle Cartesian targets
             # the conversion to Cartesian is performed in the metatensor wrapper
             # (model.py)
-            if len(output_layout.block().components) == 1:
+            if len(target_info.layout.block().components) == 1:
                 # rank-1: treat as a spherical L=1 target
                 self.last_layers[target_name] = torch.nn.ModuleDict(
                     {
                         "1": Linear(
-                            self.k_max_l[1], len(output_layout.block().properties)
+                            self.k_max_l[1], len(target_info.layout.block().properties)
                         )
                     }
                 )
-            elif len(output_layout.block().components) == 2:
+            elif len(target_info.layout.block().components) == 2:
                 # rank-2: predict as 3 spherical components (l=0,1,2),
                 # converted to Cartesian in the metatensor wrapper (model.py)
-                num_props = len(output_layout.block().properties)
+                num_props = len(target_info.layout.block().properties)
                 rank2_layers: Dict[str, torch.nn.Module] = {}
                 for l in [0, 1, 2]:  # noqa: E741
                     if l > self.l_max:
@@ -337,12 +335,8 @@ class BaseModel(torch.nn.Module):
                     "PhACE only supports Cartesian targets with rank=1 or rank=2."
                 )
         else:  # spherical equivariant
-            if target_info.is_atomic_basis:
-                output_layout = densify_atomic_basis_target(
-                    output_layout, output_layout
-                )
             irreps = []
-            for key in output_layout.keys:
+            for key in target_info.layout.keys:
                 key_values = key.values
                 l = int(key_values[0])  # noqa: E741
                 # s = int(key_values[1]) is ignored here
@@ -358,7 +352,7 @@ class BaseModel(torch.nn.Module):
                 {
                     str(l): Linear(
                         self.k_max_l[l],
-                        len(output_layout.block({"o3_lambda": l}).properties),
+                        len(target_info.layout.block({"o3_lambda": l}).properties),
                     )
                     for l in irreps  # noqa: E741
                 }

--- a/src/metatrain/experimental/phace/trainer.py
+++ b/src/metatrain/experimental/phace/trainer.py
@@ -195,6 +195,20 @@ class Trainer(TrainerInterface[TrainerHypers]):
             additive_model.to(dtype=torch.float64)
         model.scaler.to(dtype=torch.float64)
 
+        # Set up transformations
+        dataset_info = model.dataset_info
+        train_targets = dataset_info.targets
+        extra_data_info = dataset_info.extra_data
+        inversion_augmenter = InversionAugmenter(
+            target_info_dict=train_targets, extra_data_info_dict=extra_data_info
+        )
+        requested_neighbor_lists = get_requested_neighbor_lists(model)
+        atomic_basis_transform, atomic_basis_reverse_transform = (
+            get_prepare_atomic_basis_targets_transform(
+                train_targets, dataset_info.extra_data
+            )
+        )
+
         logging.info("Calculating composition weights")
         model.additive_models[0].train_model(  # this is the composition model
             train_datasets,
@@ -202,6 +216,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
             self.hypers["batch_size"],
             is_distributed,
             self.hypers["atomic_baseline"],
+            initial_transforms=[atomic_basis_transform],
         )
 
         if self.hypers["scale_targets"]:
@@ -212,6 +227,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
                 self.hypers["batch_size"],
                 is_distributed,
                 self.hypers["fixed_scaling_weights"],
+                initial_transforms=[atomic_basis_transform],
             )
 
         if self.hypers["ema_decay"] is not None:
@@ -272,35 +288,23 @@ class Trainer(TrainerInterface[TrainerHypers]):
         model.scaler.scales_to(device=device, dtype=torch.float64)
 
         # Create collate functions:
-        dataset_info = model.dataset_info
-        train_targets = dataset_info.targets
-        extra_data_info = dataset_info.extra_data
-        inversion_augmenter = InversionAugmenter(
-            target_info_dict=train_targets, extra_data_info_dict=extra_data_info
-        )
-        requested_neighbor_lists = get_requested_neighbor_lists(model)
-        atomic_basis_transform, atomic_basis_reverse_transform = (
-            get_prepare_atomic_basis_targets_transform(
-                train_targets, dataset_info.extra_data
-            )
-        )
         collate_fn_train = CollateFn(
             target_keys=list(train_targets.keys()),
             callables=[
-                get_remove_additive_transform(additive_models, train_targets),
-                get_remove_scale_transform(scaler),
                 atomic_basis_transform,
                 inversion_augmenter.apply_random_augmentations,
                 get_system_with_neighbor_lists_transform(requested_neighbor_lists),
+                get_remove_additive_transform(additive_models, train_targets),
+                get_remove_scale_transform(scaler),
             ],
         )
         collate_fn_val = CollateFn(
             target_keys=list(train_targets.keys()),
             callables=[  # no augmentation for validation
+                atomic_basis_transform,
                 get_system_with_neighbor_lists_transform(requested_neighbor_lists),
                 get_remove_additive_transform(additive_models, train_targets),
                 get_remove_scale_transform(scaler),
-                atomic_basis_transform,
             ],
         )
 
@@ -497,17 +501,22 @@ class Trainer(TrainerInterface[TrainerHypers]):
                     torch.distributed.all_reduce(train_loss_batch)
                 train_loss += train_loss_batch.item()
 
-                # if any atomic basis outputs are present, reverse the transform
-                # before calculating metrics
-                systems, targets, extra_data = atomic_basis_reverse_transform(
-                    systems, targets, extra_data
-                )
-                systems, predictions, _ = atomic_basis_reverse_transform(
-                    systems, predictions, {}
-                )
-
                 scaled_predictions = model.scaler(systems, predictions)
                 scaled_targets = model.scaler(systems, targets)
+
+                if self.hypers["log_separate_blocks"]:
+                    # if any atomic basis outputs are present and metrics are to be
+                    # reported per-block, reverse the transform (i.e. sparsify)
+                    # before calculating metrics
+                    systems, scaled_targets, extra_data = (
+                        atomic_basis_reverse_transform(
+                            systems, scaled_targets, extra_data
+                        )
+                    )
+                    systems, scaled_predictions, _ = atomic_basis_reverse_transform(
+                        systems, scaled_predictions, {}
+                    )
+
                 train_rmse_calculator.update(
                     scaled_predictions, scaled_targets, extra_data
                 )
@@ -561,16 +570,20 @@ class Trainer(TrainerInterface[TrainerHypers]):
                         # sum the loss over all processes
                         torch.distributed.all_reduce(val_loss_batch)
                     val_loss += val_loss_batch.item()
-                    # if any atomic basis outputs are present, reverse the transform
-                    # before calculating metrics
-                    systems, targets, extra_data = atomic_basis_reverse_transform(
-                        systems, targets, extra_data
-                    )
-                    systems, predictions, _ = atomic_basis_reverse_transform(
-                        systems, predictions, {}
-                    )
+
                     scaled_predictions = model.scaler(systems, predictions)
                     scaled_targets = model.scaler(systems, targets)
+
+                    if self.hypers["log_separate_blocks"]:
+                        # if any atomic basis outputs are present and metrics are to be
+                        # reported per-block, reverse the transform (i.e. sparsify)
+                        # before calculating metrics
+                        systems, targets, extra_data = atomic_basis_reverse_transform(
+                            systems, targets, extra_data
+                        )
+                        systems, predictions, _ = atomic_basis_reverse_transform(
+                            systems, predictions, {}
+                        )
                     val_rmse_calculator.update(
                         scaled_predictions, scaled_targets, extra_data
                     )

--- a/src/metatrain/pet/model.py
+++ b/src/metatrain/pet/model.py
@@ -22,7 +22,6 @@ from metatrain.utils.additive import ZBL, CompositionModel
 from metatrain.utils.data import DatasetInfo, TargetInfo
 from metatrain.utils.data.atomic_basis_helpers import (
     densify_atomic_basis_dataset_info,
-    densify_atomic_basis_target,
     sparsify_atomic_basis_target,
 )
 from metatrain.utils.dtype import dtype_to_str
@@ -160,13 +159,17 @@ class PET(ModelInterface[ModelHypers]):
             "features": ModelOutput(per_atom=True, description="internal features")
         }
 
+        # Modified dataset_info with the targets as they will be seen by PET
+        # during training.
+        train_dataset_info = self._train_dataset_info(dataset_info)
+
         self.output_shapes: Dict[str, Dict[str, List[int]]] = {}
         self.key_labels: Dict[str, Labels] = {}
         self.property_labels: Dict[str, List[Labels]] = {}
         self.component_labels: Dict[str, List[List[Labels]]] = {}
         self.target_names: List[str] = []
         self.last_layer_parameter_names: Dict[str, List[str]] = {}  # for LLPR
-        for target_name, target_info in dataset_info.targets.items():
+        for target_name, target_info in train_dataset_info.targets.items():
             self.target_names.append(target_name)
             self._add_output(target_name, target_info)
 
@@ -198,21 +201,16 @@ class PET(ModelInterface[ModelHypers]):
             self.long_range = False
             self.long_range_featurizer = DummyLongRangeFeaturizer()  # for torchscript
 
-        # as PET handles atomic basis targets in the densified form, we modify the
-        # layouts of the atomic basis targets in dataset_info, specifically for passing
-        # to the composition model and scaler. This only modifies atomic basis targets.
-        dataset_info_dense = densify_atomic_basis_dataset_info(dataset_info)
-
         # additive models: these are handled by the trainer at training
         # time, and they are added to the output at evaluation time
         composition_model = CompositionModel(
             hypers={},
             dataset_info=DatasetInfo(
-                length_unit=dataset_info.length_unit,
+                length_unit=train_dataset_info.length_unit,
                 atomic_types=self.atomic_types,
                 targets={
                     target_name: target_info
-                    for target_name, target_info in dataset_info_dense.targets.items()
+                    for target_name, target_info in train_dataset_info.targets.items()
                     if CompositionModel.is_valid_target(target_name, target_info)
                 },
             ),
@@ -221,24 +219,25 @@ class PET(ModelInterface[ModelHypers]):
 
         # Adds the ZBL repulsion model if requested
         if self.hypers["zbl"]:
+            zbl_targets = {
+                target_name: target_info
+                for target_name, target_info in train_dataset_info.targets.items()
+                if ZBL.is_valid_target(target_name, target_info)
+            }
             additive_models.append(
                 ZBL(
                     {},
                     dataset_info=DatasetInfo(
-                        length_unit=dataset_info.length_unit,
+                        length_unit=train_dataset_info.length_unit,
                         atomic_types=self.atomic_types,
-                        targets={
-                            target_name: target_info
-                            for target_name, target_info in dataset_info.targets.items()
-                            if ZBL.is_valid_target(target_name, target_info)
-                        },
+                        targets=zbl_targets,
                     ),
                 )
             )
         self.additive_models = torch.nn.ModuleList(additive_models)
 
         # scaler: this is also handled by the trainer at training time
-        self.scaler = Scaler(hypers={}, dataset_info=dataset_info_dense)
+        self.scaler = Scaler(hypers={}, dataset_info=train_dataset_info)
 
         self.single_label = Labels.single()
 
@@ -266,26 +265,30 @@ class PET(ModelInterface[ModelHypers]):
                 "The PET model does not support adding new atomic types."
             )
 
+        # Modified dataset_info with the targets as they will be seen by PET
+        # during training.
+        train_dataset_info = self._train_dataset_info(dataset_info)
+
         # register new outputs as new last layers
-        for target_name, target in new_targets.items():
+        for target_name in new_targets:
             self.target_names.append(target_name)
-            self._add_output(target_name, target)
+            self._add_output(target_name, train_dataset_info.targets[target_name])
 
         self.dataset_info = merged_info
 
         # restart the composition and scaler models
         self.additive_models[0] = self.additive_models[0].restart(
             dataset_info=DatasetInfo(
-                length_unit=dataset_info.length_unit,
+                length_unit=train_dataset_info.length_unit,
                 atomic_types=self.atomic_types,
                 targets={
                     target_name: target_info
-                    for target_name, target_info in dataset_info.targets.items()
+                    for target_name, target_info in train_dataset_info.targets.items()
                     if CompositionModel.is_valid_target(target_name, target_info)
                 },
             ),
         )
-        self.scaler = self.scaler.restart(dataset_info)
+        self.scaler = self.scaler.restart(train_dataset_info)
 
         return self
 
@@ -1216,6 +1219,18 @@ class PET(ModelInterface[ModelHypers]):
 
         return AtomisticModel(self.eval(), metadata, capabilities)
 
+    def _train_dataset_info(self, dataset_info: DatasetInfo) -> DatasetInfo:
+        """Converts the original dataset info to one corresponding to what PET
+        will see during training, which depends on transforms applied to the
+        targets during data loading.
+
+        :param dataset_info: Original dataset info describing the targets as
+            they are in the raw data.
+        :return: Modified dataset info describing the targets as they will be
+            seen by PET during training.
+        """
+        return densify_atomic_basis_dataset_info(dataset_info)
+
     def _add_output(self, target_name: str, target_info: TargetInfo) -> None:
         """
         Register a new output target by creating corresponding heads and last layers.
@@ -1224,13 +1239,9 @@ class PET(ModelInterface[ModelHypers]):
         :param target_name: Name of the target to add.
         :param target_info: TargetInfo object containing details about the target.
         """
-        output_layout = target_info.layout
-        if target_info.is_atomic_basis:
-            output_layout = densify_atomic_basis_target(output_layout, output_layout)
-
         # one output shape for each tensor block, grouped by target (i.e. tensormap)
         self.output_shapes[target_name] = {}
-        for key, block in output_layout.items():
+        for key, block in target_info.layout.items():
             dict_key = target_name
             for n, k in zip(key.names, key.values, strict=True):
                 dict_key += f"_{n}_{int(k)}"
@@ -1317,12 +1328,12 @@ class PET(ModelInterface[ModelHypers]):
         self.outputs[ll_features_name] = ModelOutput(
             per_atom=True, description=f"last layer features for {target_name}"
         )
-        self.key_labels[target_name] = output_layout.keys
+        self.key_labels[target_name] = target_info.layout.keys
         self.component_labels[target_name] = [
-            block.components for block in output_layout.blocks()
+            block.components for block in target_info.layout.blocks()
         ]
         self.property_labels[target_name] = [
-            block.properties for block in output_layout.blocks()
+            block.properties for block in target_info.layout.blocks()
         ]
 
     def _move_labels_to_device(self, device: torch.device) -> None:

--- a/src/metatrain/pet/model.py
+++ b/src/metatrain/pet/model.py
@@ -21,6 +21,7 @@ from metatrain.utils.abc import ModelInterface
 from metatrain.utils.additive import ZBL, CompositionModel
 from metatrain.utils.data import DatasetInfo, TargetInfo
 from metatrain.utils.data.atomic_basis_helpers import (
+    densify_atomic_basis_dataset_info,
     densify_atomic_basis_target,
     sparsify_atomic_basis_target,
 )
@@ -197,6 +198,11 @@ class PET(ModelInterface[ModelHypers]):
             self.long_range = False
             self.long_range_featurizer = DummyLongRangeFeaturizer()  # for torchscript
 
+        # as PET handles atomic basis targets in the densified form, we modify the
+        # layouts of the atomic basis targets in dataset_info, specifically for passing
+        # to the composition model and scaler. This only modifies atomic basis targets.
+        dataset_info_dense = densify_atomic_basis_dataset_info(dataset_info)
+
         # additive models: these are handled by the trainer at training
         # time, and they are added to the output at evaluation time
         composition_model = CompositionModel(
@@ -206,7 +212,7 @@ class PET(ModelInterface[ModelHypers]):
                 atomic_types=self.atomic_types,
                 targets={
                     target_name: target_info
-                    for target_name, target_info in dataset_info.targets.items()
+                    for target_name, target_info in dataset_info_dense.targets.items()
                     if CompositionModel.is_valid_target(target_name, target_info)
                 },
             ),
@@ -232,7 +238,7 @@ class PET(ModelInterface[ModelHypers]):
         self.additive_models = torch.nn.ModuleList(additive_models)
 
         # scaler: this is also handled by the trainer at training time
-        self.scaler = Scaler(hypers={}, dataset_info=dataset_info)
+        self.scaler = Scaler(hypers={}, dataset_info=dataset_info_dense)
 
         self.single_label = Labels.single()
 
@@ -528,14 +534,6 @@ class PET(ModelInterface[ModelHypers]):
         # **Post-processing (Evaluation Only)**
         with torch.profiler.record_function("PET::post-processing"):
             if not self.training:
-                # For atomic basis targets, sparsify to create blocks with "atom_type"
-                # in the key dimensions, and ensure properties are unpadded.
-                for k, v in atomic_predictions_dict.items():
-                    if self.dataset_info.targets[k].is_atomic_basis:
-                        return_dict[k] = sparsify_atomic_basis_target(
-                            systems, v, self.dataset_info.targets[k].layout, species
-                        )
-
                 # at evaluation, we also introduce the scaler and additive contributions
                 return_dict = self.scaler(
                     systems, return_dict, selected_atoms=selected_atoms
@@ -577,6 +575,14 @@ class PET(ModelInterface[ModelHypers]):
                                 output_blocks.append(b)
                         return_dict[name] = TensorMap(
                             return_dict[name].keys, output_blocks
+                        )
+
+                # For atomic basis targets, sparsify to create blocks with "atom_type"
+                # in the key dimensions, and ensure properties are unpadded.
+                for k, v in atomic_predictions_dict.items():
+                    if self.dataset_info.targets[k].is_atomic_basis:
+                        return_dict[k] = sparsify_atomic_basis_target(
+                            systems, v, self.dataset_info.targets[k].layout, species
                         )
 
         return return_dict

--- a/src/metatrain/pet/trainer.py
+++ b/src/metatrain/pet/trainer.py
@@ -165,6 +165,25 @@ class Trainer(TrainerInterface[TrainerHypers]):
             additive_model.to(dtype=torch.float64)
         model.scaler.to(dtype=torch.float64)
 
+        # Set up transformations
+        dataset_info = model.dataset_info
+        train_targets = dataset_info.targets
+        extra_data_info = dataset_info.extra_data
+        rotational_augmenter = RotationalAugmenter(
+            target_info_dict=train_targets, extra_data_info_dict=extra_data_info
+        )
+        requested_neighbor_lists = get_requested_neighbor_lists(model)
+        max_atoms = self.hypers["max_atoms_per_batch"]
+        # When max_atoms_per_batch is set, batches are pre-filtered by atom count at
+        # construction time, so batch_atom_bounds filtering in the collate function is
+        # not needed (and its documented behaviour is to be ignored in this mode).
+        batch_atom_bounds = (
+            None if max_atoms is not None else self.hypers["batch_atom_bounds"]
+        )
+        atomic_basis_transform, atomic_basis_reverse_transform = (
+            get_prepare_atomic_basis_targets_transform(train_targets, extra_data_info)
+        )
+
         logging.info("Calculating composition weights")
         model.additive_models[0].train_model(  # this is the composition model
             train_datasets,
@@ -172,6 +191,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
             self.hypers["batch_size"],
             is_distributed,
             self.hypers["atomic_baseline"],
+            initial_transforms=[atomic_basis_transform],
         )
 
         if self.hypers["scale_targets"]:
@@ -182,6 +202,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
                 self.hypers["batch_size"],
                 is_distributed,
                 self.hypers["fixed_scaling_weights"],
+                initial_transforms=[atomic_basis_transform],
             )
 
         logging.info("Setting up data loaders")
@@ -225,41 +246,24 @@ class Trainer(TrainerInterface[TrainerHypers]):
         model.scaler.scales_to(device=device, dtype=torch.float64)
 
         # Create collate functions:
-        dataset_info = model.dataset_info
-        train_targets = dataset_info.targets
-        extra_data_info = dataset_info.extra_data
-        rotational_augmenter = RotationalAugmenter(
-            target_info_dict=train_targets, extra_data_info_dict=extra_data_info
-        )
-        requested_neighbor_lists = get_requested_neighbor_lists(model)
-        max_atoms = self.hypers["max_atoms_per_batch"]
-        # When max_atoms_per_batch is set, batches are pre-filtered by atom count at
-        # construction time, so batch_atom_bounds filtering in the collate function is
-        # not needed (and its documented behaviour is to be ignored in this mode).
-        batch_atom_bounds = (
-            None if max_atoms is not None else self.hypers["batch_atom_bounds"]
-        )
-        atomic_basis_transform, atomic_basis_reverse_transform = (
-            get_prepare_atomic_basis_targets_transform(train_targets, extra_data_info)
-        )
         collate_fn_train = CollateFn(
             target_keys=list(train_targets.keys()),
             callables=[
-                get_remove_additive_transform(additive_models, train_targets),
-                get_remove_scale_transform(scaler),
                 atomic_basis_transform,
                 rotational_augmenter.apply_random_augmentations,
                 get_system_with_neighbor_lists_transform(requested_neighbor_lists),
+                get_remove_additive_transform(additive_models, train_targets),
+                get_remove_scale_transform(scaler),
             ],
             batch_atom_bounds=batch_atom_bounds,
         )
         collate_fn_val = CollateFn(
             target_keys=list(train_targets.keys()),
             callables=[  # no augmentation for validation
+                atomic_basis_transform,
                 get_system_with_neighbor_lists_transform(requested_neighbor_lists),
                 get_remove_additive_transform(additive_models, train_targets),
                 get_remove_scale_transform(scaler),
-                atomic_basis_transform,
             ],
             batch_atom_bounds=batch_atom_bounds,
         )
@@ -476,21 +480,26 @@ class Trainer(TrainerInterface[TrainerHypers]):
                     torch.distributed.all_reduce(train_loss_batch)
                 train_loss += train_loss_batch.item()
 
-                # if any atomic basis outputs are present, reverse the transform
-                # before calculating metrics
-                systems, targets, extra_data = atomic_basis_reverse_transform(
-                    systems, targets, extra_data
-                )
-                systems, predictions, _ = atomic_basis_reverse_transform(
-                    systems, predictions, {}
-                )
-
                 scaled_predictions = (model.module if is_distributed else model).scaler(
                     systems, predictions
                 )
                 scaled_targets = (model.module if is_distributed else model).scaler(
                     systems, targets
                 )
+
+                if self.hypers["log_separate_blocks"]:
+                    # if any atomic basis outputs are present and metrics are to be
+                    # reported per-block, reverse the transform (i.e. sparsify)
+                    # before calculating metrics
+                    systems, scaled_targets, extra_data = (
+                        atomic_basis_reverse_transform(
+                            systems, scaled_targets, extra_data
+                        )
+                    )
+                    systems, scaled_predictions, _ = atomic_basis_reverse_transform(
+                        systems, scaled_predictions, {}
+                    )
+
                 train_rmse_calculator.update(
                     scaled_predictions, scaled_targets, extra_data
                 )
@@ -547,21 +556,26 @@ class Trainer(TrainerInterface[TrainerHypers]):
                         torch.distributed.all_reduce(val_loss_batch)
                     val_loss += val_loss_batch.item()
 
-                    # if any atomic basis outputs are present, reverse the transform
-                    # before calculating metrics
-                    systems, targets, extra_data = atomic_basis_reverse_transform(
-                        systems, targets, extra_data
-                    )
-                    systems, predictions, _ = atomic_basis_reverse_transform(
-                        systems, predictions, {}
-                    )
-
                     scaled_predictions = (
                         model.module if is_distributed else model
                     ).scaler(systems, predictions)
                     scaled_targets = (model.module if is_distributed else model).scaler(
                         systems, targets
                     )
+
+                    if self.hypers["log_separate_blocks"]:
+                        # if any atomic basis outputs are present and metrics are to be
+                        # reported per-block, reverse the transform (i.e. sparsify)
+                        # before calculating metrics
+                        systems, scaled_targets, extra_data = (
+                            atomic_basis_reverse_transform(
+                                systems, scaled_targets, extra_data
+                            )
+                        )
+                        systems, scaled_predictions, _ = atomic_basis_reverse_transform(
+                            systems, scaled_predictions, {}
+                        )
+
                     val_rmse_calculator.update(
                         scaled_predictions, scaled_targets, extra_data
                     )

--- a/src/metatrain/soap_bpnn/model.py
+++ b/src/metatrain/soap_bpnn/model.py
@@ -20,6 +20,7 @@ from metatrain.utils.abc import ModelInterface
 from metatrain.utils.additive import ZBL, CompositionModel
 from metatrain.utils.data import TargetInfo
 from metatrain.utils.data.atomic_basis_helpers import (
+    densify_atomic_basis_dataset_info,
     densify_atomic_basis_target,
     sparsify_atomic_basis_target,
 )
@@ -386,6 +387,11 @@ class SoapBpnn(ModelInterface[ModelHypers]):
             offset += 2 * L + 1
         self._sph_to_cart_rank2 = W
 
+        # as SOAP-BPNN handles atomic basis targets in the densified form, we modify the
+        # layouts of the atomic basis targets in dataset_info, specifically for passing
+        # to the composition model and scaler. This only modifies atomic basis targets.
+        dataset_info_dense = densify_atomic_basis_dataset_info(dataset_info)
+
         # additive models: these are handled by the trainer at training
         # time, and they are added to the output at evaluation time
         composition_model = CompositionModel(
@@ -395,7 +401,7 @@ class SoapBpnn(ModelInterface[ModelHypers]):
                 atomic_types=self.atomic_types,
                 targets={
                     target_name: target_info
-                    for target_name, target_info in dataset_info.targets.items()
+                    for target_name, target_info in dataset_info_dense.targets.items()
                     if CompositionModel.is_valid_target(target_name, target_info)
                 },
             ),
@@ -419,7 +425,7 @@ class SoapBpnn(ModelInterface[ModelHypers]):
         self.additive_models = torch.nn.ModuleList(additive_models)
 
         # scaler: this is also handled by the trainer at training time
-        self.scaler = Scaler(hypers={}, dataset_info=dataset_info)
+        self.scaler = Scaler(hypers={}, dataset_info=dataset_info_dense)
 
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.outputs
@@ -813,16 +819,6 @@ class SoapBpnn(ModelInterface[ModelHypers]):
                 return_dict[output_name] = sum_over_atoms(atomic_property)
 
         if not self.training:
-            # For atomic basis targets, sparsify to create blocks with "atom_type"
-            # in the key dimensions, and ensure properties are unpadded.
-            targets = self.dataset_info.targets
-            for k, v in return_dict.items():
-                if k in targets and targets[k].is_atomic_basis:
-                    return_dict[k] = sparsify_atomic_basis_target(
-                        systems,
-                        v,
-                        targets[k].layout,
-                    )
             # at evaluation, we also introduce the scaler and additive contributions
             return_dict = self.scaler(
                 systems, return_dict, selected_atoms=selected_atoms
@@ -864,6 +860,17 @@ class SoapBpnn(ModelInterface[ModelHypers]):
                         else:
                             output_blocks.append(b)
                     return_dict[name] = TensorMap(return_dict[name].keys, output_blocks)
+
+            # For atomic basis targets, sparsify to create blocks with "atom_type"
+            # in the key dimensions, and ensure properties are unpadded.
+            targets = self.dataset_info.targets
+            for k, v in return_dict.items():
+                if k in targets and targets[k].is_atomic_basis:
+                    return_dict[k] = sparsify_atomic_basis_target(
+                        systems,
+                        v,
+                        targets[k].layout,
+                    )
 
         return return_dict
 

--- a/src/metatrain/soap_bpnn/model.py
+++ b/src/metatrain/soap_bpnn/model.py
@@ -21,7 +21,6 @@ from metatrain.utils.additive import ZBL, CompositionModel
 from metatrain.utils.data import TargetInfo
 from metatrain.utils.data.atomic_basis_helpers import (
     densify_atomic_basis_dataset_info,
-    densify_atomic_basis_target,
     sparsify_atomic_basis_target,
 )
 from metatrain.utils.data.dataset import DatasetInfo
@@ -358,6 +357,10 @@ class SoapBpnn(ModelInterface[ModelHypers]):
             values=torch.arange(self.n_inputs_last_layer).unsqueeze(1),
         )
 
+        # Modified dataset_info with the targets as they will be seen by
+        # the model during training.
+        train_dataset_info = self._train_dataset_info(dataset_info)
+
         self.num_properties: Dict[str, Dict[str, int]] = {}  # by target and block
         self.basis_calculators = torch.nn.ModuleDict({})
         self.heads = torch.nn.ModuleDict({})
@@ -369,7 +372,7 @@ class SoapBpnn(ModelInterface[ModelHypers]):
         self.last_layer_parameter_names: Dict[str, List[str]] = {}  # for LLPR
         self.cartesian_rank1_targets: List[str] = []
         self.cartesian_rank2_targets: List[str] = []
-        for target_name, target in dataset_info.targets.items():
+        for target_name, target in train_dataset_info.targets.items():
             self._add_output(target_name, target)
 
         # Pre-compute spherical→Cartesian conversion matrix for rank-2 tensors.
@@ -387,45 +390,41 @@ class SoapBpnn(ModelInterface[ModelHypers]):
             offset += 2 * L + 1
         self._sph_to_cart_rank2 = W
 
-        # as SOAP-BPNN handles atomic basis targets in the densified form, we modify the
-        # layouts of the atomic basis targets in dataset_info, specifically for passing
-        # to the composition model and scaler. This only modifies atomic basis targets.
-        dataset_info_dense = densify_atomic_basis_dataset_info(dataset_info)
-
         # additive models: these are handled by the trainer at training
         # time, and they are added to the output at evaluation time
         composition_model = CompositionModel(
             hypers={},
             dataset_info=DatasetInfo(
-                length_unit=dataset_info.length_unit,
+                length_unit=train_dataset_info.length_unit,
                 atomic_types=self.atomic_types,
                 targets={
                     target_name: target_info
-                    for target_name, target_info in dataset_info_dense.targets.items()
+                    for target_name, target_info in train_dataset_info.targets.items()
                     if CompositionModel.is_valid_target(target_name, target_info)
                 },
             ),
         )
         additive_models = [composition_model]
         if self.hypers["zbl"]:
+            zbl_targets = {
+                target_name: target_info
+                for target_name, target_info in train_dataset_info.targets.items()
+                if ZBL.is_valid_target(target_name, target_info)
+            }
             additive_models.append(
                 ZBL(
                     {},
                     dataset_info=DatasetInfo(
-                        length_unit=dataset_info.length_unit,
+                        length_unit=train_dataset_info.length_unit,
                         atomic_types=self.atomic_types,
-                        targets={
-                            target_name: target_info
-                            for target_name, target_info in dataset_info.targets.items()
-                            if ZBL.is_valid_target(target_name, target_info)
-                        },
+                        targets=zbl_targets,
                     ),
                 )
             )
         self.additive_models = torch.nn.ModuleList(additive_models)
 
         # scaler: this is also handled by the trainer at training time
-        self.scaler = Scaler(hypers={}, dataset_info=dataset_info_dense)
+        self.scaler = Scaler(hypers={}, dataset_info=train_dataset_info)
 
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.outputs
@@ -449,25 +448,29 @@ class SoapBpnn(ModelInterface[ModelHypers]):
                 "The SOAP-BPNN model does not support adding new atomic types."
             )
 
+        # Modified dataset_info with the targets as they will be seen by
+        # the model during training.
+        train_dataset_info = self._train_dataset_info(dataset_info)
+
         # register new outputs as new last layers
-        for target_name, target in new_targets.items():
-            self._add_output(target_name, target)
+        for target_name in new_targets:
+            self._add_output(target_name, train_dataset_info.targets[target_name])
 
         self.dataset_info = merged_info
 
         # restart the composition and scaler models
         self.additive_models[0] = self.additive_models[0].restart(
             dataset_info=DatasetInfo(
-                length_unit=dataset_info.length_unit,
+                length_unit=train_dataset_info.length_unit,
                 atomic_types=self.atomic_types,
                 targets={
                     target_name: target_info
-                    for target_name, target_info in dataset_info.targets.items()
+                    for target_name, target_info in train_dataset_info.targets.items()
                     if CompositionModel.is_valid_target(target_name, target_info)
                 },
             ),
         )
-        self.scaler = self.scaler.restart(dataset_info)
+        self.scaler = self.scaler.restart(train_dataset_info)
 
         return self
 
@@ -1006,13 +1009,24 @@ class SoapBpnn(ModelInterface[ModelHypers]):
 
         return AtomisticModel(self.eval(), metadata, capabilities)
 
+    def _train_dataset_info(self, dataset_info: DatasetInfo) -> DatasetInfo:
+        """Converts the original dataset info to one corresponding to what the
+        model will see during training, which depends on transforms applied to
+        the targets during data loading.
+
+        :param dataset_info: Original dataset info describing the targets as
+            they are in the raw data.
+        :return: Modified dataset info describing the targets as they will be
+            seen by the model during training.
+        """
+        return densify_atomic_basis_dataset_info(dataset_info)
+
     def _add_output(self, target_name: str, target: TargetInfo) -> None:
         # register bases of spherical tensors (TensorBasis)
         self.num_properties[target_name] = {}
         self.basis_calculators[target_name] = torch.nn.ModuleDict({})
-        output_layout = target.layout
         if target.is_scalar:
-            for key, block in output_layout.items():
+            for key, block in target.layout.items():
                 dict_key = target_name
                 for n, k in zip(key.names, key.values, strict=True):
                     dict_key += f"_{n}_{int(k)}"
@@ -1028,11 +1042,7 @@ class SoapBpnn(ModelInterface[ModelHypers]):
                     legacy=self.legacy,
                 )
         elif target.is_spherical:
-            if target.is_atomic_basis:
-                output_layout = densify_atomic_basis_target(
-                    output_layout, output_layout
-                )
-            for key, block in output_layout.items():
+            for key, block in target.layout.items():
                 dict_key = target_name
                 for n, k in zip(key.names, key.values, strict=True):
                     dict_key += f"_{n}_{int(k)}"
@@ -1050,7 +1060,7 @@ class SoapBpnn(ModelInterface[ModelHypers]):
                     self.legacy,
                 )
         elif target.is_cartesian:
-            n_cart_components = len(output_layout.block().components)
+            n_cart_components = len(target.layout.block().components)
             if n_cart_components == 1:
                 # rank-1: hard-code to spherical (o3_lambda=1, o3_sigma=1)
                 self.cartesian_rank1_targets.append(target_name)
@@ -1071,7 +1081,7 @@ class SoapBpnn(ModelInterface[ModelHypers]):
                         target_name + f"_o3_lambda_{o3_lambda}_o3_sigma_{o3_sigma}"
                     )
                     self.num_properties[target_name][dict_key] = len(
-                        output_layout.block().properties.values
+                        target.layout.block().properties.values
                     )
                     self.basis_calculators[target_name][dict_key] = TensorBasis(
                         self.atomic_types,
@@ -1128,7 +1138,7 @@ class SoapBpnn(ModelInterface[ModelHypers]):
         # For rank-2 Cartesian targets, construct an internal spherical layout
         # so the last-layer/label setup matches the spherical decomposition.
         if target_name in self.cartesian_rank2_targets:
-            num_subtargets = len(output_layout.block().properties.values)
+            num_subtargets = len(target.layout.block().properties.values)
             internal_keys = Labels(
                 ["o3_lambda", "o3_sigma"],
                 torch.tensor([[0, 1], [1, -1], [2, 1]]),
@@ -1151,12 +1161,12 @@ class SoapBpnn(ModelInterface[ModelHypers]):
                                 torch.arange(-o3_lambda, o3_lambda + 1).reshape(-1, 1),
                             )
                         ],
-                        properties=output_layout.block().properties,
+                        properties=target.layout.block().properties,
                     )
                 )
             layout_for_layers = TensorMap(keys=internal_keys, blocks=internal_blocks)
         else:
-            layout_for_layers = output_layout
+            layout_for_layers = target.layout
 
         # last linear layers, one per block
         self.last_layers[target_name] = torch.nn.ModuleDict({})

--- a/src/metatrain/soap_bpnn/trainer.py
+++ b/src/metatrain/soap_bpnn/trainer.py
@@ -138,6 +138,16 @@ class Trainer(TrainerInterface[TrainerHypers]):
             additive_model.to(dtype=torch.float64)
         model.scaler.to(dtype=torch.float64)
 
+        # Set up transformations
+        dataset_info = model.dataset_info
+        train_targets = dataset_info.targets
+        requested_neighbor_lists = get_requested_neighbor_lists(model)
+        atomic_basis_transform, atomic_basis_reverse_transform = (
+            get_prepare_atomic_basis_targets_transform(
+                train_targets, dataset_info.extra_data
+            )
+        )
+
         logging.info("Calculating composition weights")
         model.additive_models[0].train_model(  # this is the composition model
             train_datasets,
@@ -145,6 +155,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
             self.hypers["batch_size"],
             is_distributed,
             self.hypers["atomic_baseline"],
+            initial_transforms=[atomic_basis_transform],
         )
 
         if self.hypers["scale_targets"]:
@@ -155,6 +166,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
                 self.hypers["batch_size"],
                 is_distributed,
                 self.hypers["fixed_scaling_weights"],
+                initial_transforms=[atomic_basis_transform],
             )
 
         logging.info("Setting up data loaders")
@@ -198,21 +210,13 @@ class Trainer(TrainerInterface[TrainerHypers]):
         model.scaler.scales_to(device=device, dtype=torch.float64)
 
         # Create a collate function:
-        dataset_info = model.dataset_info
-        train_targets = dataset_info.targets
-        requested_neighbor_lists = get_requested_neighbor_lists(model)
-        atomic_basis_transform, atomic_basis_reverse_transform = (
-            get_prepare_atomic_basis_targets_transform(
-                train_targets, dataset_info.extra_data
-            )
-        )
         collate_fn = CollateFn(
             target_keys=list(train_targets.keys()),
             callables=[
+                atomic_basis_transform,
                 get_system_with_neighbor_lists_transform(requested_neighbor_lists),
                 get_remove_additive_transform(additive_models, train_targets),
                 get_remove_scale_transform(scaler),
-                atomic_basis_transform,
             ],
             batch_atom_bounds=self.hypers["batch_atom_bounds"],
         )
@@ -391,21 +395,26 @@ class Trainer(TrainerInterface[TrainerHypers]):
                     torch.distributed.all_reduce(train_loss_batch)
                 train_loss += train_loss_batch.item()
 
-                # if any atomic basis outputs are present, reverse the transform
-                # before calculating metrics
-                systems, targets, extra_data = atomic_basis_reverse_transform(
-                    systems, targets, extra_data
-                )
-                systems, predictions, _ = atomic_basis_reverse_transform(
-                    systems, predictions, {}
-                )
-
                 scaled_predictions = (model.module if is_distributed else model).scaler(
                     systems, predictions
                 )
                 scaled_targets = (model.module if is_distributed else model).scaler(
                     systems, targets
                 )
+
+                if self.hypers["log_separate_blocks"]:
+                    # if any atomic basis outputs are present and metrics are to be
+                    # reported per-block, reverse the transform (i.e. sparsify)
+                    # before calculating metrics
+                    systems, scaled_targets, extra_data = (
+                        atomic_basis_reverse_transform(
+                            systems, scaled_targets, extra_data
+                        )
+                    )
+                    systems, scaled_predictions, _ = atomic_basis_reverse_transform(
+                        systems, scaled_predictions, {}
+                    )
+
                 train_rmse_calculator.update(
                     scaled_predictions, scaled_targets, extra_data
                 )
@@ -463,20 +472,27 @@ class Trainer(TrainerInterface[TrainerHypers]):
                         # sum the loss over all processes
                         torch.distributed.all_reduce(val_loss_batch)
                     val_loss += val_loss_batch.item()
-                    # if any atomic basis outputs are present, reverse the transform
-                    # before calculating metrics
-                    systems, targets, extra_data = atomic_basis_reverse_transform(
-                        systems, targets, extra_data
-                    )
-                    systems, predictions, _ = atomic_basis_reverse_transform(
-                        systems, predictions, {}
-                    )
+
                     scaled_predictions = (
                         model.module if is_distributed else model
                     ).scaler(systems, predictions)
                     scaled_targets = (model.module if is_distributed else model).scaler(
                         systems, targets
                     )
+
+                    if self.hypers["log_separate_blocks"]:
+                        # if any atomic basis outputs are present and metrics are to be
+                        # reported per-block, reverse the transform (i.e. sparsify)
+                        # before calculating metrics
+                        systems, scaled_targets, extra_data = (
+                            atomic_basis_reverse_transform(
+                                systems, scaled_targets, extra_data
+                            )
+                        )
+                        systems, scaled_predictions, _ = atomic_basis_reverse_transform(
+                            systems, scaled_predictions, {}
+                        )
+
                     val_rmse_calculator.update(
                         scaled_predictions, scaled_targets, extra_data
                     )

--- a/src/metatrain/utils/additive/_base_composition.py
+++ b/src/metatrain/utils/additive/_base_composition.py
@@ -288,20 +288,19 @@ class BaseCompositionModel(torch.nn.Module):
                 # TODO: store XTX by sample kind instead, saving memory
                 self.XTX[target_name][key].values[:] += XTX
 
-                # Compute "XTY", i.e. X.T @ Y
-                if self.sample_kinds[target_name] == "per_structure":
-                    # For per-structure targets, we can directly compute X.T @ Y as
-                    # there is no NaN property padding.
-                    self.XTY[target_name][key].values[:] += torch.tensordot(
-                        X, Y, dims=([0], [0])
-                    )
+                # Compute and accummulate "XTY", i.e. X.T @ Y
+                XTY = self.XTY[target_name][key]
+                if self.sample_kinds[target_name] != "per_atom":
+                    # Explicitly compute X.T @ Y.
+                    XTY.values[:] += torch.tensordot(X, Y, dims=([0], [0]))
                 else:
-                    # For per-atom targets, these *could* be atomic basis and have NaN
-                    # padding. Compute XTY separately for each atomic type.
-                    for i in range(X.shape[1]):
-                        self.XTY[target_name][key].values[i] += torch.sum(
-                            Y[X[:, i].bool()], dim=0
-                        )
+                    # X in this case is a one hot encoding of the atom types,
+                    # so we just need to sum Y over atoms of each type to get X.T @ Y.
+                    # This avoids NaNs getting leaked from one atom type to another.
+                    type_indices = X.argmax(dim=1)
+                    # scatter_add_ does not broadcast, so we have to expand type_indices
+                    idx = type_indices.reshape(-1, *[1] * len(Y.shape[1:])).expand_as(Y)
+                    XTY.values.scatter_add_(dim=0, index=idx, src=Y)
 
     def _sanitize_fixed_weights(
         self,
@@ -417,9 +416,13 @@ class BaseCompositionModel(torch.nn.Module):
                         )
 
                     else:
-                        if self.sample_kinds[target_name] == "per_structure":
+                        if self.sample_kinds[target_name] != "per_atom":
+                            # Solve linear system explicitly.
                             weight_vals = _solve_linear_system(XTX_values, XTY_values)
                         else:
+                            # XTX in this case is a diagonal matrix (the counts of atoms
+                            # of each type), so we can solve it faster. This also avoids
+                            # NaNs getting leaked from one atom type to another.
                             weight_vals = XTY_values / torch.diag(XTX_values).unsqueeze(
                                 1
                             )
@@ -508,13 +511,14 @@ class BaseCompositionModel(torch.nn.Module):
                     X_block = X_block[atom_type_mask]
 
                 # Compute X.T @ W
-                if self.sample_kinds[output_name] == "per_structure":
+                if self.sample_kinds[output_name] != "per_atom":
                     out_vals = torch.tensordot(
                         X_block, weight_block.values, dims=([1], [0])
                     )
                 else:
                     # No multiplication is needed for per-atom targets, we just need to
                     # broadcast the weights according to the atom types in the samples.
+                    # This also avoids NaN getting leaked from one atom type to another.
                     out_vals = weight_block.values[X_block.argmax(dim=1)]
 
                 prediction_blocks.append(

--- a/src/metatrain/utils/additive/_base_composition.py
+++ b/src/metatrain/utils/additive/_base_composition.py
@@ -289,9 +289,19 @@ class BaseCompositionModel(torch.nn.Module):
                 self.XTX[target_name][key].values[:] += XTX
 
                 # Compute "XTY", i.e. X.T @ Y
-                self.XTY[target_name][key].values[:] += torch.tensordot(
-                    X, Y, dims=([0], [0])
-                )
+                if self.sample_kinds[target_name] == "per_structure":
+                    # For per-structure targets, we can directly compute X.T @ Y as
+                    # there is no NaN property padding.
+                    self.XTY[target_name][key].values[:] += torch.tensordot(
+                        X, Y, dims=([0], [0])
+                    )
+                else:
+                    # For per-atom targets, these *could* be atomic basis and have NaN
+                    # padding. Compute XTY separately for each atomic type.
+                    for i in range(X.shape[1]):
+                        self.XTY[target_name][key].values[i] += torch.sum(
+                            Y[X[:, i].bool()], dim=0
+                        )
 
     def _sanitize_fixed_weights(
         self,
@@ -407,7 +417,12 @@ class BaseCompositionModel(torch.nn.Module):
                         )
 
                     else:
-                        weight_vals = _solve_linear_system(XTX_values, XTY_values)
+                        if self.sample_kinds[target_name] == "per_structure":
+                            weight_vals = _solve_linear_system(XTX_values, XTY_values)
+                        else:
+                            weight_vals = XTY_values / torch.diag(XTX_values).unsqueeze(
+                                1
+                            )
                         weight_vals = weight_vals.reshape(*XTY_shape)
 
                 blocks.append(
@@ -493,9 +508,15 @@ class BaseCompositionModel(torch.nn.Module):
                     X_block = X_block[atom_type_mask]
 
                 # Compute X.T @ W
-                out_vals = torch.tensordot(
-                    X_block, weight_block.values, dims=([1], [0])
-                )
+                if self.sample_kinds[output_name] == "per_structure":
+                    out_vals = torch.tensordot(
+                        X_block, weight_block.values, dims=([1], [0])
+                    )
+                else:
+                    # No multiplication is needed for per-atom targets, we just need to
+                    # broadcast the weights according to the atom types in the samples.
+                    out_vals = weight_block.values[X_block.argmax(dim=1)]
+
                 prediction_blocks.append(
                     TensorBlock(
                         values=out_vals,

--- a/src/metatrain/utils/additive/composition.py
+++ b/src/metatrain/utils/additive/composition.py
@@ -1,16 +1,19 @@
 import logging
-from typing import Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 import metatensor.torch as mts
 import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
-from metatomic.torch import ModelOutput, NeighborListOptions, System
+from metatomic.torch import ModelOutput, System
 from torch.utils.data import DataLoader, DistributedSampler
 
 from metatrain.utils.data import (
     CollateFn,
     CombinedDataLoader,
     Dataset,
+)
+from metatrain.utils.data.atomic_basis_helpers import (
+    densify_atomic_basis_target,
 )
 from metatrain.utils.neighbor_lists import get_system_with_neighbor_lists_transform
 
@@ -21,7 +24,7 @@ from ._base_composition import (
     FixedCompositionWeights,
     _include_key,
 )
-from .remove import remove_additive
+from .remove import get_remove_additive_transform
 
 
 class CompositionModel(torch.nn.Module):
@@ -93,12 +96,60 @@ class CompositionModel(torch.nn.Module):
             self._new_outputs.append(target_name)
             self._add_output(target_name, target_info)
 
+    def _get_collate_fn(
+        self,
+        additive_models: List[torch.nn.Module],
+        initial_transforms: List[Callable],
+    ) -> CollateFn:
+        """
+        Build a collate function for the dataloader that will be used to fit the
+        composition weights. This collate function will include the necessary callables:
+
+            - any initial transforms provided in `initial_transforms`
+            - adds any necessary neighbor lists.
+            - adds additive model contributions (other than the composition model) that
+              are present in the model.
+
+        :param additive_models: A list of the additive models whose contributions should
+            be removed from the targets before fitting the composition weights. This is
+            used to build the collate function for the dataloader.
+        :param initial_transforms: A list of any additional callables to be included in
+            the collate function, which should be applied before the callable that
+            removes the additive contributions. This can be used to include the atomic
+            basis transform, for example, if needed.
+        :return: The created collate function.
+        """
+        callables = []
+        if len(initial_transforms) > 0:
+            callables += initial_transforms
+
+        if len(additive_models) > 0:
+            requested_neighbor_lists = []
+            for additive_model in additive_models:
+                if hasattr(additive_model, "requested_neighbor_lists"):
+                    requested_neighbor_lists += (
+                        additive_model.requested_neighbor_lists()
+                    )
+
+            callables += [
+                get_system_with_neighbor_lists_transform(requested_neighbor_lists),
+                get_remove_additive_transform(
+                    additive_models, self.dataset_info.targets
+                ),
+            ]
+
+        return CollateFn(
+            target_keys=list(self.dataset_info.targets.keys()),
+            callables=callables,
+        )
+
     def _get_dataloader(
         self,
         datasets: List[Union[Dataset, torch.utils.data.Subset]],
-        requested_neighbor_lists: List[NeighborListOptions],
+        additive_models: List[torch.nn.Module],
         batch_size: int,
         is_distributed: bool,
+        initial_transforms: List[Callable],
     ) -> DataLoader:
         """
         Create a DataLoader for the provided datasets. As the dataloader is only used to
@@ -108,24 +159,17 @@ class CompositionModel(torch.nn.Module):
         precision is enforced.
 
         :param datasets: A list of datasets to create the dataloader from.
-        :param requested_neighbor_lists: A list of `NeighborListOptions` objects,
-            each of which specifies the parameters for a neighbor list that might be
-            required by the additive models whose contributions will be removed from
-            the targets before fitting the composition weights.
+        :param additive_models: A list of the additive models whose contributions should
+            be removed from the targets before fitting the composition weights. This is
+            used to build the collate function for the dataloader.
         :param batch_size: The batch size to use for the dataloader.
         :param is_distributed: Whether to use distributed sampling for the dataloader.
+        :param initial_transforms: A list of any additional callables to be included in
+            the collate function, which should be applied before the callable that
+            removes the additive contributions. This can be used to include the atomic
+            basis transform, for example, if needed.
         :return: A DataLoader for the CompositionModel fitting.
         """
-        # Create the collate function
-        collate_fn = CollateFn(
-            target_keys=list(self.dataset_info.targets.keys()),
-            callables=[
-                # these neighbor lists might be required by the other additive models
-                # that need to be removed from the targets before fitting the
-                # composition weights
-                get_system_with_neighbor_lists_transform(requested_neighbor_lists)
-            ],
-        )
 
         dtype = datasets[0][0]["system"].positions.dtype
         if dtype != torch.float64:
@@ -167,7 +211,9 @@ class CompositionModel(torch.nn.Module):
                     sampler=sampler,
                     shuffle=None if sampler else False,
                     drop_last=False,
-                    collate_fn=collate_fn,
+                    collate_fn=self._get_collate_fn(
+                        additive_models, initial_transforms
+                    ),
                 )
             )
 
@@ -180,6 +226,7 @@ class CompositionModel(torch.nn.Module):
         batch_size: int,
         is_distributed: bool,
         fixed_weights: Optional[FixedCompositionWeights] = None,
+        initial_transforms: Optional[List[Callable]] = None,
     ) -> None:
         """
         Train the composition model on the provided training data in the ``datasets``.
@@ -203,6 +250,10 @@ class CompositionModel(torch.nn.Module):
             If a dict of weights is provided for a target, all atomic types handled
             by the model must have a weight specified.
             If ``None``, all weights will be fitted normally.
+        :param initial_transforms: A list of any additional callables to be included in
+            the collate function, which should be applied before the callable that
+            removes the additive contributions. This can be used to include the atomic
+            basis transform, for example, if needed.
         """
 
         if not isinstance(datasets, list):
@@ -211,17 +262,16 @@ class CompositionModel(torch.nn.Module):
         if len(self.target_infos) == 0:  # no (new) targets to fit
             return
 
-        # Create dataloader for the training datasets. Note that these might need
-        # neighbor lists if any of the `additive_models` require them.
-        requested_neighbor_lists = []
-        for additive_model in additive_models:
-            if hasattr(additive_model, "requested_neighbor_lists"):
-                requested_neighbor_lists += additive_model.requested_neighbor_lists()
+        if initial_transforms is None:
+            initial_transforms = []
+
+        # Create dataloader for the training datasets
         dataloader = self._get_dataloader(
             datasets,
-            requested_neighbor_lists,
+            additive_models,
             batch_size,
             is_distributed=is_distributed,
+            initial_transforms=initial_transforms,
         )
 
         if fixed_weights is None:
@@ -242,17 +292,6 @@ class CompositionModel(torch.nn.Module):
             if len(targets) == 0:
                 break
 
-            # remove additive contributions from these targets
-            for additive_model in additive_models:
-                targets = remove_additive(
-                    systems,
-                    targets,
-                    additive_model,
-                    {
-                        target_name: self.target_infos[target_name]
-                        for target_name in targets
-                    },
-                )
             self.model.accumulate(systems, targets)
 
         if is_distributed:
@@ -369,6 +408,10 @@ class CompositionModel(torch.nn.Module):
         return self.outputs
 
     def _add_output(self, target_name: str, target_info: TargetInfo) -> None:
+        layout = target_info.layout
+        if target_info.is_atomic_basis:
+            layout = densify_atomic_basis_target(layout, layout)
+
         self.outputs[target_name] = ModelOutput(
             quantity=target_info.quantity,
             unit=target_info.unit,
@@ -379,12 +422,10 @@ class CompositionModel(torch.nn.Module):
         # Create a fake weights buffer for the target, filtering the blocks that will
         # not be fitted
         layout = mts.filter_blocks(
-            target_info.layout,
+            layout,
             Labels(
-                target_info.layout.keys.names,
-                torch.vstack(
-                    [key.values for key in target_info.layout.keys if _include_key(key)]
-                ),
+                layout.keys.names,
+                torch.vstack([key.values for key in layout.keys if _include_key(key)]),
                 assume_unique=True,
             ),
         )

--- a/src/metatrain/utils/additive/composition.py
+++ b/src/metatrain/utils/additive/composition.py
@@ -128,7 +128,7 @@ class CompositionModel(torch.nn.Module):
                 # these neighbor lists might be required by the other additive models
                 # that need to be removed from the targets before fitting the
                 # composition weights
-                get_system_with_neighbor_lists_transform(requested_neighbor_lists)
+                get_system_with_neighbor_lists_transform(requested_neighbor_lists),
             ],
         )
 

--- a/src/metatrain/utils/additive/composition.py
+++ b/src/metatrain/utils/additive/composition.py
@@ -128,7 +128,7 @@ class CompositionModel(torch.nn.Module):
                 # these neighbor lists might be required by the other additive models
                 # that need to be removed from the targets before fitting the
                 # composition weights
-                get_system_with_neighbor_lists_transform(requested_neighbor_lists),
+                get_system_with_neighbor_lists_transform(requested_neighbor_lists)
             ],
         )
 
@@ -230,7 +230,7 @@ class CompositionModel(torch.nn.Module):
         # Create dataloader for the training datasets
         dataloader = self._get_dataloader(
             datasets,
-            additive_models,
+            requested_neighbor_lists,
             batch_size,
             is_distributed=is_distributed,
             initial_transforms=initial_transforms,
@@ -265,7 +265,6 @@ class CompositionModel(torch.nn.Module):
                         for target_name in targets
                     },
                 )
-
             self.model.accumulate(systems, targets)
 
         if is_distributed:

--- a/src/metatrain/utils/additive/composition.py
+++ b/src/metatrain/utils/additive/composition.py
@@ -1,19 +1,16 @@
 import logging
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Sequence, Union
 
 import metatensor.torch as mts
 import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
-from metatomic.torch import ModelOutput, System
+from metatomic.torch import ModelOutput, NeighborListOptions, System
 from torch.utils.data import DataLoader, DistributedSampler
 
 from metatrain.utils.data import (
     CollateFn,
     CombinedDataLoader,
     Dataset,
-)
-from metatrain.utils.data.atomic_basis_helpers import (
-    densify_atomic_basis_target,
 )
 from metatrain.utils.neighbor_lists import get_system_with_neighbor_lists_transform
 
@@ -24,7 +21,7 @@ from ._base_composition import (
     FixedCompositionWeights,
     _include_key,
 )
-from .remove import get_remove_additive_transform
+from .remove import remove_additive
 
 
 class CompositionModel(torch.nn.Module):
@@ -96,60 +93,13 @@ class CompositionModel(torch.nn.Module):
             self._new_outputs.append(target_name)
             self._add_output(target_name, target_info)
 
-    def _get_collate_fn(
-        self,
-        additive_models: List[torch.nn.Module],
-        initial_transforms: List[Callable],
-    ) -> CollateFn:
-        """
-        Build a collate function for the dataloader that will be used to fit the
-        composition weights. This collate function will include the necessary callables:
-
-            - any initial transforms provided in `initial_transforms`
-            - adds any necessary neighbor lists.
-            - adds additive model contributions (other than the composition model) that
-              are present in the model.
-
-        :param additive_models: A list of the additive models whose contributions should
-            be removed from the targets before fitting the composition weights. This is
-            used to build the collate function for the dataloader.
-        :param initial_transforms: A list of any additional callables to be included in
-            the collate function, which should be applied before the callable that
-            removes the additive contributions. This can be used to include the atomic
-            basis transform, for example, if needed.
-        :return: The created collate function.
-        """
-        callables = []
-        if len(initial_transforms) > 0:
-            callables += initial_transforms
-
-        if len(additive_models) > 0:
-            requested_neighbor_lists = []
-            for additive_model in additive_models:
-                if hasattr(additive_model, "requested_neighbor_lists"):
-                    requested_neighbor_lists += (
-                        additive_model.requested_neighbor_lists()
-                    )
-
-            callables += [
-                get_system_with_neighbor_lists_transform(requested_neighbor_lists),
-                get_remove_additive_transform(
-                    additive_models, self.dataset_info.targets
-                ),
-            ]
-
-        return CollateFn(
-            target_keys=list(self.dataset_info.targets.keys()),
-            callables=callables,
-        )
-
     def _get_dataloader(
         self,
         datasets: List[Union[Dataset, torch.utils.data.Subset]],
-        additive_models: List[torch.nn.Module],
+        requested_neighbor_lists: List[NeighborListOptions],
         batch_size: int,
         is_distributed: bool,
-        initial_transforms: List[Callable],
+        initial_transforms: Sequence[Callable],
     ) -> DataLoader:
         """
         Create a DataLoader for the provided datasets. As the dataloader is only used to
@@ -159,17 +109,28 @@ class CompositionModel(torch.nn.Module):
         precision is enforced.
 
         :param datasets: A list of datasets to create the dataloader from.
-        :param additive_models: A list of the additive models whose contributions should
-            be removed from the targets before fitting the composition weights. This is
-            used to build the collate function for the dataloader.
+        :param requested_neighbor_lists: A list of `NeighborListOptions` objects,
+            each of which specifies the parameters for a neighbor list that might be
+            required by the additive models whose contributions will be removed from
+            the targets before fitting the composition weights.
         :param batch_size: The batch size to use for the dataloader.
         :param is_distributed: Whether to use distributed sampling for the dataloader.
-        :param initial_transforms: A list of any additional callables to be included in
-            the collate function, which should be applied before the callable that
-            removes the additive contributions. This can be used to include the atomic
-            basis transform, for example, if needed.
+        :param initial_transforms: A list of callables to be included in
+            the collate function. The callables passed here will be applied before the
+            other callables set by the composition model.
         :return: A DataLoader for the CompositionModel fitting.
         """
+        # Create the collate function
+        collate_fn = CollateFn(
+            target_keys=list(self.dataset_info.targets.keys()),
+            callables=[
+                *initial_transforms,
+                # these neighbor lists might be required by the other additive models
+                # that need to be removed from the targets before fitting the
+                # composition weights
+                get_system_with_neighbor_lists_transform(requested_neighbor_lists),
+            ],
+        )
 
         dtype = datasets[0][0]["system"].positions.dtype
         if dtype != torch.float64:
@@ -211,9 +172,7 @@ class CompositionModel(torch.nn.Module):
                     sampler=sampler,
                     shuffle=None if sampler else False,
                     drop_last=False,
-                    collate_fn=self._get_collate_fn(
-                        additive_models, initial_transforms
-                    ),
+                    collate_fn=collate_fn,
                 )
             )
 
@@ -226,7 +185,7 @@ class CompositionModel(torch.nn.Module):
         batch_size: int,
         is_distributed: bool,
         fixed_weights: Optional[FixedCompositionWeights] = None,
-        initial_transforms: Optional[List[Callable]] = None,
+        initial_transforms: Sequence[Callable] = (),
     ) -> None:
         """
         Train the composition model on the provided training data in the ``datasets``.
@@ -250,10 +209,9 @@ class CompositionModel(torch.nn.Module):
             If a dict of weights is provided for a target, all atomic types handled
             by the model must have a weight specified.
             If ``None``, all weights will be fitted normally.
-        :param initial_transforms: A list of any additional callables to be included in
-            the collate function, which should be applied before the callable that
-            removes the additive contributions. This can be used to include the atomic
-            basis transform, for example, if needed.
+        :param initial_transforms: A list of callables to be included in
+            the collate function of the dataloader. The callables passed here will be
+            applied before the other callables set by the composition model.
         """
 
         if not isinstance(datasets, list):
@@ -262,8 +220,12 @@ class CompositionModel(torch.nn.Module):
         if len(self.target_infos) == 0:  # no (new) targets to fit
             return
 
-        if initial_transforms is None:
-            initial_transforms = []
+        # Create dataloader for the training datasets. Note that these might need
+        # neighbor lists if any of the `additive_models` require them.
+        requested_neighbor_lists = []
+        for additive_model in additive_models:
+            if hasattr(additive_model, "requested_neighbor_lists"):
+                requested_neighbor_lists += additive_model.requested_neighbor_lists()
 
         # Create dataloader for the training datasets
         dataloader = self._get_dataloader(
@@ -291,6 +253,18 @@ class CompositionModel(torch.nn.Module):
             }
             if len(targets) == 0:
                 break
+
+            # remove additive contributions from these targets
+            for additive_model in additive_models:
+                targets = remove_additive(
+                    systems,
+                    targets,
+                    additive_model,
+                    {
+                        target_name: self.target_infos[target_name]
+                        for target_name in targets
+                    },
+                )
 
             self.model.accumulate(systems, targets)
 
@@ -408,10 +382,6 @@ class CompositionModel(torch.nn.Module):
         return self.outputs
 
     def _add_output(self, target_name: str, target_info: TargetInfo) -> None:
-        layout = target_info.layout
-        if target_info.is_atomic_basis:
-            layout = densify_atomic_basis_target(layout, layout)
-
         self.outputs[target_name] = ModelOutput(
             quantity=target_info.quantity,
             unit=target_info.unit,
@@ -422,10 +392,12 @@ class CompositionModel(torch.nn.Module):
         # Create a fake weights buffer for the target, filtering the blocks that will
         # not be fitted
         layout = mts.filter_blocks(
-            layout,
+            target_info.layout,
             Labels(
-                layout.keys.names,
-                torch.vstack([key.values for key in layout.keys if _include_key(key)]),
+                target_info.layout.keys.names,
+                torch.vstack(
+                    [key.values for key in target_info.layout.keys if _include_key(key)]
+                ),
                 assume_unique=True,
             ),
         )

--- a/src/metatrain/utils/additive/remove.py
+++ b/src/metatrain/utils/additive/remove.py
@@ -154,12 +154,12 @@ def get_remove_additive_transform(
         :return: The systems, updated targets and extra data.
         """
         for additive_model in additive_models:
-            new_targets = remove_additive(
+            targets = remove_additive(
                 systems,
                 targets,
                 additive_model,
                 target_info_dict,
             )
-        return systems, new_targets, extra
+        return systems, targets, extra
 
     return transform

--- a/src/metatrain/utils/data/atomic_basis_helpers.py
+++ b/src/metatrain/utils/data/atomic_basis_helpers.py
@@ -5,6 +5,7 @@ import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
 from metatomic.torch import System
 
+from ..data import DatasetInfo
 from .target_info import TargetInfo
 
 
@@ -677,3 +678,38 @@ def get_prepare_atomic_basis_targets_transform(
         return systems, targets, extra
 
     return transform, reverse_transform
+
+
+# ===== DatasetInfo manipulation utilities
+
+
+def densify_atomic_basis_dataset_info(dataset_info: DatasetInfo) -> DatasetInfo:
+    """
+    Densify the atomic basis target layouts in the TargetInfos of the input
+    ``dataset_info`` by moving any
+
+    :param dataset_info: the input DatasetInfo with TargetInfos containing atomic basis
+        targets to densify.
+    :return: a new DatasetInfo with the same information as the input, but with the
+        atomic basis targets densified.
+    """
+
+    return DatasetInfo(
+        length_unit=dataset_info.length_unit,
+        atomic_types=dataset_info.atomic_types,
+        targets={
+            target_name: (
+                TargetInfo(
+                    quantity=target_info.quantity,
+                    unit=target_info.unit,
+                    layout=densify_atomic_basis_target(
+                        target_info.layout, target_info.layout
+                    ),
+                    description=target_info.description,
+                )
+                if target_info.is_atomic_basis
+                else target_info
+            )
+            for target_name, target_info in dataset_info.targets.items()
+        },
+    )

--- a/src/metatrain/utils/scaler/scaler.py
+++ b/src/metatrain/utils/scaler/scaler.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 import metatensor.torch as mts
 import torch
@@ -6,14 +6,17 @@ from metatensor.torch import Labels, TensorBlock, TensorMap
 from metatomic.torch import ModelOutput, System
 from torch.utils.data import DataLoader, DistributedSampler
 
+from metatrain.utils.additive import get_remove_additive_transform
 from metatrain.utils.data import (
     CollateFn,
     CombinedDataLoader,
     Dataset,
 )
+from metatrain.utils.data.atomic_basis_helpers import (
+    densify_atomic_basis_target,
+)
 from metatrain.utils.per_atom import average_by_num_atoms
 
-from ..additive import remove_additive
 from ..data import DatasetInfo, TargetInfo, unpack_batch
 from ..transfer import batch_to
 from ._base_scaler import BaseScaler, FixedScalerWeights
@@ -21,7 +24,9 @@ from ._base_scaler import BaseScaler, FixedScalerWeights
 
 class Scaler(torch.nn.Module):
     """
-    Placeholder docs.
+    Fits a scaler for a dict of targets. Scales are computed as the per-property (and
+    therefore per-block) standard deviations. By default, the scales are also computed
+    per atomic type for per-atom targets.
 
     :param hypers: Hyperparameters for the scaler. Should be an empty dictionary.
     :param dataset_info: Information about the dataset used to initialize the scaler.
@@ -65,11 +70,51 @@ class Scaler(torch.nn.Module):
             self.new_outputs.append(target_name)
             self._add_output(target_name, target_info)
 
+    def _get_collate_fn(
+        self,
+        additive_models: List[torch.nn.Module],
+        initial_transforms: List[Callable],
+    ) -> CollateFn:
+        """
+        Build a collate function for the dataloader that will be used to fit the
+        composition weights. This collate function will include the necessary callables:
+
+            - any initial transforms provided in `initial_transforms`
+            - adds additive model contributions (other than the composition model) that
+              are present in the model.
+
+        :param additive_models: A list of the additive models whose contributions should
+            be removed from the targets before fitting the composition weights. This is
+            used to build the collate function for the dataloader.
+        :param initial_transforms: A list of any additional callables to be included in
+            the collate function, which should be applied before the callable that
+            removes the additive contributions. This can be used to include the atomic
+            basis transform, for example, if needed.
+        :return: The created collate function.
+        """
+        callables = []
+        if len(initial_transforms) > 0:
+            callables += initial_transforms
+
+        if len(additive_models) > 0:
+            callables.append(
+                get_remove_additive_transform(
+                    additive_models, self.dataset_info.targets
+                ),
+            )
+
+        return CollateFn(
+            target_keys=list(self.dataset_info.targets.keys()),
+            callables=callables,
+        )
+
     def _get_dataloader(
         self,
         datasets: List[Union[Dataset, torch.utils.data.Subset]],
+        additive_models: List[torch.nn.Module],
         batch_size: int,
         is_distributed: bool,
+        initial_transforms: List[Callable],
     ) -> DataLoader:
         """
         Create a DataLoader for the provided datasets. As the dataloader is only used to
@@ -79,13 +124,17 @@ class Scaler(torch.nn.Module):
         is enforced.
 
         :param datasets: List of datasets to create the dataloader from.
+        :param additive_models: A list of the additive models whose contributions should
+            be removed from the targets before fitting the scaler weights. This is used
+            to build the collate function for the dataloader.
         :param batch_size: Batch size to use for the dataloader.
         :param is_distributed: Whether to use distributed sampling or not.
+        :param initial_transforms: A list of any additional callables to be included in
+            the collate function, which should be applied before the callable that
+            removes the additive contributions. This can be used to include the atomic
+            basis transform, for example, if needed.
         :return: The created DataLoader.
         """
-        # Create the collate function
-        targets_keys = list(self.dataset_info.targets.keys())
-        collate_fn = CollateFn(target_keys=targets_keys)
 
         dtype = datasets[0][0]["system"].positions.dtype
         if dtype != torch.float64:
@@ -127,7 +176,9 @@ class Scaler(torch.nn.Module):
                     sampler=sampler,
                     shuffle=None if sampler else False,
                     drop_last=False,
-                    collate_fn=collate_fn,
+                    collate_fn=self._get_collate_fn(
+                        additive_models, initial_transforms
+                    ),
                 )
             )
 
@@ -140,9 +191,15 @@ class Scaler(torch.nn.Module):
         batch_size: int,
         is_distributed: bool,
         fixed_weights: Optional[FixedScalerWeights] = None,
+        initial_transforms: Optional[List[Callable]] = None,
     ) -> None:
         """
-        Placeholder docs.
+        Train the scaler model by accumulating the necessary quantities from the
+        provided datasets and fitting the scales. The scales are computed as the
+        per-property (and therefore per-block) standard deviations. By default, the
+        scales are also computed per atomic type for per-atom targets. If
+        `fixed_weights` is provided, these are used instead of the computed scales for
+        the specified targets.
 
         :param datasets: List of datasets to use for training the scaler.
         :param additive_models: List of additive models to remove from the targets
@@ -154,6 +211,10 @@ class Scaler(torch.nn.Module):
             are either a single float value to be applied to all atomic types, or a
             dict mapping atomic type (int) to weight (float). If not provided, all
             scales will be computed based on the accumulated quantities.
+        :param initial_transforms: A list of any additional callables to be included in
+            the collate function, which should be applied before the callable that
+            removes the additive contributions. This can be used to include the atomic
+            basis transform, for example, if needed.
         """
         if not isinstance(datasets, list):
             datasets = [datasets]
@@ -161,9 +222,16 @@ class Scaler(torch.nn.Module):
         if len(self.target_infos) == 0:  # no (new) targets to fit
             return
 
+        if initial_transforms is None:
+            initial_transforms = []
+
         # Create dataloader for the training datasets
         dataloader = self._get_dataloader(
-            datasets, batch_size, is_distributed=is_distributed
+            datasets,
+            additive_models,
+            batch_size,
+            is_distributed=is_distributed,
+            initial_transforms=initial_transforms,
         )
 
         device = self.dummy_buffer.device
@@ -177,17 +245,6 @@ class Scaler(torch.nn.Module):
             if len(targets) == 0:
                 break
 
-            # remove additive contributions from these targets
-            for additive_model in additive_models:
-                targets = remove_additive(
-                    systems,
-                    targets,
-                    additive_model,
-                    {
-                        target_name: self.target_infos[target_name]
-                        for target_name in targets
-                    },
-                )
             targets = average_by_num_atoms(targets, systems, [])
             self.model.accumulate(systems, targets, extra_data)
 
@@ -283,14 +340,16 @@ class Scaler(torch.nn.Module):
         return self.outputs
 
     def _add_output(self, target_name: str, target_info: TargetInfo) -> None:
+        layout = target_info.layout
+        if target_info.is_atomic_basis:
+            layout = densify_atomic_basis_target(layout, layout)
+
         self.outputs[target_name] = ModelOutput(
             quantity=target_info.quantity,
             unit=target_info.unit,
             per_atom=True,
             description=target_info.description,
         )
-
-        layout = target_info.layout
 
         valid_sample_names = [
             ["system"],

--- a/src/metatrain/utils/scaler/scaler.py
+++ b/src/metatrain/utils/scaler/scaler.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Sequence, Union
 
 import metatensor.torch as mts
 import torch
@@ -6,17 +6,14 @@ from metatensor.torch import Labels, TensorBlock, TensorMap
 from metatomic.torch import ModelOutput, System
 from torch.utils.data import DataLoader, DistributedSampler
 
-from metatrain.utils.additive import get_remove_additive_transform
 from metatrain.utils.data import (
     CollateFn,
     CombinedDataLoader,
     Dataset,
 )
-from metatrain.utils.data.atomic_basis_helpers import (
-    densify_atomic_basis_target,
-)
 from metatrain.utils.per_atom import average_by_num_atoms
 
+from ..additive import remove_additive
 from ..data import DatasetInfo, TargetInfo, unpack_batch
 from ..transfer import batch_to
 from ._base_scaler import BaseScaler, FixedScalerWeights
@@ -70,51 +67,12 @@ class Scaler(torch.nn.Module):
             self.new_outputs.append(target_name)
             self._add_output(target_name, target_info)
 
-    def _get_collate_fn(
-        self,
-        additive_models: List[torch.nn.Module],
-        initial_transforms: List[Callable],
-    ) -> CollateFn:
-        """
-        Build a collate function for the dataloader that will be used to fit the
-        composition weights. This collate function will include the necessary callables:
-
-            - any initial transforms provided in `initial_transforms`
-            - adds additive model contributions (other than the composition model) that
-              are present in the model.
-
-        :param additive_models: A list of the additive models whose contributions should
-            be removed from the targets before fitting the composition weights. This is
-            used to build the collate function for the dataloader.
-        :param initial_transforms: A list of any additional callables to be included in
-            the collate function, which should be applied before the callable that
-            removes the additive contributions. This can be used to include the atomic
-            basis transform, for example, if needed.
-        :return: The created collate function.
-        """
-        callables = []
-        if len(initial_transforms) > 0:
-            callables += initial_transforms
-
-        if len(additive_models) > 0:
-            callables.append(
-                get_remove_additive_transform(
-                    additive_models, self.dataset_info.targets
-                ),
-            )
-
-        return CollateFn(
-            target_keys=list(self.dataset_info.targets.keys()),
-            callables=callables,
-        )
-
     def _get_dataloader(
         self,
         datasets: List[Union[Dataset, torch.utils.data.Subset]],
-        additive_models: List[torch.nn.Module],
         batch_size: int,
         is_distributed: bool,
-        initial_transforms: List[Callable],
+        initial_transforms: Sequence[Callable],
     ) -> DataLoader:
         """
         Create a DataLoader for the provided datasets. As the dataloader is only used to
@@ -124,17 +82,18 @@ class Scaler(torch.nn.Module):
         is enforced.
 
         :param datasets: List of datasets to create the dataloader from.
-        :param additive_models: A list of the additive models whose contributions should
-            be removed from the targets before fitting the scaler weights. This is used
-            to build the collate function for the dataloader.
         :param batch_size: Batch size to use for the dataloader.
         :param is_distributed: Whether to use distributed sampling or not.
-        :param initial_transforms: A list of any additional callables to be included in
-            the collate function, which should be applied before the callable that
-            removes the additive contributions. This can be used to include the atomic
-            basis transform, for example, if needed.
+        :param initial_transforms: A list of callables to be included in
+            the collate function. The callables passed here will be
+            applied before the other callables set by the scaler.
         :return: The created DataLoader.
         """
+        # Create the collate function
+        targets_keys = list(self.dataset_info.targets.keys())
+        collate_fn = CollateFn(
+            target_keys=targets_keys, callables=[*initial_transforms]
+        )
 
         dtype = datasets[0][0]["system"].positions.dtype
         if dtype != torch.float64:
@@ -176,9 +135,7 @@ class Scaler(torch.nn.Module):
                     sampler=sampler,
                     shuffle=None if sampler else False,
                     drop_last=False,
-                    collate_fn=self._get_collate_fn(
-                        additive_models, initial_transforms
-                    ),
+                    collate_fn=collate_fn,
                 )
             )
 
@@ -191,7 +148,7 @@ class Scaler(torch.nn.Module):
         batch_size: int,
         is_distributed: bool,
         fixed_weights: Optional[FixedScalerWeights] = None,
-        initial_transforms: Optional[List[Callable]] = None,
+        initial_transforms: Sequence[Callable] = (),
     ) -> None:
         """
         Train the scaler model by accumulating the necessary quantities from the
@@ -211,10 +168,9 @@ class Scaler(torch.nn.Module):
             are either a single float value to be applied to all atomic types, or a
             dict mapping atomic type (int) to weight (float). If not provided, all
             scales will be computed based on the accumulated quantities.
-        :param initial_transforms: A list of any additional callables to be included in
-            the collate function, which should be applied before the callable that
-            removes the additive contributions. This can be used to include the atomic
-            basis transform, for example, if needed.
+        :param initial_transforms: A list of callables to be included in
+            the collate function of the dataloader. The callables passed here will be
+            applied before the other callables set by the scaler.
         """
         if not isinstance(datasets, list):
             datasets = [datasets]
@@ -222,13 +178,9 @@ class Scaler(torch.nn.Module):
         if len(self.target_infos) == 0:  # no (new) targets to fit
             return
 
-        if initial_transforms is None:
-            initial_transforms = []
-
         # Create dataloader for the training datasets
         dataloader = self._get_dataloader(
             datasets,
-            additive_models,
             batch_size,
             is_distributed=is_distributed,
             initial_transforms=initial_transforms,
@@ -245,6 +197,17 @@ class Scaler(torch.nn.Module):
             if len(targets) == 0:
                 break
 
+            # remove additive contributions from these targets
+            for additive_model in additive_models:
+                targets = remove_additive(
+                    systems,
+                    targets,
+                    additive_model,
+                    {
+                        target_name: self.target_infos[target_name]
+                        for target_name in targets
+                    },
+                )
             targets = average_by_num_atoms(targets, systems, [])
             self.model.accumulate(systems, targets, extra_data)
 
@@ -340,16 +303,14 @@ class Scaler(torch.nn.Module):
         return self.outputs
 
     def _add_output(self, target_name: str, target_info: TargetInfo) -> None:
-        layout = target_info.layout
-        if target_info.is_atomic_basis:
-            layout = densify_atomic_basis_target(layout, layout)
-
         self.outputs[target_name] = ModelOutput(
             quantity=target_info.quantity,
             unit=target_info.unit,
             per_atom=True,
             description=target_info.description,
         )
+
+        layout = target_info.layout
 
         valid_sample_names = [
             ["system"],

--- a/tests/utils/test_additive.py
+++ b/tests/utils/test_additive.py
@@ -13,6 +13,10 @@ from metatrain.utils.additive import (
     remove_additive,
 )
 from metatrain.utils.data import Dataset, DatasetInfo
+from metatrain.utils.data.atomic_basis_helpers import (
+    densify_atomic_basis_dataset_info,
+    get_prepare_atomic_basis_targets_transform,
+)
 from metatrain.utils.data.readers import read_systems, read_targets
 from metatrain.utils.data.target_info import (
     get_energy_target_info,
@@ -906,7 +910,9 @@ def test_composition_many_subtargets():
 
 
 def test_composition_spherical():
-    """Test the calculation of composition weights for a per-structure scalar."""
+    """
+    Test the calculation of composition weights for a per-structure spherical target.
+    """
 
     # Here we use three synthetic structures, each with an invariant target and random
     # spherical targets with L=1:
@@ -1230,3 +1236,557 @@ def test_composition_spherical_atomic_basis(missing_type):
         torch.testing.assert_close(
             F_block.values, torch.tensor([0.0], dtype=torch.float64).reshape(-1, 1, 1)
         )
+
+
+def test_composition_spherical_atomic_basis_dense():
+    """
+    Test the composition weights for an atomic-basis spherical target in the
+    dense representation are correct.
+
+    With two H atoms (invariant values 2.0 and 4.0 on H's single basis function) and two
+    O atoms (invariant values (3.0, 5.0) and (7.0, 9.0) on O's two basis functions), the
+    expected composition weights are:
+
+        W[H, n=0] = mean(2.0, 4.0) = 3.0  (H data, H's single basis)
+        W[H, n=0] = NaN
+        W[O, n=0] = mean(3.0, 7.0) = 5.0  (O data, O's first basis)
+        W[O, n=1] = mean(5.0, 9.0) = 7.0  (O data, O's second basis)
+    """
+    atomic_types = [1, 8]
+
+    # Build targets in the sparse representation with ``atom_type`` as a key
+    # dimension.
+    components = [Labels(names=["o3_mu"], values=torch.tensor([[0]]))]
+
+    tensor_map_1 = TensorMap(
+        keys=Labels(
+            names=["o3_lambda", "o3_sigma", "atom_type"],
+            values=torch.tensor([[0, 1, 1]]),
+        ),
+        blocks=[
+            TensorBlock(
+                values=torch.tensor(
+                    [[[2.0]], [[4.0]]], dtype=torch.float64
+                ),  # two H atoms, single invariant basis
+                samples=Labels(
+                    names=["system", "atom"],
+                    values=torch.tensor([[0, 0], [0, 1]]),
+                ),
+                components=components,
+                properties=Labels(names=["n"], values=torch.tensor([[0]])),
+            ),
+        ],
+    )
+    tensor_map_2 = TensorMap(
+        keys=Labels(
+            names=["o3_lambda", "o3_sigma", "atom_type"],
+            values=torch.tensor([[0, 1, 8]]),
+        ),
+        blocks=[
+            TensorBlock(
+                values=torch.tensor(
+                    [[[3.0, 5.0]], [[7.0, 9.0]]], dtype=torch.float64
+                ),  # two O atoms, two invariant bases each
+                samples=Labels(
+                    names=["system", "atom"],
+                    values=torch.tensor([[1, 0], [1, 1]]),
+                ),
+                components=components,
+                properties=Labels(names=["n"], values=torch.tensor([[0], [1]])),
+            ),
+        ],
+    )
+
+    systems = [
+        System(
+            positions=torch.zeros((2, 3), dtype=torch.float64),
+            types=torch.tensor([1, 1]),
+            cell=torch.eye(3, dtype=torch.float64),
+            pbc=torch.tensor([True, True, True]),
+        ),
+        System(
+            positions=torch.zeros((2, 3), dtype=torch.float64),
+            types=torch.tensor([8, 8]),
+            cell=torch.eye(3, dtype=torch.float64),
+            pbc=torch.tensor([True, True, True]),
+        ),
+    ]
+
+    # ``mtt::aux::system_index`` is auto-added by DiskDataset but not by
+    # ``Dataset.from_dict``; the atomic-basis densification transform in the
+    # collate function asserts on its presence, so we add it explicitly here.
+    system_indices = [
+        TensorMap(
+            keys=Labels(names=["_"], values=torch.tensor([[0]])),
+            blocks=[
+                TensorBlock(
+                    values=torch.tensor([[i]], dtype=torch.float64),
+                    samples=Labels(names=["system"], values=torch.tensor([[i]])),
+                    components=[],
+                    properties=Labels(names=["_"], values=torch.tensor([[0]])),
+                )
+            ],
+        )
+        for i in range(len(systems))
+    ]
+    dataset = Dataset.from_dict(
+        {
+            "system": systems,
+            "spherical_atomic_basis": [tensor_map_1, tensor_map_2],
+            "mtt::aux::system_index": system_indices,
+        }
+    )
+
+    # H has 1 invariant basis function; O has 2 invariant basis functions.
+    irreps = {
+        1: [{"o3_lambda": 0, "o3_sigma": 1, "num": 1}],
+        8: [{"o3_lambda": 0, "o3_sigma": 1, "num": 2}],
+    }
+
+    dataset_info = DatasetInfo(
+        length_unit="angstrom",
+        atomic_types=atomic_types,
+        targets={
+            "spherical_atomic_basis": get_generic_target_info(
+                "spherical_atomic_basis",
+                {
+                    "quantity": "",
+                    "unit": "",
+                    "type": {"spherical": {"irreps": irreps}},
+                    "num_subtargets": 1,
+                    "per_atom": True,
+                },
+            )
+        },
+    )
+
+    # Densify targets to the dense representation
+    atomic_basis_transform, _ = get_prepare_atomic_basis_targets_transform(
+        dataset_info.targets, {}
+    )
+    dataset_info_dense = densify_atomic_basis_dataset_info(dataset_info)
+
+    composition_model = CompositionModel(
+        hypers={},
+        dataset_info=dataset_info_dense,
+    )
+    composition_model.train_model(
+        [dataset],
+        [],
+        batch_size=2,
+        is_distributed=False,
+        initial_transforms=[atomic_basis_transform],
+    )
+
+    # Check weights
+    weight_block = composition_model.model.weights["spherical_atomic_basis"].block(
+        {"o3_lambda": 0, "o3_sigma": 1}
+    )
+    W = weight_block.values
+    nan = float("nan")
+    expected = torch.tensor(
+        [
+            [[3.0, nan]],
+            [[5.0, 7.0]],
+        ],
+        dtype=torch.float64,
+    )
+    print("Composition weights:\n", W)
+    print("Expected weights:\n", expected)
+    torch.testing.assert_close(W, expected, rtol=1e-10, atol=1e-10, equal_nan=True)
+
+    # Check predictions
+    predictions = composition_model(
+        systems,
+        outputs={"spherical_atomic_basis": ModelOutput(per_atom=True)},
+    )
+    pred_values = (
+        predictions["spherical_atomic_basis"]
+        .block({"o3_lambda": 0, "o3_sigma": 1})
+        .values
+    )
+    expected_preds = torch.tensor(
+        [
+            [[3.0, nan]],
+            [[3.0, nan]],
+            [[5.0, 7.0]],
+            [[5.0, 7.0]],
+        ],
+        dtype=torch.float64,
+    )
+    print("Predicted values:\n", pred_values)
+    print("Expected values:\n", expected_preds)
+    torch.testing.assert_close(
+        pred_values, expected_preds, rtol=1e-10, atol=1e-10, equal_nan=True
+    )
+
+
+def test_composition_atomic_basis_sparse_dense_consistency():
+    """
+    Fit composition model in both the sparse and dense representations for an atomic
+    basis target, and check for consistency.
+    """
+    atomic_types = [1, 8]
+    n_atoms_per_type = 3
+
+    h_values = torch.tensor([[2.0], [4.0], [6.0]], dtype=torch.float64)
+    o_values = torch.tensor([[3.0, 5.0], [7.0, 9.0], [11.0, 13.0]], dtype=torch.float64)
+
+    systems = [
+        System(
+            positions=torch.zeros((2 * n_atoms_per_type, 3), dtype=torch.float64),
+            types=torch.tensor([1, 1, 1, 8, 8, 8]),
+            cell=torch.eye(3, dtype=torch.float64),
+            pbc=torch.tensor([True, True, True]),
+        )
+    ]
+    components = [Labels(names=["o3_mu"], values=torch.tensor([[0]]))]
+
+    sparse_keys = Labels(
+        names=["o3_lambda", "o3_sigma", "atom_type"],
+        values=torch.tensor([[0, 1, 1], [0, 1, 8]]),
+    )
+    target = TensorMap(
+        sparse_keys,
+        [
+            TensorBlock(
+                values=h_values.reshape(-1, 1, 1),
+                samples=Labels(
+                    names=["system", "atom"],
+                    values=torch.tensor([[0, 0], [0, 1], [0, 2]]),
+                ),
+                components=components,
+                properties=Labels(names=["n"], values=torch.tensor([[0]])),
+            ),
+            TensorBlock(
+                values=o_values.reshape(-1, 1, 2),
+                samples=Labels(
+                    names=["system", "atom"],
+                    values=torch.tensor([[0, 3], [0, 4], [0, 5]]),
+                ),
+                components=components,
+                properties=Labels(names=["n"], values=torch.tensor([[0], [1]])),
+            ),
+        ],
+    )
+    # ``mtt::aux::system_index`` is needed for densifying atomic basis targets.
+    system_indices = [
+        TensorMap(
+            keys=Labels(names=["_"], values=torch.tensor([[0]])),
+            blocks=[
+                TensorBlock(
+                    values=torch.tensor([[i]], dtype=torch.float64),
+                    samples=Labels(names=["system"], values=torch.tensor([[i]])),
+                    components=[],
+                    properties=Labels(names=["_"], values=torch.tensor([[0]])),
+                )
+            ],
+        )
+        for i in range(len(systems))
+    ]
+    dataset = Dataset.from_dict(
+        {
+            "system": systems,
+            "target": [target],
+            "mtt::aux::system_index": system_indices,
+        }
+    )
+
+    # Target-info: H with a single invariant basis, O with two invariant bases.
+    irreps = {
+        1: [{"o3_lambda": 0, "o3_sigma": 1, "num": 1}],
+        8: [{"o3_lambda": 0, "o3_sigma": 1, "num": 2}],
+    }
+    dataset_info = DatasetInfo(
+        length_unit="angstrom",
+        atomic_types=atomic_types,
+        targets={
+            "target": get_generic_target_info(
+                "target",
+                {
+                    "quantity": "",
+                    "unit": "",
+                    "type": {"spherical": {"irreps": irreps}},
+                    "num_subtargets": 1,
+                    "per_atom": True,
+                },
+            )
+        },
+    )
+
+    # Fit sparse and dense CompositionModels on the same dataset.
+    sparse_model = CompositionModel(
+        hypers={},
+        dataset_info=dataset_info,
+    )
+    sparse_model.train_model(
+        [dataset], [], batch_size=1, is_distributed=False, initial_transforms=[]
+    )
+
+    # Densify targets to the dense representation
+    atomic_basis_transform, _ = get_prepare_atomic_basis_targets_transform(
+        dataset_info.targets, {}
+    )
+    dataset_info_dense = densify_atomic_basis_dataset_info(dataset_info)
+
+    dense_model = CompositionModel(
+        hypers={},
+        dataset_info=dataset_info_dense,
+    )
+    dense_model.train_model(
+        [dataset],
+        [],
+        batch_size=1,
+        is_distributed=False,
+        initial_transforms=[atomic_basis_transform],
+    )
+
+    # Get the weights
+    w_sparse_H = (
+        sparse_model.model.weights["target"]
+        .block({"o3_lambda": 0, "o3_sigma": 1, "atom_type": 1})
+        .values
+    )
+    w_sparse_O = (
+        sparse_model.model.weights["target"]
+        .block({"o3_lambda": 0, "o3_sigma": 1, "atom_type": 8})
+        .values
+    )
+    w_dense = (
+        dense_model.model.weights["target"]
+        .block({"o3_lambda": 0, "o3_sigma": 1})
+        .values
+    )
+
+    h_index = 0
+    o_index = 1
+
+    # Consistency checks
+    torch.testing.assert_close(
+        w_dense[h_index, 0, 0],
+        w_sparse_H[h_index, 0, 0],
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    torch.testing.assert_close(
+        w_dense[o_index, 0, :],
+        w_sparse_O[o_index, 0, :],
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    assert torch.isnan(w_dense[h_index, 0, 1])
+
+    # Finally check the actual values of the sparse weights
+    torch.testing.assert_close(
+        w_sparse_H[h_index, 0, 0],
+        h_values.mean(),
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    torch.testing.assert_close(
+        w_sparse_O[o_index, 0, :],
+        o_values.mean(dim=0),
+        rtol=1e-10,
+        atol=1e-10,
+    )
+
+
+def test_composition_spherical_atomic_basis_dense_nan_weights():
+    """
+    Test that when fitting an atomic-basis spherical target in the *dense*
+    representation, produces ``NaN`` composition weights for exactly the properties
+    whose target values were NaN-padded for the given atom types during densification.
+    """
+    atomic_types = [1, 8]
+    components = [Labels(names=["o3_mu"], values=torch.tensor([[0]]))]
+
+    # Structure 1: one O atom with its two-basis invariant values.
+    tensor_map_1 = TensorMap(
+        keys=Labels(
+            names=["o3_lambda", "o3_sigma", "atom_type"],
+            values=torch.tensor([[0, 1, 8]]),
+        ),
+        blocks=[
+            TensorBlock(
+                values=torch.tensor([[[1.0, 2.0]]], dtype=torch.float64),
+                samples=Labels(names=["system", "atom"], values=torch.tensor([[0, 0]])),
+                components=components,
+                properties=Labels(names=["n"], values=torch.tensor([[0], [1]])),
+            ),
+        ],
+    )
+
+    # Structure 2: H2O molecule — two H and one O, each on their own bases.
+    tensor_map_2 = TensorMap(
+        keys=Labels(
+            names=["o3_lambda", "o3_sigma", "atom_type"],
+            values=torch.tensor([[0, 1, 1], [0, 1, 8]]),
+        ),
+        blocks=[
+            TensorBlock(
+                values=torch.tensor(
+                    [[[1.0]], [[1.5]]], dtype=torch.float64
+                ),  # two H atoms, single invariant basis
+                samples=Labels(
+                    names=["system", "atom"],
+                    values=torch.tensor([[1, 0], [1, 1]]),
+                ),
+                components=components,
+                properties=Labels(names=["n"], values=torch.tensor([[0]])),
+            ),
+            TensorBlock(
+                values=torch.tensor(
+                    [[[3.0, 4.0]]], dtype=torch.float64
+                ),  # one O atom, two invariant bases
+                samples=Labels(names=["system", "atom"], values=torch.tensor([[1, 2]])),
+                components=components,
+                properties=Labels(names=["n"], values=torch.tensor([[0], [1]])),
+            ),
+        ],
+    )
+
+    systems = [
+        System(
+            positions=torch.zeros((1, 3), dtype=torch.float64),
+            types=torch.tensor([8]),
+            cell=torch.eye(3, dtype=torch.float64),
+            pbc=torch.tensor([True, True, True]),
+        ),
+        System(
+            positions=torch.zeros((3, 3), dtype=torch.float64),
+            types=torch.tensor([1, 1, 8]),
+            cell=torch.eye(3, dtype=torch.float64),
+            pbc=torch.tensor([True, True, True]),
+        ),
+    ]
+    # ``mtt::aux::system_index`` is needed for densifying atomic basis targets.
+    system_indices = [
+        TensorMap(
+            keys=Labels(names=["_"], values=torch.tensor([[0]])),
+            blocks=[
+                TensorBlock(
+                    values=torch.tensor([[i]], dtype=torch.float64),
+                    samples=Labels(names=["system"], values=torch.tensor([[i]])),
+                    components=[],
+                    properties=Labels(names=["_"], values=torch.tensor([[0]])),
+                )
+            ],
+        )
+        for i in range(len(systems))
+    ]
+    dataset = Dataset.from_dict(
+        {
+            "system": systems,
+            "spherical_atomic_basis": [tensor_map_1, tensor_map_2],
+            "mtt::aux::system_index": system_indices,
+        }
+    )
+
+    # H has 1 invariant basis; O has 2 invariant bases.
+    irreps = {
+        1: [{"o3_lambda": 0, "o3_sigma": 1, "num": 1}],
+        8: [{"o3_lambda": 0, "o3_sigma": 1, "num": 2}],
+    }
+
+    dataset_info = DatasetInfo(
+        length_unit="angstrom",
+        atomic_types=atomic_types,
+        targets={
+            "spherical_atomic_basis": get_generic_target_info(
+                "spherical_atomic_basis",
+                {
+                    "quantity": "",
+                    "unit": "",
+                    "type": {"spherical": {"irreps": irreps}},
+                    "num_subtargets": 1,
+                    "per_atom": True,
+                },
+            )
+        },
+    )
+    # Densify targets to the dense representation
+    atomic_basis_transform, _ = get_prepare_atomic_basis_targets_transform(
+        dataset_info.targets, {}
+    )
+    dataset_info_dense = densify_atomic_basis_dataset_info(dataset_info)
+
+    composition_model = CompositionModel(
+        hypers={},
+        dataset_info=dataset_info_dense,
+    )
+    composition_model.train_model(
+        [dataset],
+        [],
+        batch_size=1,
+        is_distributed=False,
+        initial_transforms=[atomic_basis_transform],
+    )
+
+    # Get weights
+    W = (
+        composition_model.model.weights["spherical_atomic_basis"]
+        .block({"o3_lambda": 0, "o3_sigma": 1})
+        .values
+    )
+    h_index, o_index = 0, 1
+
+    nan_mask_expected = torch.tensor(
+        [
+            [[False, True]],  # H: n=0 is finite, n=1 is NaN
+            [[False, False]],  # O: both positions finite
+        ]
+    )
+    assert torch.equal(torch.isnan(W), nan_mask_expected)
+
+    # Check non-NaN weights
+    torch.testing.assert_close(
+        W[h_index, 0, 0],
+        torch.tensor((1.0 + 1.5) / 2, dtype=torch.float64),
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    torch.testing.assert_close(
+        W[o_index, 0, :],
+        torch.tensor([(1.0 + 3.0) / 2, (2.0 + 4.0) / 2], dtype=torch.float64),
+        rtol=1e-10,
+        atol=1e-10,
+    )
+
+    # Get predictions
+    predictions = composition_model(
+        [systems[1]],
+        outputs={"spherical_atomic_basis": ModelOutput(per_atom=True)},
+    )
+    pred_values = (
+        predictions["spherical_atomic_basis"]
+        .block({"o3_lambda": 0, "o3_sigma": 1})
+        .values
+    )
+    pred_nan_mask_expected = torch.tensor(
+        [
+            [[False, True]],  # H atom 0
+            [[False, True]],  # H atom 1
+            [[False, False]],  # O atom
+        ]
+    )
+    assert torch.equal(torch.isnan(pred_values), pred_nan_mask_expected)
+
+    # Check predictions
+    torch.testing.assert_close(
+        pred_values[0, 0, 0],
+        torch.tensor(1.25, dtype=torch.float64),
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    torch.testing.assert_close(
+        pred_values[1, 0, 0],
+        torch.tensor(1.25, dtype=torch.float64),
+        rtol=1e-10,
+        atol=1e-10,
+    )
+    torch.testing.assert_close(
+        pred_values[2, 0, :],
+        torch.tensor([2.0, 3.0], dtype=torch.float64),
+        rtol=1e-10,
+        atol=1e-10,
+    )


### PR DESCRIPTION
Specifically for atomic basis targets, fitting and inference of the `CompositionModel` and `Scaler` benefits from the atomic basis targets being densified in atom type. For architectures that support atomic basis targets and predict them in the densified form (PET, MACE, PhACE), this PR extends using the densified form also for the CM and Scaler.

During training, metrics are computed in the dense representation, avoiding the reverse sparsification step.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - ~[ ] Documentation updated (for new features)?~
 - ~[ ] Issue referenced (for PRs that solve an issue)?~

# Maintainer/Reviewer checklist

 - ~[ ] CHANGELOG updated with public API or any other important changes?~
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1115.org.readthedocs.build/en/1115/

<!-- readthedocs-preview metatrain end -->