### PR TITLE
Skip allreduce for fixed-weight targets in the composition model

### DIFF
--- a/src/metatrain/utils/additive/composition.py
+++ b/src/metatrain/utils/additive/composition.py
@@ -271,6 +271,8 @@ class CompositionModel(torch.nn.Module):
             torch.distributed.barrier()
             # All-reduce the accumulated TensorMaps across all processes
             for target_name in self._new_outputs:
+                if target_name in fixed_weights:
+                    continue  # nothing was accumulated
                 for XTX_block, XTY_block in zip(
                     self.model.XTX[target_name],
                     self.model.XTY[target_name],


### PR DESCRIPTION
Add small guard to prevent trying to reduce CM features when they're never accumulated in the first place.

# Maintainer/Reviewer checklist

 ~~- [ ] CHANGELOG updated with public API or any other important changes?~~
 - [x] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1120.org.readthedocs.build/en/1120/

<!-- readthedocs-preview metatrain end -->