### PR TITLE
Introduces the ability to use atom_pair targets in metatrain

### DIFF
--- a/src/metatrain/utils/data/target_info.py
+++ b/src/metatrain/utils/data/target_info.py
@@ -721,7 +721,7 @@ def _get_spherical_irreps_iter(
     irreps_iter = [
         [
             (
-                irrep.get("num", 1) * target["num_subtargets"],
+                irrep.get("num", 1) * target["num_subtargets"], 
                 irrep["o3_lambda"],
                 irrep["o3_sigma"],
             )


### PR DESCRIPTION
This is just to keep track of the changes vs https://github.com/metatensor/metatrain/pull/1075 . Once that one is merged a PR against main will be made


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1118.org.readthedocs.build/en/1118/

<!-- readthedocs-preview metatrain end -->