### PR TITLE
Wrong `per_atom` value in augmentation tests

### DIFF
--- a/tests/utils/test_augmentation.py
+++ b/tests/utils/test_augmentation.py
@@ -136,8 +136,8 @@ def test_rotation_per_structure_spherical(batch_size):
 
 @pytest.mark.parametrize("batch_size", [1, 2])
 def test_rotation_per_atom_spherical(batch_size):
-    """Tests that the rotational augmenter rotates a dipole moment consistent with
-    targets computed from DFT"""
+    """Tests that the rotational augmenter rotates electron density projections
+    consistent with targets computed from DFT"""
 
     target_name = "mtt::electron_density_basis_projs"
 

--- a/tests/utils/test_augmentation.py
+++ b/tests/utils/test_augmentation.py
@@ -195,7 +195,7 @@ def test_rotation_per_atom_spherical(batch_size):
                             ]
                         }
                     },
-                    "per_atom": False,
+                    "per_atom": True,
                     "num_subtargets": 1,
                 },
             )


### PR DESCRIPTION
This does not affect the augmenter and that's why tests pass, but it should be correct for consistency


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1116.org.readthedocs.build/en/1116/

<!-- readthedocs-preview metatrain end -->