### PR TITLE
Add rank 2 spherical targets

### DIFF
--- a/src/metatrain/experimental/mace/model.py
+++ b/src/metatrain/experimental/mace/model.py
@@ -663,11 +663,13 @@ class MetaMACE(ModelInterface[ModelHypers]):
         :param target_name: Name of the target to add.
         :param target_info: TargetInfo object containing details about the target.
         """
-        # We don't support Cartesian tensors with rank > 1
-        if target_info.is_cartesian:
-            if len(target_info.layout.block().components) > 1:
+        # We don't support targets with rank > 1
+        if target_info.is_cartesian or target_info.is_spherical:
+            if len(target_info.layout.block(0).components) > 1:
                 raise ValueError(
-                    "MetaMACE does not support Cartesian tensors with rank > 1."
+                    "MetaMACE does not support target tensors with rank > 1."
+                    f"{target_name} has rank "
+                    f"{len(target_info.layout.block(0).components)}."
                 )
 
         self.layouts[target_name] = target_info.layout

--- a/src/metatrain/experimental/mace/tests/test_basic.py
+++ b/src/metatrain/experimental/mace/tests/test_basic.py
@@ -145,6 +145,7 @@ class TestInput(InputTests, MACETests): ...
 class TestOutput(OutputTests, MACETests):
     supports_features = False
     supports_spherical_atomic_basis_outputs = True
+    supports_spherical_rank2_outputs = False
 
     @pytest.fixture
     def n_features(self, model_hypers: dict) -> list[int]:

--- a/src/metatrain/experimental/phace/model.py
+++ b/src/metatrain/experimental/phace/model.py
@@ -618,6 +618,13 @@ class PhACE(ModelInterface[ModelHypers]):
             per_atom=True,
         )
 
+        if target_info.is_spherical and len(target_info.layout.block(0).components) > 1:
+            raise ValueError(
+                "PhACE does not support target spherical tensors with rank > 1."
+                f"'{target_name}' has rank "
+                f"{len(target_info.layout.block(0).components)}."
+            )
+
         if target_info.is_cartesian and len(target_info.layout.block().components) == 2:
             # rank-2 Cartesian: store internal spherical layout (l=0, l=1, l=2)
             # so that the forward pass constructs the spherical TensorMap, which

--- a/src/metatrain/experimental/phace/tests/test_basic.py
+++ b/src/metatrain/experimental/phace/tests/test_basic.py
@@ -34,7 +34,7 @@ class PhACETests(ArchitectureTests):
 class TestOutput(OutputTests, PhACETests):
     is_equivariant_reflections = False
     equivariance_error_tolerance = 1e-4  # due to many layers in the default hypers
-    supports_spherical_atomic_basis_outputs = True
+    supports_spherical_rank2_outputs = False
 
     @pytest.fixture
     def n_last_layer_features(self) -> int:

--- a/src/metatrain/share/base_hypers.py
+++ b/src/metatrain/share/base_hypers.py
@@ -124,14 +124,16 @@ class SphericalTargetConfig(TypedDict):
     irreps: (
         list[SphericalTargetIrrepsConfig] | dict[int, list[SphericalTargetIrrepsConfig]]
     )
-    product: NotRequired[Literal[None, "coupled"]] = None
+    product: NotRequired[Literal[None, "coupled", "cartesian"]] = None
     """Means of describing a higher rank target that is made of the base irreps.
     If:
 
-    - ``product`` is ``None`` or not provided: the target is of rank 1.
+    - ``product`` is ``None`` or not provided: the target has simply the base irreps.
     - ``product`` is ``"coupled"``: the target is built by all the possible products
       between irreps and coupling them to their irreducible representations.
       The target is therefore still of rank 1.
+    - ``product`` is ``"cartesian"``: the target is built by all the possible products
+      between irreps, creating a target of rank 2.
     """
 
 

--- a/src/metatrain/soap_bpnn/model.py
+++ b/src/metatrain/soap_bpnn/model.py
@@ -1042,6 +1042,12 @@ class SoapBpnn(ModelInterface[ModelHypers]):
                     legacy=self.legacy,
                 )
         elif target.is_spherical:
+            if len(target.layout.block(0).components) > 1:
+                raise ValueError(
+                    "SOAP-BPNN does not support target spherical tensors with rank > 1."
+                    f"'{target_name}' has rank "
+                    f"{len(target.layout.block(0).components)}."
+                )
             for key, block in target.layout.items():
                 dict_key = target_name
                 for n, k in zip(key.names, key.values, strict=True):

--- a/src/metatrain/soap_bpnn/tests/test_basic.py
+++ b/src/metatrain/soap_bpnn/tests/test_basic.py
@@ -34,6 +34,8 @@ class TestInput(InputTests, SoapBPNNTests): ...
 
 class TestOutput(OutputTests, SoapBPNNTests):
     supports_vector_outputs = True
+    supports_spherical_rank2_outputs = False
+    supports_spherical_atomic_basis_outputs = False
 
     @pytest.fixture
     def n_features(self):

--- a/src/metatrain/soap_bpnn/tests/test_basic.py
+++ b/src/metatrain/soap_bpnn/tests/test_basic.py
@@ -35,7 +35,6 @@ class TestInput(InputTests, SoapBPNNTests): ...
 class TestOutput(OutputTests, SoapBPNNTests):
     supports_vector_outputs = True
     supports_spherical_rank2_outputs = False
-    supports_spherical_atomic_basis_outputs = False
 
     @pytest.fixture
     def n_features(self):

--- a/src/metatrain/utils/additive/_base_composition.py
+++ b/src/metatrain/utils/additive/_base_composition.py
@@ -673,7 +673,7 @@ def _include_key(key: LabelsEntry) -> bool:
     elif key.names == valid_key_names[3] or key.names == valid_key_names[4]:
         if (
             key["o3_lambda_1"] == key["o3_lambda_2"]
-            and key["o3_sigma_1"] == key["o3_sigma_2"] == 1
+            and key["o3_sigma_1"] == key["o3_sigma_2"]
         ):
             include_key = True
 

--- a/src/metatrain/utils/additive/_base_composition.py
+++ b/src/metatrain/utils/additive/_base_composition.py
@@ -283,6 +283,13 @@ class BaseCompositionModel(torch.nn.Module):
 
                 # Get the target block values
                 Y = block.values
+                if "o3_lambda_1" in key.names:
+                    # For rank 2 tensors, we fit only their invariant part (the trace).
+                    # Get the trace for each (sample, property)
+                    traces = torch.diagonal(Y, dim1=1, dim2=2).mean(dim=-1)
+                    # Recreate the blocks with only the invariant contribution.
+                    Id = torch.eye(Y.shape[1], dtype=dtype, device=device)
+                    Y = torch.einsum("sp,ij->sijp", traces, Id)
 
                 # Accumulate "XTX", i.e. X.T @ X
                 # TODO: store XTX by sample kind instead, saving memory
@@ -617,20 +624,38 @@ def _include_key(key: LabelsEntry) -> bool:
     composition model.
 
     The rules are as follows:
+
         - If the key has a single name "_" (indicating a scalar), it is included.
         - If the key has names ["o3_lambda", "o3_sigma"] it is included if values are 0
           and 1 respectively (indicating an invariant block of a spherical target).
         - If the key has names ["o3_lambda", "o3_sigma", "atom_type"] it is included if
           values are 0, 1, and any value respectively (indicating an invariant block of
           an atomic-basis spherical target).
+        - If the key has names ["o3_lambda_1", "o3_lambda_2", "o3_sigma_1",
+          "o3_sigma_2"] it is included if values are equal for the two lambda,
+          and the sigma values are 1 (these are rank 2 tensors where the
+          trace is invariant).
+        - If the key has names ["o3_lambda_1", "o3_lambda_2", "o3_sigma_1",
+          "o3_sigma_2", "atom_type"] it is included if values are equal for the two
+          lambda, and the sigma values are 1 (these are rank 2 tensors where the
+          trace is invariant, and these tensors belong to an atomic basis target).
+
     :param key: The key to check.
 
     :return: Whether the key should be included in the composition model.
     """
     valid_key_names = [
         ["_"],  # scalar
-        ["o3_lambda", "o3_sigma"],  # spherical
-        ["o3_lambda", "o3_sigma", "atom_type"],  # spherical atomic basis
+        ["o3_lambda", "o3_sigma"],  # spherical rank 1
+        ["o3_lambda", "o3_sigma", "atom_type"],  # atomic basis rank 1
+        ["o3_lambda_1", "o3_lambda_2", "o3_sigma_1", "o3_sigma_2"],  # spherical rank 2
+        [
+            "o3_lambda_1",
+            "o3_lambda_2",
+            "o3_sigma_1",
+            "o3_sigma_2",
+            "atom_type",
+        ],  # atomic basis rank 2
     ]
     include_key = False
 
@@ -643,6 +668,13 @@ def _include_key(key: LabelsEntry) -> bool:
 
     elif key.names == valid_key_names[2]:
         if key["o3_lambda"] == 0 and key["o3_sigma"] == 1:
+            include_key = True
+
+    elif key.names == valid_key_names[3] or key.names == valid_key_names[4]:
+        if (
+            key["o3_lambda_1"] == key["o3_lambda_2"]
+            and key["o3_sigma_1"] == key["o3_sigma_2"] == 1
+        ):
             include_key = True
 
     else:

--- a/src/metatrain/utils/additive/composition.py
+++ b/src/metatrain/utils/additive/composition.py
@@ -460,13 +460,26 @@ class CompositionModel(torch.nn.Module):
             return False
 
         if target_info.is_spherical:
-            if "o3_lambda" in target_info.layout.keys.names:  # coupled
+            if "o3_lambda" in target_info.layout.keys.names:  # rank 1
                 if len(target_info.layout.blocks({"o3_lambda": 0, "o3_sigma": 1})) == 0:
                     # No invariant blocks
                     logging.debug(
                         "Composition model does not support spherical "
                         f"target {target_name} since it does not have "
                         "any invariant blocks."
+                    )
+                    return False
+            elif "o3_lambda_2" in target_info.layout.keys.names:  # rank 2
+                if not any(
+                    key["o3_lambda_1"] == key["o3_lambda_2"]
+                    and key["o3_sigma_1"] == key["o3_sigma_2"]
+                    for key in target_info.layout.keys
+                ):
+                    # No invariant contribution
+                    logging.debug(
+                        "Composition model does not support spherical "
+                        f"target {target_name} since it does not have "
+                        "any invariant contribution."
                     )
                     return False
 

--- a/src/metatrain/utils/additive/composition.py
+++ b/src/metatrain/utils/additive/composition.py
@@ -458,15 +458,18 @@ class CompositionModel(torch.nn.Module):
                 "since it is not either scalar or spherical."
             )
             return False
-        if (
-            target_info.is_spherical
-            and len(target_info.layout.blocks({"o3_lambda": 0, "o3_sigma": 1})) == 0
-        ):
-            logging.debug(
-                f"Composition model does not support spherical target {target_name} "
-                "since it does not have any invariant blocks."
-            )
-            return False
+
+        if target_info.is_spherical:
+            if "o3_lambda" in target_info.layout.keys.names:  # coupled
+                if len(target_info.layout.blocks({"o3_lambda": 0, "o3_sigma": 1})) == 0:
+                    # No invariant blocks
+                    logging.debug(
+                        "Composition model does not support spherical"
+                        f"target {target_name} since it does not have "
+                        "any invariant blocks."
+                    )
+                    return False
+
         return True
 
     def sync_tensor_maps(self) -> None:

--- a/src/metatrain/utils/additive/composition.py
+++ b/src/metatrain/utils/additive/composition.py
@@ -464,7 +464,7 @@ class CompositionModel(torch.nn.Module):
                 if len(target_info.layout.blocks({"o3_lambda": 0, "o3_sigma": 1})) == 0:
                     # No invariant blocks
                     logging.debug(
-                        "Composition model does not support spherical"
+                        "Composition model does not support spherical "
                         f"target {target_name} since it does not have "
                         "any invariant blocks."
                     )

--- a/src/metatrain/utils/augmentation.py
+++ b/src/metatrain/utils/augmentation.py
@@ -256,7 +256,6 @@ def _apply_wigner_D_matrices(
     new_blocks: List[TensorBlock] = []
     is_atomic_basis = any(k.startswith("atom_type") for k in target_tmap.keys.names)
     for key, block in target_tmap.items():
-        ell, sigma = int(key[0]), int(key[1])
         values = block.values
         if block.samples.names == ["system"]:
             split_values = torch.split(values, [1 for _ in systems])
@@ -272,19 +271,46 @@ def _apply_wigner_D_matrices(
             )
 
         new_values = []
-        for v, transformation, wigner_D_matrix in zip(
-            split_values, transformations, wigner_D_matrices[ell], strict=True
-        ):
-            is_inverted = torch.det(transformation) < 0
-            new_v = v.clone()
-            if is_inverted:  # inversion
-                new_v = new_v * (-1) ** ell * sigma
-            # fold property dimension in, apply transformation,
-            # unfold property dimension
-            new_v = new_v.transpose(1, 2)
-            new_v = new_v @ wigner_D_matrix.T
-            new_v = new_v.transpose(1, 2)
-            new_values.append(new_v)
+        rank = len(block.components)
+        if rank == 1:
+            ell, sigma = int(key["o3_lambda"]), int(key["o3_sigma"])
+            for v, transformation, wigner_D_matrix in zip(
+                split_values, transformations, wigner_D_matrices[ell], strict=True
+            ):
+                is_inverted = torch.det(transformation) < 0
+                new_v = v.clone()
+                if is_inverted:  # inversion
+                    new_v = new_v * (-1) ** ell * sigma
+                # fold property dimension in, apply transformation,
+                # unfold property dimension
+                new_v = new_v.transpose(1, 2)
+                new_v = new_v @ wigner_D_matrix.T
+                new_v = new_v.transpose(1, 2)
+                new_values.append(new_v)
+        elif rank == 2:
+            ell1, ell2, sigma1, sigma2 = (
+                int(key["o3_lambda_1"]),
+                int(key["o3_lambda_2"]),
+                int(key["o3_sigma_1"]),
+                int(key["o3_sigma_2"]),
+            )
+            for v, transformation, wigner_D_matrix1, wigner_D_matrix2 in zip(
+                split_values,
+                transformations,
+                wigner_D_matrices[ell1],
+                wigner_D_matrices[ell2],
+                strict=True,
+            ):
+                is_inverted = torch.det(transformation) < 0
+                new_v = v.clone()
+                if is_inverted:
+                    # Invert if the two components have different parity.
+                    new_v = new_v * (-1) ** ell1 * sigma1 * (-1) ** ell2 * sigma2
+                new_v = torch.einsum(
+                    "Aa,iabp,bB->iABp", wigner_D_matrix1, new_v, wigner_D_matrix2.T
+                )
+
+                new_values.append(new_v)
         new_values = torch.concatenate(new_values)
         new_block = TensorBlock(
             values=new_values,
@@ -400,6 +426,11 @@ def _apply_augmentations(
 
             is_spherical = all(
                 len(block.components) == 1 and block.components[0].names == ["o3_mu"]
+                for block in original_tmap.blocks()
+            ) or all(
+                len(block.components) == 2
+                and block.components[0].names == ["o3_mu_1"]
+                and block.components[1].names == ["o3_mu_2"]
                 for block in original_tmap.blocks()
             )
 

--- a/src/metatrain/utils/data/target_info.py
+++ b/src/metatrain/utils/data/target_info.py
@@ -139,10 +139,7 @@ class TargetInfo:
             self.is_scalar = True
         elif components_first_block[0].names[0].startswith("xyz"):
             self.is_cartesian = True
-        elif (
-            len(components_first_block) == 1
-            and components_first_block[0].names[0] == "o3_mu"
-        ):
+        elif components_first_block[0].names[0].startswith("o3_mu"):
             self.is_spherical = True
         else:
             raise ValueError(
@@ -549,9 +546,12 @@ def _get_spherical_target_info(target_name: str, target: DictConfig) -> TargetIn
     # Define the names of the keys in the tensormap
     if product in [None, "coupled"]:
         keys_names = ["o3_lambda", "o3_sigma"]
+    elif product == "cartesian":
+        keys_names = ["o3_lambda_1", "o3_lambda_2", "o3_sigma_1", "o3_sigma_2"]
     else:
         raise ValueError(
-            f"Unknown product {product!r}. Supported values are 'coupled', and None."
+            f"Unknown product {product!r}. Supported values are 'cartesian', "
+            "'coupled' and None."
         )
 
     if is_atomic_basis:
@@ -686,11 +686,12 @@ def _build_spherical_target_block(
 def _get_spherical_irreps_iter(
     irreps: list[dict],
     target: dict,
-    product: Optional[Literal["coupled"]] = None,
+    product: Optional[Literal["cartesian", "coupled"]] = None,
 ) -> tuple[list[list[tuple[int, int, int]]], list[Labels]]:
-    if product is not None and product not in ["coupled"]:
+    if product not in [None, "cartesian", "coupled"]:
         raise ValueError(
-            f"Product {product!r} is not supported. Supported products are ['coupled']."
+            f"Product '{product}' is not supported. Supported products are"
+            " 'cartesian' and 'coupled'."
         )
 
     irreps_iter = [
@@ -703,7 +704,7 @@ def _get_spherical_irreps_iter(
         ]
         for irrep in irreps
     ]
-    if product is not None:
+    if product in ["cartesian", "coupled"]:
         irreps_iter = [
             i_irrep + j_irrep
             for i_irrep, j_irrep in itertools.product(irreps_iter, repeat=2)

--- a/src/metatrain/utils/testing/architectures.py
+++ b/src/metatrain/utils/testing/architectures.py
@@ -295,6 +295,39 @@ class ArchitectureTests:
         )
 
     @pytest.fixture
+    def dataset_info_spherical_rank2(self, per_atom: bool) -> DatasetInfo:
+        """Fixture that provides a basic ``DatasetInfo`` with a spherical
+        target of rank 2 for testing.
+
+        :param per_atom: Whether the target is per-atom or not.
+        :return: A ``DatasetInfo`` instance with a spherical target of
+            rank 2.
+        """
+        return DatasetInfo(
+            length_unit="Angstrom",
+            atomic_types=[1, 6, 7, 8],
+            targets={
+                "spherical_tensor_rank2": get_generic_target_info(
+                    "spherical_tensor_rank2",
+                    {
+                        "quantity": "spherical_tensor_rank2",
+                        "unit": "",
+                        "type": {
+                            "spherical": {
+                                "product": "cartesian",
+                                "irreps": [
+                                    {"o3_lambda": 2, "o3_sigma": 1},
+                                ],
+                            },
+                        },
+                        "num_subtargets": 2,
+                        "per_atom": per_atom,
+                    },
+                )
+            },
+        )
+
+    @pytest.fixture
     def dataset_info_spherical_atomic_basis(self) -> DatasetInfo:
         """Fixture that provides a basic ``DatasetInfo`` with a spherical
         target that uses an atomic basis for testing.
@@ -313,6 +346,56 @@ class ArchitectureTests:
                         "unit": "",
                         "type": {
                             "spherical": {
+                                "irreps": {
+                                    1: [
+                                        {"num": 2, "o3_lambda": 0, "o3_sigma": 1},
+                                        {"num": 1, "o3_lambda": 1, "o3_sigma": 1},
+                                    ],
+                                    6: [
+                                        {"num": 3, "o3_lambda": 0, "o3_sigma": 1},
+                                        {"num": 2, "o3_lambda": 1, "o3_sigma": 1},
+                                        {"num": 1, "o3_lambda": 2, "o3_sigma": 1},
+                                    ],
+                                    7: [
+                                        {"num": 3, "o3_lambda": 0, "o3_sigma": 1},
+                                        {"num": 2, "o3_lambda": 1, "o3_sigma": 1},
+                                        {"num": 1, "o3_lambda": 2, "o3_sigma": 1},
+                                    ],
+                                    8: [
+                                        {"num": 3, "o3_lambda": 0, "o3_sigma": 1},
+                                        {"num": 2, "o3_lambda": 1, "o3_sigma": 1},
+                                        {"num": 1, "o3_lambda": 2, "o3_sigma": 1},
+                                    ],
+                                },
+                            }
+                        },
+                        "num_subtargets": 2,
+                        "per_atom": True,
+                    },
+                )
+            },
+        )
+
+    @pytest.fixture
+    def dataset_info_spherical_atomic_basis_rank2(self) -> DatasetInfo:
+        """Fixture that provides a basic ``DatasetInfo`` with a spherical
+        target that uses an atomic basis for testing.
+
+        :return: A ``DatasetInfo`` instance with a spherical target of rank
+            2 in an atomic basis.
+        """
+        return DatasetInfo(
+            length_unit="Angstrom",
+            atomic_types=[1, 6, 7, 8],
+            targets={
+                "spherical_tensor_atomic_basis_rank2": get_generic_target_info(
+                    "spherical_tensor_atomic_basis_rank2",
+                    {
+                        "quantity": "spherical_tensor_atomic_basis_rank2",
+                        "unit": "",
+                        "type": {
+                            "spherical": {
+                                "product": "cartesian",
                                 "irreps": {
                                     1: [
                                         {"num": 2, "o3_lambda": 0, "o3_sigma": 1},

--- a/src/metatrain/utils/testing/output.py
+++ b/src/metatrain/utils/testing/output.py
@@ -43,6 +43,8 @@ class OutputTests(ArchitectureTests):
     """Whether the model supports vector outputs."""
     supports_spherical_outputs: bool = True
     """Whether the model supports spherical tensor outputs."""
+    supports_spherical_rank2_outputs: bool = True
+    """Whether the model supports spherical tensor outputs of rank 2."""
     supports_spherical_atomic_basis_outputs: bool = True
     """Whether the model supports spherical atomic basis outputs."""
     supports_selected_atoms: bool = True
@@ -324,6 +326,51 @@ class OutputTests(ArchitectureTests):
             else:
                 assert spherical_target_block.values.shape[0] == 1
 
+    def test_output_spherical_rank2(
+        self,
+        model_hypers: dict,
+        dataset_info_spherical_rank2: DatasetInfo,
+        per_atom: bool,
+    ) -> None:
+        """Tests that forward pass works for spherical outputs of rank 2.
+
+        It also tests that the returned outputs have the expected samples
+        and values shape.
+
+        This test is skipped if the model does not support spherical outputs,
+        i.e., if ``supports_spherical_outputs`` is set to ``False``, or it does
+        not support spherical rank 2 outputs, i.e., if
+        ``supports_spherical_rank2_outputs`` is set to ``False``.
+
+        If this test is failing, your model might:
+        - not be producing spherical outputs of rank 2 when requested.
+        - not be taking into account correctly the ``per_atom`` field of the
+        outputs passed to the ``outputs`` argument of the ``forward()`` method.
+
+        :param model_hypers: Hyperparameters to initialize the model.
+        :param dataset_info_spherical_rank2: Dataset information with spherical
+          outputs of rank 2.
+        :param per_atom: Whether the requested outputs are per-atom or not.
+        """
+        if not self.supports_spherical_outputs:
+            pytest.skip(f"{self.architecture} does not support spherical outputs.")
+        if not self.supports_spherical_rank2_outputs:
+            pytest.skip(
+                f"{self.architecture} does not support spherical rank 2 outputs."
+            )
+
+        outputs = self._get_output(
+            model_hypers,
+            dataset_info_spherical_rank2,
+            per_atom,
+            ["spherical_tensor_rank2"],
+        )
+
+        if per_atom:
+            assert outputs["spherical_tensor_rank2"].block().values.shape[0] == 4
+        else:
+            assert outputs["spherical_tensor_rank2"].block().values.shape[0] == 1
+
     def test_output_spherical_atomic_basis(
         self,
         model_hypers: dict,
@@ -362,6 +409,51 @@ class OutputTests(ArchitectureTests):
             dataset_info_spherical_atomic_basis,
             per_atom=True,
             outputs=["spherical_tensor_atomic_basis"],
+        )
+
+    def test_output_spherical_atomic_basis_rank2(
+        self,
+        model_hypers: dict,
+        dataset_info_spherical_atomic_basis_rank2: DatasetInfo,
+    ) -> None:
+        """Tests that forward pass works for spherical outputs that
+        use an atomic basis and are of rank 2.
+
+        It also tests that the returned outputs have the expected samples
+        and values shape.
+
+        This test is skipped if one of the following is False:
+        - ``supports_spherical_outputs``
+        - ``supports_spherical_atomic_basis_outputs``
+        - ``supports_spherical_rank2_outputs``
+
+        If this test is failing and
+        - ``test_output_spherical``, ``test_output_spherical_atomic_basis`` and
+          ``test_output_spherical_rank2`` are passing: your model is not handling
+          the possibility that outputs can be spherical, in an atomic basis and
+          of rank 2 at the same time.
+        - Any of the previously mentioned tests is failing: fix those tests first.
+
+        :param model_hypers: Hyperparameters to initialize the model.
+        :param dataset_info_spherical_atomic_basis_rank2: Dataset information with
+            spherical outputs of rank 2 using an atomic basis.
+        """
+        if not self.supports_spherical_outputs:
+            pytest.skip(f"{self.architecture} does not support spherical outputs.")
+        if not self.supports_spherical_atomic_basis_outputs:
+            pytest.skip(
+                f"{self.architecture} does not support spherical atomic basis outputs."
+            )
+        if not self.supports_spherical_rank2_outputs:
+            pytest.skip(
+                f"{self.architecture} does not support spherical rank 2 outputs."
+            )
+
+        self._get_output(
+            model_hypers,
+            dataset_info_spherical_atomic_basis_rank2,
+            per_atom=True,
+            outputs=["spherical_tensor_atomic_basis_rank2"],
         )
 
     def test_prediction_energy_subset_elements(

--- a/src/metatrain/utils/testing/output.py
+++ b/src/metatrain/utils/testing/output.py
@@ -423,11 +423,13 @@ class OutputTests(ArchitectureTests):
         and values shape.
 
         This test is skipped if one of the following is False:
+
         - ``supports_spherical_outputs``
         - ``supports_spherical_atomic_basis_outputs``
         - ``supports_spherical_rank2_outputs``
 
         If this test is failing and
+
         - ``test_output_spherical``, ``test_output_spherical_atomic_basis`` and
           ``test_output_spherical_rank2`` are passing: your model is not handling
           the possibility that outputs can be spherical, in an atomic basis and

--- a/tests/utils/data/test_target_info.py
+++ b/tests/utils/data/test_target_info.py
@@ -55,8 +55,8 @@ def cartesian_target_config() -> DictConfig:
     )
 
 
-@pytest.fixture(params=[None, "coupled"])
-def spherical_product(request) -> Literal[None, "coupled"]:
+@pytest.fixture(params=[None, "cartesian", "coupled"])
+def spherical_product(request) -> Literal[None, "cartesian", "coupled"]:
     return request.param
 
 
@@ -197,6 +197,8 @@ def test_layout_spherical(spherical_target_config, spherical_product):
 
     if spherical_product is None:
         assert len(target_info.layout.blocks()) == 3
+    elif spherical_product == "cartesian":
+        assert len(target_info.layout.blocks()) == 9
     elif spherical_product == "coupled":
         assert len(target_info.layout.blocks()) == 5
 
@@ -221,6 +223,8 @@ def test_layout_spherical_atomicbasis(
 
     if spherical_product is None:
         assert len(target_info.layout.blocks()) == 4
+    elif spherical_product == "cartesian":
+        assert len(target_info.layout.blocks()) == 10
     elif spherical_product == "coupled":
         assert len(target_info.layout.blocks()) == 6
 
@@ -366,7 +370,9 @@ def test_layout_spherical_with_variant(
     # Check that the properties labels were created correctly without the variant part
     # and mtt:: prefix. The properties label should be the same in all cases.
     for block in target_info.layout.blocks():
-        if spherical_product == "coupled":
+        if spherical_product == "cartesian":
+            assert block.properties.names == ["n_1", "n_2"]
+        elif spherical_product == "coupled":
             assert block.properties.names == ["l_1", "l_2", "n_1", "n_2"]
         else:
             assert block.properties.names == ["n"]
@@ -394,7 +400,9 @@ def test_layout_spherical_atomicbasis_with_variant(
     # Check that the properties labels were created correctly without the variant part
     # and mtt:: prefix. The properties label should be the same in all cases.
     for block in target_info.layout.blocks():
-        if spherical_product == "coupled":
+        if spherical_product == "cartesian":
+            assert block.properties.names == ["n_1", "n_2"]
+        elif spherical_product == "coupled":
             assert block.properties.names == ["l_1", "l_2", "n_1", "n_2"]
         else:
             assert block.properties.names == ["n"]

--- a/tests/utils/test_additive.py
+++ b/tests/utils/test_additive.py
@@ -26,6 +26,8 @@ from metatrain.utils.neighbor_lists import (
     get_requested_neighbor_lists,
     get_system_with_neighbor_lists,
 )
+from metatrain.utils.data.readers.metatensor import _empty_tensor_map_like
+
 
 
 RESOURCES_PATH = Path(__file__).parents[1] / "resources"
@@ -1789,4 +1791,686 @@ def test_composition_spherical_atomic_basis_dense_nan_weights():
         torch.tensor([2.0, 3.0], dtype=torch.float64),
         rtol=1e-10,
         atol=1e-10,
+    )
+
+
+
+def test_composition_spherical_per_atom_rank_2():
+    """
+    Test the calculation of composition weights for a spherical per-atom rank 2 target
+    (keys: o3_lambda_1, o3_lambda_2, o3_sigma_1, o3_sigma_2) is correct.
+
+    All atoms contribute to the same blocks,
+    so the composition model fits a single weight per atomic type.
+    """
+
+    systems = [
+        System(
+            positions=torch.tensor([[0.0, 0.0, 0.0]], dtype=torch.float64),
+            types=torch.tensor([8]),
+            cell=torch.eye(3, dtype=torch.float64),
+            pbc=torch.tensor([True, True, True]),
+        ),
+        System(
+            positions=torch.tensor(
+                [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+                dtype=torch.float64,
+            ),
+            types=torch.tensor([1, 1, 8]),
+            cell=torch.eye(3, dtype=torch.float64),
+            pbc=torch.tensor([True, True, True]),
+        ),
+    ]
+
+    pp_full_sys1 = torch.zeros(1, 3, 3, 1, dtype=torch.float64)
+    pp_full_sys1[0, torch.arange(3), torch.arange(3), 0] = torch.tensor(
+        [1.0, 2.0, 3.0], dtype=torch.float64
+    )
+    pp_full_sys2 = torch.zeros(3, 3, 3, 1, dtype=torch.float64)
+    pp_full_sys2[2, torch.arange(3), torch.arange(3), 0] = torch.tensor(
+        [3.0, 4.0, 5.0], dtype=torch.float64
+    )
+
+    tensor_map_1 = TensorMap(
+        keys=Labels(
+            names=["o3_lambda_1", "o3_lambda_2", "o3_sigma_1", "o3_sigma_2"],
+            values=torch.tensor([[0, 0, 1, 1], [1, 1, 1, 1]]),
+        ),
+        blocks=[
+            TensorBlock(
+                values=torch.tensor([[[[1.0]]]], dtype=torch.float64),
+                samples=Labels(names=["system", "atom"], values=torch.tensor([[0, 0]])),
+                components=[
+                    Labels(names=["o3_mu_1"], values=torch.tensor([[0]])),
+                    Labels(names=["o3_mu_2"], values=torch.tensor([[0]])),
+                ],
+                properties=Labels(names=["_"], values=torch.tensor([[0]])),
+            ),
+            TensorBlock(
+                values=pp_full_sys1,
+                samples=Labels(names=["system", "atom"], values=torch.tensor([[0, 0]])),
+                components=[
+                    Labels(names=["o3_mu_1"], values=torch.arange(-1, 2).reshape(-1, 1)),
+                    Labels(names=["o3_mu_2"], values=torch.arange(-1, 2).reshape(-1, 1)),
+                ],
+                properties=Labels(names=["_"], values=torch.tensor([[0]])),
+            ),
+        ],
+    )
+
+    ss_vals_sys2 = torch.tensor([[[[1.0]]], [[[1.5]]], [[[2.0]]]], dtype=torch.float64)
+    tensor_map_2 = TensorMap(
+        keys=Labels(
+            names=["o3_lambda_1", "o3_lambda_2", "o3_sigma_1", "o3_sigma_2"],
+            values=torch.tensor([[0, 0, 1, 1], [1, 1, 1, 1]]),
+        ),
+        blocks=[
+            TensorBlock(
+                values=ss_vals_sys2,
+                samples=Labels(
+                    names=["system", "atom"],
+                    values=torch.tensor([[1, 0], [1, 1], [1, 2]]),
+                ),
+                components=[
+                    Labels(names=["o3_mu_1"], values=torch.tensor([[0]])),
+                    Labels(names=["o3_mu_2"], values=torch.tensor([[0]])),
+                ],
+                properties=Labels(names=["_"], values=torch.tensor([[0]])),
+            ),
+            TensorBlock(
+                values=pp_full_sys2,
+                samples=Labels(
+                    names=["system", "atom"],
+                    values=torch.tensor([[1, 0], [1, 1], [1, 2]]),
+                ),
+                components=[
+                    Labels(names=["o3_mu_1"], values=torch.arange(-1, 2).reshape(-1, 1)),
+                    Labels(names=["o3_mu_2"], values=torch.arange(-1, 2).reshape(-1, 1)),
+                ],
+                properties=Labels(names=["_"], values=torch.tensor([[0]])),
+            ),
+        ],
+    )
+
+    dataset = Dataset.from_dict(
+        {"system": systems, "rank_2_target": [tensor_map_1, tensor_map_2]}
+    )
+
+    target_info = get_generic_target_info(
+        "rank_2_target",
+        {
+            "quantity": "",
+            "unit": "",
+            "type": {
+                "spherical": {
+                    "irreps": {
+                        1: [{"o3_lambda": 0, "o3_sigma": 1}],
+                        8: [
+                            {"o3_lambda": 0, "o3_sigma": 1},
+                            {"o3_lambda": 1, "o3_sigma": 1},
+                        ],
+                    },
+                    "product": "cartesian",
+                }
+            },
+            "num_subtargets": 1,
+            "per_atom": True,
+        },
+    )
+    target_info.layout = _empty_tensor_map_like(tensor_map_1)
+
+    composition_model = CompositionModel(
+        hypers={},
+        dataset_info=DatasetInfo(
+            length_unit="angstrom",
+            atomic_types=[1, 8],
+            targets={"rank_2_target": target_info},
+        ),
+    )
+
+    composition_model.train_model([dataset], [], batch_size=1, is_distributed=False)
+
+    output = composition_model(
+        [systems[1]], {"rank_2_target": ModelOutput(per_atom=True)}
+    )
+
+    ss_key = {"o3_lambda_1": 0, "o3_lambda_2": 0, "o3_sigma_1": 1, "o3_sigma_2": 1}
+    pp_key = {"o3_lambda_1": 1, "o3_lambda_2": 1, "o3_sigma_1": 1, "o3_sigma_2": 1}
+
+    ss_block = output["rank_2_target"].block(ss_key)
+    torch.testing.assert_close(
+        ss_block.values,
+        torch.tensor(
+            [1.25, 1.25, 1.5], dtype=torch.float64
+        ).reshape(-1, 1, 1, 1),
+    )
+
+    pp_block = output["rank_2_target"].block(pp_key)
+    expected_pp = torch.zeros(3, 3, 3, 1, dtype=torch.float64)
+    expected_pp[2, torch.arange(3), torch.arange(3), 0] = torch.tensor(
+        [3.0, 3.0, 3.0], dtype=torch.float64
+    )
+    torch.testing.assert_close(pp_block.values, expected_pp)
+
+def test_composition_spherical_per_atom_rank_2_rotation_invariance():
+    """
+    Test the calculation of composition weights for a spherical per-atom rank 2 target
+    (keys: o3_lambda_1, o3_lambda_2, o3_sigma_1, o3_sigma_2) is invariant under fitting
+    on a rotated version of the dataset.
+    """
+
+    def Rz(theta):
+        c, s = torch.cos(torch.tensor(theta)), torch.sin(torch.tensor(theta))
+        return torch.tensor(
+            [[c, -s, 0.0], [s, c, 0.0], [0.0, 0.0, 1.0]], dtype=torch.float64
+        )
+
+    positions = torch.tensor(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=torch.float64
+    )
+    R = Rz(torch.pi / 2)
+    positions_rotated = positions @ R.T
+
+    system = System(
+        positions=positions,
+        types=torch.tensor([8, 1, 1]),
+        cell=torch.eye(3, dtype=torch.float64),
+        pbc=torch.tensor([True, True, True]),
+    )
+    system_rotated = System(
+        positions=positions_rotated,
+        types=torch.tensor([8, 1, 1]),
+        cell=torch.eye(3, dtype=torch.float64),
+        pbc=torch.tensor([True, True, True]),
+    )
+
+    ss_vals = torch.tensor([[[[1.0]]], [[[1.5]]], [[[2.0]]]], dtype=torch.float64)
+
+    pp_full = torch.zeros(3, 3, 3, 1, dtype=torch.float64)
+    pp_full[torch.arange(3), torch.arange(3), torch.arange(3), 0] = torch.tensor(
+        [1.0, 2.0, 3.0], dtype=torch.float64
+    )
+    pp_vals = pp_full[..., 0]  
+    pp_vals_rotated = torch.einsum("ac,bd,icd->iab", R, R, pp_vals).unsqueeze(-1)
+
+    def make_tensor_map(ss_values, pp_values, system_idx):
+        samples_3 = Labels(
+            names=["system", "atom"],
+            values=torch.tensor(
+                [[system_idx, 0], [system_idx, 1], [system_idx, 2]]
+            ),
+        )
+        return TensorMap(
+            keys=Labels(
+                names=["o3_lambda_1", "o3_lambda_2", "o3_sigma_1", "o3_sigma_2"],
+                values=torch.tensor([[0, 0, 1, 1], [1, 1, 1, 1]]),
+            ),
+            blocks=[
+                TensorBlock(
+                    values=ss_values,
+                    samples=samples_3,
+                    components=[
+                        Labels(names=["o3_mu_1"], values=torch.tensor([[0]])),
+                        Labels(names=["o3_mu_2"], values=torch.tensor([[0]])),
+                    ],
+                    properties=Labels(names=["_"], values=torch.tensor([[0]])),
+                ),
+                TensorBlock(
+                    values=pp_values,
+                    samples=samples_3,
+                    components=[
+                        Labels(
+                            names=["o3_mu_1"],
+                            values=torch.arange(-1, 2).reshape(-1, 1),
+                        ),
+                        Labels(
+                            names=["o3_mu_2"],
+                            values=torch.arange(-1, 2).reshape(-1, 1),
+                        ),
+                    ],
+                    properties=Labels(names=["_"], values=torch.tensor([[0]])),
+                ),
+            ],
+        )
+
+    target_info = get_generic_target_info(
+        "rank_2_target",
+        {
+            "quantity": "",
+            "unit": "",
+            "type": {
+                "spherical": {
+                    "irreps": {
+                        1: [{"o3_lambda": 0, "o3_sigma": 1}],
+                        8: [
+                            {"o3_lambda": 0, "o3_sigma": 1},
+                            {"o3_lambda": 1, "o3_sigma": 1},
+                        ],
+                    },
+                    "product": "cartesian",
+                }
+            },
+            "num_subtargets": 1,
+            "per_atom": True,
+        },
+    )
+    target_info.layout = _empty_tensor_map_like(make_tensor_map(ss_vals, pp_full, 0))
+
+    dataset_info = DatasetInfo(
+        length_unit="angstrom",
+        atomic_types=[1, 8],
+        targets={"rank_2_target": target_info},
+    )
+
+    dataset_orig = Dataset.from_dict(
+        {
+            "system": [system],
+            "rank_2_target": [make_tensor_map(ss_vals, pp_full, 0)],
+        }
+    )
+    model_orig = CompositionModel(hypers={}, dataset_info=dataset_info)
+    model_orig.train_model([dataset_orig], [], batch_size=1, is_distributed=False)
+
+    dataset_rot = Dataset.from_dict(
+        {
+            "system": [system_rotated],
+            "rank_2_target": [make_tensor_map(ss_vals, pp_vals_rotated, 0)],
+        }
+    )
+    model_rot = CompositionModel(hypers={}, dataset_info=dataset_info)
+    model_rot.train_model([dataset_rot], [], batch_size=1, is_distributed=False)
+
+    weights_orig = model_orig.model.weights["rank_2_target"]
+    weights_rot = model_rot.model.weights["rank_2_target"]
+
+    ss_key = {"o3_lambda_1": 0, "o3_lambda_2": 0, "o3_sigma_1": 1, "o3_sigma_2": 1}
+    pp_key = {"o3_lambda_1": 1, "o3_lambda_2": 1, "o3_sigma_1": 1, "o3_sigma_2": 1}
+
+    torch.testing.assert_close(
+        weights_orig.block(ss_key).values,
+        weights_rot.block(ss_key).values,
+    )
+    torch.testing.assert_close(
+        weights_orig.block(pp_key).values,
+        weights_rot.block(pp_key).values,
+    )
+
+@pytest.mark.parametrize("missing_type", [False, True])
+def test_composition_spherical_atomic_basis_rank_2(missing_type):
+    """
+    Test the calculation of composition weights for a spherical per-atom rank 2 atomic
+    basis target (keys: o3_lambda_1, o3_sigma_1, o3_lambda_2, o3_sigma_2, atom_type) is
+    correct.
+    """
+
+    systems = [
+        System(
+            positions=torch.tensor([[0.0, 0.0, 0.0]], dtype=torch.float64),
+            types=torch.tensor([8]),
+            cell=torch.eye(3, dtype=torch.float64),
+            pbc=torch.tensor([True, True, True]),
+        ),
+        System(
+            positions=torch.tensor(
+                [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+                dtype=torch.float64,
+            ),
+            types=torch.tensor([1, 1, 8]),
+            cell=torch.eye(3, dtype=torch.float64),
+            pbc=torch.tensor([True, True, True]),
+        ),
+    ]
+
+    pp_full_sys1 = torch.zeros(1, 3, 3, 1, dtype=torch.float64)
+    pp_full_sys1[0, torch.arange(3), torch.arange(3), 0] = torch.tensor(
+        [1.0, 2.0, 3.0], dtype=torch.float64
+    )
+    pp_full_sys2 = torch.zeros(1, 3, 3, 1, dtype=torch.float64)
+    pp_full_sys2[0, torch.arange(3), torch.arange(3), 0] = torch.tensor(
+        [3.0, 4.0, 5.0], dtype=torch.float64
+    )
+
+    tensor_map_1 = TensorMap(
+        keys=Labels(
+            names=[
+                "o3_lambda_1",
+                "o3_lambda_2",
+                "o3_sigma_1",
+                "o3_sigma_2",
+                "atom_type",
+            ],
+            values=torch.tensor([[0, 0, 1, 1, 8], [1, 1, 1, 1, 8]]),
+        ),
+        blocks=[
+            TensorBlock(
+                values=torch.tensor([[[[1.0]]]], dtype=torch.float64),
+                samples=Labels(names=["system", "atom"], values=torch.tensor([[0, 0]])),
+                components=[
+                    Labels(names=["o3_mu_1"], values=torch.tensor([[0]])),
+                    Labels(names=["o3_mu_2"], values=torch.tensor([[0]])),
+                ],
+                properties=Labels(names=["_"], values=torch.tensor([[0]])),
+            ),
+            TensorBlock(
+                values=pp_full_sys1,
+                samples=Labels(names=["system", "atom"], values=torch.tensor([[0, 0]])),
+                components=[
+                    Labels(
+                        names=["o3_mu_1"], values=torch.arange(-1, 2).reshape(-1, 1)
+                    ),
+                    Labels(
+                        names=["o3_mu_2"], values=torch.arange(-1, 2).reshape(-1, 1)
+                    ),
+                ],
+                properties=Labels(names=["_"], values=torch.tensor([[0]])),
+            ),
+        ],
+    )
+
+    tensor_map_2 = TensorMap(
+        keys=Labels(
+            names=[
+                "o3_lambda_1",
+                "o3_lambda_2",
+                "o3_sigma_1",
+                "o3_sigma_2",
+                "atom_type",
+            ],
+            values=torch.tensor([[0, 0, 1, 1, 1], [0, 0, 1, 1, 8], [1, 1, 1, 1, 8]]),
+        ),
+        blocks=[
+            TensorBlock(
+                values=torch.tensor([[[[1.0]]], [[[1.5]]]], dtype=torch.float64),
+                samples=Labels(
+                    names=["system", "atom"],
+                    values=torch.tensor([[1, 0], [1, 1]]),
+                ),
+                components=[
+                    Labels(names=["o3_mu_1"], values=torch.tensor([[0]])),
+                    Labels(names=["o3_mu_2"], values=torch.tensor([[0]])),
+                ],
+                properties=Labels(names=["_"], values=torch.tensor([[0]])),
+            ),
+            TensorBlock(
+                values=torch.tensor([[[[2.0]]]], dtype=torch.float64),
+                samples=Labels(
+                    names=["system", "atom"],
+                    values=torch.tensor([[1, 2]]),
+                ),
+                components=[
+                    Labels(names=["o3_mu_1"], values=torch.tensor([[0]])),
+                    Labels(names=["o3_mu_2"], values=torch.tensor([[0]])),
+                ],
+                properties=Labels(names=["_"], values=torch.tensor([[0]])),
+            ),
+            TensorBlock(
+                values=pp_full_sys2,
+                samples=Labels(
+                    names=["system", "atom"],
+                    values=torch.tensor([[1, 2]]),
+                ),
+                components=[
+                    Labels(
+                        names=["o3_mu_1"], values=torch.arange(-1, 2).reshape(-1, 1)
+                    ),
+                    Labels(
+                        names=["o3_mu_2"], values=torch.arange(-1, 2).reshape(-1, 1)
+                    ),
+                ],
+                properties=Labels(names=["_"], values=torch.tensor([[0]])),
+            ),
+        ],
+    )
+
+    dataset = Dataset.from_dict(
+        {
+            "system": systems,
+            "uncoupled_hamiltonian": [tensor_map_1, tensor_map_2],
+        }
+    )
+
+    atomic_types = [1, 8]
+    irreps = {
+        1: [{"o3_lambda": 0, "o3_sigma": 1}],
+        8: [
+            {"o3_lambda": 0, "o3_sigma": 1},
+            {"o3_lambda": 1, "o3_sigma": 1},
+        ],
+    }
+    if missing_type:
+        atomic_types.append(9)
+        irreps[9] = [{"o3_lambda": 0, "o3_sigma": 1}]
+
+    composition_model = CompositionModel(
+        hypers={},
+        dataset_info=DatasetInfo(
+            length_unit="angstrom",
+            atomic_types=atomic_types,
+            targets={
+                "uncoupled_hamiltonian": get_generic_target_info(
+                    "uncoupled_hamiltonian",
+                    {
+                        "quantity": "",
+                        "unit": "",
+                        "type": {
+                            "spherical": {"irreps": irreps, "product": "cartesian"}
+                        },
+                        "num_subtargets": 1,
+                        "per_atom": True,
+                    },
+                )
+            },
+        ),
+    )
+
+    composition_model.train_model([dataset], [], batch_size=1, is_distributed=False)
+    assert composition_model.atomic_types == atomic_types
+
+    output = composition_model(
+        [systems[1]], {"uncoupled_hamiltonian": ModelOutput(per_atom=True)}
+    )
+
+    ss_key = {"o3_lambda_1": 0, "o3_lambda_2": 0, "o3_sigma_1": 1, "o3_sigma_2": 1}
+    pp_key = {"o3_lambda_1": 1, "o3_lambda_2": 1, "o3_sigma_1": 1, "o3_sigma_2": 1}
+
+    H_ss_block = output["uncoupled_hamiltonian"].block({**ss_key, "atom_type": 1})
+    torch.testing.assert_close(
+        H_ss_block.values,
+        torch.tensor([1.25, 1.25], dtype=torch.float64).reshape(-1, 1, 1, 1),
+    )
+
+    O_ss_block = output["uncoupled_hamiltonian"].block({**ss_key, "atom_type": 8})
+    torch.testing.assert_close(
+        O_ss_block.values,
+        torch.tensor([1.5], dtype=torch.float64).reshape(-1, 1, 1, 1),
+    )
+
+    O_pp_block = output["uncoupled_hamiltonian"].block({**pp_key, "atom_type": 8})
+    expected_pp = torch.zeros(1, 3, 3, 1, dtype=torch.float64)
+    expected_pp[0, torch.arange(3), torch.arange(3), 0] = torch.tensor(
+        [3.0, 3.0, 3.0], dtype=torch.float64
+    )
+    torch.testing.assert_close(O_pp_block.values, expected_pp)
+
+    if missing_type:
+        system_F = System(
+            positions=torch.tensor([[0.0, 0.0, 0.0]], dtype=torch.float64),
+            types=torch.tensor([9]),
+            cell=torch.eye(3, dtype=torch.float64),
+            pbc=torch.tensor([True, True, True]),
+        )
+        output_F = composition_model(
+            [system_F], {"uncoupled_hamiltonian": ModelOutput(per_atom=True)}
+        )
+        F_ss_block = output_F["uncoupled_hamiltonian"].block({**ss_key, "atom_type": 9})
+        torch.testing.assert_close(
+            F_ss_block.values,
+            torch.tensor([0.0], dtype=torch.float64).reshape(-1, 1, 1, 1),
+        )
+
+@pytest.mark.parametrize("missing_type", [False, True])
+def test_composition_spherical_atomic_basis_rank_2_rotation_invariance(missing_type):
+    """
+    Test the calculation of composition weights for a spherical per-atom rank 2 atomic
+    basis target (keys: o3_lambda_1, o3_lambda_2, o3_sigma_1, o3_sigma_2, atom_type) is
+    invariant under fitting on a rotated version of the dataset.
+    """
+
+    def Rz(theta):
+        c, s = torch.cos(torch.tensor(theta)), torch.sin(torch.tensor(theta))
+        return torch.tensor(
+            [[c, -s, 0.0], [s, c, 0.0], [0.0, 0.0, 1.0]], dtype=torch.float64
+        )
+
+    positions = torch.tensor(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=torch.float64
+    )
+    R = Rz(torch.pi / 2)
+    positions_rotated = positions @ R.T
+
+    system = System(
+        positions=positions,
+        types=torch.tensor([8, 1, 1]),
+        cell=torch.eye(3, dtype=torch.float64),
+        pbc=torch.tensor([True, True, True]),
+    )
+    system_rotated = System(
+        positions=positions_rotated,
+        types=torch.tensor([8, 1, 1]),
+        cell=torch.eye(3, dtype=torch.float64),
+        pbc=torch.tensor([True, True, True]),
+    )
+
+    pp_O = torch.zeros(1, 3, 3, 1, dtype=torch.float64)
+    pp_O[0, torch.arange(3), torch.arange(3), 0] = torch.tensor(
+        [1.0, 2.0, 3.0], dtype=torch.float64
+    )
+    pp_O_rotated = torch.einsum(
+        "ac,bd,icd->iab", R, R, pp_O[..., 0]
+    ).unsqueeze(-1)
+
+    def make_tensor_map(system_idx, pp_O_vals):
+        return TensorMap(
+            keys=Labels(
+                names=[
+                    "o3_lambda_1",
+                    "o3_lambda_2",
+                    "o3_sigma_1",
+                    "o3_sigma_2",
+                    "atom_type",
+                ],
+                values=torch.tensor([[0, 0, 1, 1, 1], [0, 0, 1, 1, 8], [1, 1, 1, 1, 8]]),
+            ),
+            blocks=[
+                TensorBlock(
+                    values=torch.tensor([[[[1.0]]], [[[1.5]]]], dtype=torch.float64),
+                    samples=Labels(
+                        names=["system", "atom"],
+                        values=torch.tensor([[system_idx, 1], [system_idx, 2]]),
+                    ),
+                    components=[
+                        Labels(names=["o3_mu_1"], values=torch.tensor([[0]])),
+                        Labels(names=["o3_mu_2"], values=torch.tensor([[0]])),
+                    ],
+                    properties=Labels(names=["_"], values=torch.tensor([[0]])),
+                ),
+                TensorBlock(
+                    values=torch.tensor([[[[2.0]]]], dtype=torch.float64),
+                    samples=Labels(
+                        names=["system", "atom"],
+                        values=torch.tensor([[system_idx, 0]]),
+                    ),
+                    components=[
+                        Labels(names=["o3_mu_1"], values=torch.tensor([[0]])),
+                        Labels(names=["o3_mu_2"], values=torch.tensor([[0]])),
+                    ],
+                    properties=Labels(names=["_"], values=torch.tensor([[0]])),
+                ),
+                TensorBlock(
+                    values=pp_O_vals,
+                    samples=Labels(
+                        names=["system", "atom"],
+                        values=torch.tensor([[system_idx, 0]]),
+                    ),
+                    components=[
+                        Labels(
+                            names=["o3_mu_1"],
+                            values=torch.arange(-1, 2).reshape(-1, 1),
+                        ),
+                        Labels(
+                            names=["o3_mu_2"],
+                            values=torch.arange(-1, 2).reshape(-1, 1),
+                        ),
+                    ],
+                    properties=Labels(names=["_"], values=torch.tensor([[0]])),
+                ),
+            ],
+        )
+
+    atomic_types = [1, 8]
+    irreps = {
+        1: [{"o3_lambda": 0, "o3_sigma": 1}],
+        8: [
+            {"o3_lambda": 0, "o3_sigma": 1},
+            {"o3_lambda": 1, "o3_sigma": 1},
+        ],
+    }
+    if missing_type:
+        atomic_types.append(9)
+        irreps[9] = [{"o3_lambda": 0, "o3_sigma": 1}]
+
+    target_info = get_generic_target_info(
+        "uncoupled_hamiltonian",
+        {
+            "quantity": "",
+            "unit": "",
+            "type": {
+                "spherical": {"irreps": irreps, "product": "cartesian"}
+            },
+            "num_subtargets": 1,
+            "per_atom": True,
+        },
+    )
+    dataset_info = DatasetInfo(
+        length_unit="angstrom",
+        atomic_types=atomic_types,
+        targets={"uncoupled_hamiltonian": target_info},
+    )
+
+    dataset_orig = Dataset.from_dict(
+        {
+            "system": [system],
+            "uncoupled_hamiltonian": [make_tensor_map(0, pp_O)],
+        }
+    )
+    model_orig = CompositionModel(hypers={}, dataset_info=dataset_info)
+    model_orig.train_model([dataset_orig], [], batch_size=1, is_distributed=False)
+
+    dataset_rot = Dataset.from_dict(
+        {
+            "system": [system_rotated],
+            "uncoupled_hamiltonian": [make_tensor_map(0, pp_O_rotated)],
+        }
+    )
+    model_rot = CompositionModel(hypers={}, dataset_info=dataset_info)
+    model_rot.train_model([dataset_rot], [], batch_size=1, is_distributed=False)
+
+    weights_orig = model_orig.model.weights["uncoupled_hamiltonian"]
+    weights_rot = model_rot.model.weights["uncoupled_hamiltonian"]
+
+    ss_key = {"o3_lambda_1": 0, "o3_lambda_2": 0, "o3_sigma_1": 1, "o3_sigma_2": 1}
+    pp_key = {"o3_lambda_1": 1, "o3_lambda_2": 1, "o3_sigma_1": 1, "o3_sigma_2": 1}
+
+    torch.testing.assert_close(
+        weights_orig.block({**ss_key, "atom_type": 1}).values,
+        weights_rot.block({**ss_key, "atom_type": 1}).values,
+    )
+    torch.testing.assert_close(
+        weights_orig.block({**ss_key, "atom_type": 8}).values,
+        weights_rot.block({**ss_key, "atom_type": 8}).values,
+    )
+
+    torch.testing.assert_close(
+        weights_orig.block({**pp_key, "atom_type": 8}).values,
+        weights_rot.block({**pp_key, "atom_type": 8}).values,
     )

--- a/tests/utils/test_additive.py
+++ b/tests/utils/test_additive.py
@@ -2467,13 +2467,16 @@ def test_composition_spherical_atomic_basis_rank_2_rotation_invariance(missing_t
     torch.testing.assert_close(
         weights_orig.block({**ss_key, "atom_type": 1}).values,
         weights_rot.block({**ss_key, "atom_type": 1}).values,
+        equal_nan=True,
     )
     torch.testing.assert_close(
         weights_orig.block({**ss_key, "atom_type": 8}).values,
         weights_rot.block({**ss_key, "atom_type": 8}).values,
+        equal_nan=True,
     )
 
     torch.testing.assert_close(
         weights_orig.block({**pp_key, "atom_type": 8}).values,
         weights_rot.block({**pp_key, "atom_type": 8}).values,
+        equal_nan=True,
     )

--- a/tests/utils/test_additive.py
+++ b/tests/utils/test_additive.py
@@ -18,6 +18,7 @@ from metatrain.utils.data.atomic_basis_helpers import (
     get_prepare_atomic_basis_targets_transform,
 )
 from metatrain.utils.data.readers import read_systems, read_targets
+from metatrain.utils.data.readers.metatensor import _empty_tensor_map_like
 from metatrain.utils.data.target_info import (
     get_energy_target_info,
     get_generic_target_info,
@@ -26,8 +27,6 @@ from metatrain.utils.neighbor_lists import (
     get_requested_neighbor_lists,
     get_system_with_neighbor_lists,
 )
-from metatrain.utils.data.readers.metatensor import _empty_tensor_map_like
-
 
 
 RESOURCES_PATH = Path(__file__).parents[1] / "resources"
@@ -1794,7 +1793,6 @@ def test_composition_spherical_atomic_basis_dense_nan_weights():
     )
 
 
-
 def test_composition_spherical_per_atom_rank_2():
     """
     Test the calculation of composition weights for a spherical per-atom rank 2 target
@@ -1850,8 +1848,12 @@ def test_composition_spherical_per_atom_rank_2():
                 values=pp_full_sys1,
                 samples=Labels(names=["system", "atom"], values=torch.tensor([[0, 0]])),
                 components=[
-                    Labels(names=["o3_mu_1"], values=torch.arange(-1, 2).reshape(-1, 1)),
-                    Labels(names=["o3_mu_2"], values=torch.arange(-1, 2).reshape(-1, 1)),
+                    Labels(
+                        names=["o3_mu_1"], values=torch.arange(-1, 2).reshape(-1, 1)
+                    ),
+                    Labels(
+                        names=["o3_mu_2"], values=torch.arange(-1, 2).reshape(-1, 1)
+                    ),
                 ],
                 properties=Labels(names=["_"], values=torch.tensor([[0]])),
             ),
@@ -1884,8 +1886,12 @@ def test_composition_spherical_per_atom_rank_2():
                     values=torch.tensor([[1, 0], [1, 1], [1, 2]]),
                 ),
                 components=[
-                    Labels(names=["o3_mu_1"], values=torch.arange(-1, 2).reshape(-1, 1)),
-                    Labels(names=["o3_mu_2"], values=torch.arange(-1, 2).reshape(-1, 1)),
+                    Labels(
+                        names=["o3_mu_1"], values=torch.arange(-1, 2).reshape(-1, 1)
+                    ),
+                    Labels(
+                        names=["o3_mu_2"], values=torch.arange(-1, 2).reshape(-1, 1)
+                    ),
                 ],
                 properties=Labels(names=["_"], values=torch.tensor([[0]])),
             ),
@@ -1940,9 +1946,7 @@ def test_composition_spherical_per_atom_rank_2():
     ss_block = output["rank_2_target"].block(ss_key)
     torch.testing.assert_close(
         ss_block.values,
-        torch.tensor(
-            [1.25, 1.25, 1.5], dtype=torch.float64
-        ).reshape(-1, 1, 1, 1),
+        torch.tensor([1.25, 1.25, 1.5], dtype=torch.float64).reshape(-1, 1, 1, 1),
     )
 
     pp_block = output["rank_2_target"].block(pp_key)
@@ -1951,6 +1955,7 @@ def test_composition_spherical_per_atom_rank_2():
         [3.0, 3.0, 3.0], dtype=torch.float64
     )
     torch.testing.assert_close(pp_block.values, expected_pp)
+
 
 def test_composition_spherical_per_atom_rank_2_rotation_invariance():
     """
@@ -1990,15 +1995,13 @@ def test_composition_spherical_per_atom_rank_2_rotation_invariance():
     pp_full[torch.arange(3), torch.arange(3), torch.arange(3), 0] = torch.tensor(
         [1.0, 2.0, 3.0], dtype=torch.float64
     )
-    pp_vals = pp_full[..., 0]  
+    pp_vals = pp_full[..., 0]
     pp_vals_rotated = torch.einsum("ac,bd,icd->iab", R, R, pp_vals).unsqueeze(-1)
 
     def make_tensor_map(ss_values, pp_values, system_idx):
         samples_3 = Labels(
             names=["system", "atom"],
-            values=torch.tensor(
-                [[system_idx, 0], [system_idx, 1], [system_idx, 2]]
-            ),
+            values=torch.tensor([[system_idx, 0], [system_idx, 1], [system_idx, 2]]),
         )
         return TensorMap(
             keys=Labels(
@@ -2094,6 +2097,7 @@ def test_composition_spherical_per_atom_rank_2_rotation_invariance():
         weights_orig.block(pp_key).values,
         weights_rot.block(pp_key).values,
     )
+
 
 @pytest.mark.parametrize("missing_type", [False, True])
 def test_composition_spherical_atomic_basis_rank_2(missing_type):
@@ -2308,6 +2312,7 @@ def test_composition_spherical_atomic_basis_rank_2(missing_type):
             torch.tensor([0.0], dtype=torch.float64).reshape(-1, 1, 1, 1),
         )
 
+
 @pytest.mark.parametrize("missing_type", [False, True])
 def test_composition_spherical_atomic_basis_rank_2_rotation_invariance(missing_type):
     """
@@ -2345,9 +2350,7 @@ def test_composition_spherical_atomic_basis_rank_2_rotation_invariance(missing_t
     pp_O[0, torch.arange(3), torch.arange(3), 0] = torch.tensor(
         [1.0, 2.0, 3.0], dtype=torch.float64
     )
-    pp_O_rotated = torch.einsum(
-        "ac,bd,icd->iab", R, R, pp_O[..., 0]
-    ).unsqueeze(-1)
+    pp_O_rotated = torch.einsum("ac,bd,icd->iab", R, R, pp_O[..., 0]).unsqueeze(-1)
 
     def make_tensor_map(system_idx, pp_O_vals):
         return TensorMap(
@@ -2359,7 +2362,9 @@ def test_composition_spherical_atomic_basis_rank_2_rotation_invariance(missing_t
                     "o3_sigma_2",
                     "atom_type",
                 ],
-                values=torch.tensor([[0, 0, 1, 1, 1], [0, 0, 1, 1, 8], [1, 1, 1, 1, 8]]),
+                values=torch.tensor(
+                    [[0, 0, 1, 1, 1], [0, 0, 1, 1, 8], [1, 1, 1, 1, 8]]
+                ),
             ),
             blocks=[
                 TensorBlock(
@@ -2424,9 +2429,7 @@ def test_composition_spherical_atomic_basis_rank_2_rotation_invariance(missing_t
         {
             "quantity": "",
             "unit": "",
-            "type": {
-                "spherical": {"irreps": irreps, "product": "cartesian"}
-            },
+            "type": {"spherical": {"irreps": irreps, "product": "cartesian"}},
             "num_subtargets": 1,
             "per_atom": True,
         },

--- a/tests/utils/test_augmentation.py
+++ b/tests/utils/test_augmentation.py
@@ -311,6 +311,96 @@ def test_rotation_per_atom_spherical_atomicbasis(batch_size):
         # Check that the rotated target matches the reference
         mts.allclose_raise(RfX, fRX, atol=1e-5)
 
+@pytest.mark.parametrize("batch_size", [1, 2])
+def test_rotation_per_atom_spherical_rank2(batch_size):
+    """Tests that the rotational augmenter rotates a Hamiltonian
+    in the uncoupled basis (rank 2 tensors with an atomic basis)
+    consistent with targets computed from DFT"""
+    target_name = "mtt::hamiltonian_nodes_uncoupled"
+
+    # Hard-coded rotation matrix used to generate the system for which DFT was run
+    R = np.array(
+        [
+            [0.22922512, -0.15149287, 0.96151222],
+            [0.66175278, -0.70015582, -0.26807664],
+            [0.71382008, 0.69773328, -0.06024247],
+        ]
+    )
+
+    # Load the target data
+    dataset_unrotated = DiskDataset(RESOURCES_PATH / "spherical_targets_unrotated.zip")
+    dataset_rotated = DiskDataset(RESOURCES_PATH / "spherical_targets_rotated.zip")
+
+    X = [
+        sample["system"].to(torch.float64)
+        for i, sample in enumerate(dataset_unrotated)
+        if i < batch_size
+    ]
+    fX = mts.join(
+        [
+            sample[target_name]
+            for i, sample in enumerate(dataset_unrotated)
+            if i < batch_size
+        ],
+        axis="samples",
+    )
+    fRX = mts.join(
+        [
+            sample[target_name]
+            for i, sample in enumerate(dataset_rotated)
+            if i < batch_size
+        ],
+        axis="samples",
+    )
+
+    dataset_info = DatasetInfo(
+        length_unit="angstrom",
+        atomic_types=[1, 8],
+        targets={
+            target_name: get_generic_target_info(
+                target_name,
+                {
+                    "quantity": "spherical",
+                    "unit": "",
+                    "type": {
+                        "spherical": {
+                            "product": "cartesian",
+                            "irreps": {
+                                1: [  # H
+                                    {"o3_lambda": 0, "o3_sigma": 1, "num": 3},
+                                    {"o3_lambda": 1, "o3_sigma": 1, "num": 1},
+                                ],
+                                8: [  # O
+                                    {"o3_lambda": 0, "o3_sigma": 1, "num": 5},
+                                    {"o3_lambda": 1, "o3_sigma": 1, "num": 3},
+                                    {"o3_lambda": 2, "o3_sigma": 1, "num": 2},
+                                    {"o3_lambda": 3, "o3_sigma": 1, "num": 1},
+                                ],
+                            },
+                        }
+                    },
+                    "per_atom": True,
+                    "num_subtargets": 1,
+                },
+            )
+        },
+    )
+
+    rotational_augmenter = RotationalAugmenter(dataset_info.targets, {})
+
+    # Apply the augmentation to the target
+    _, RfX, _ = rotational_augmenter.apply_augmentations(
+        X,
+        {target_name: fX},
+        extra_data={},
+        rotations=[Rotation.from_matrix(R.T)] * batch_size,
+        inversions=[1] * batch_size,
+    )
+    RfX = RfX[target_name]
+
+    # Check that the rotated target matches the reference
+    mts.allclose_raise(RfX, fRX, atol=1e-5)
+
 
 def test_missing_library(monkeypatch, layout_spherical):
     # Pretend 'spherical' is not installed

--- a/tests/utils/test_augmentation.py
+++ b/tests/utils/test_augmentation.py
@@ -388,18 +388,22 @@ def test_rotation_per_atom_spherical_rank2(batch_size):
 
     rotational_augmenter = RotationalAugmenter(dataset_info.targets, {})
 
-    # Apply the augmentation to the target
-    _, RfX, _ = rotational_augmenter.apply_augmentations(
-        X,
-        {target_name: fX},
-        extra_data={},
-        rotations=[Rotation.from_matrix(R.T)] * batch_size,
-        inversions=[1] * batch_size,
-    )
-    RfX = RfX[target_name]
+    with pytest.raises(
+        (ValueError, torch.jit.Error),
+        match="Rotational augmentation of atomic basis targets is not supported yet.",
+    ):
+        # Apply the augmentation to the target
+        _, RfX, _ = rotational_augmenter.apply_augmentations(
+            X,
+            {target_name: fX},
+            extra_data={},
+            rotations=[Rotation.from_matrix(R.T)] * batch_size,
+            inversions=[1] * batch_size,
+        )
+        RfX = RfX[target_name]
 
-    # Check that the rotated target matches the reference
-    mts.allclose_raise(RfX, fRX, atol=1e-5)
+        # Check that the rotated target matches the reference
+        mts.allclose_raise(RfX, fRX, atol=1e-5)
 
 
 def test_missing_library(monkeypatch, layout_spherical):

--- a/tests/utils/test_augmentation.py
+++ b/tests/utils/test_augmentation.py
@@ -311,6 +311,7 @@ def test_rotation_per_atom_spherical_atomicbasis(batch_size):
         # Check that the rotated target matches the reference
         mts.allclose_raise(RfX, fRX, atol=1e-5)
 
+
 @pytest.mark.parametrize("batch_size", [1, 2])
 def test_rotation_per_atom_spherical_rank2(batch_size):
     """Tests that the rotational augmenter rotates a Hamiltonian

--- a/tests/utils/test_scaler.py
+++ b/tests/utils/test_scaler.py
@@ -17,11 +17,6 @@ from metatrain.utils.data.target_info import (
     get_generic_target_info,
 )
 from metatrain.utils.scaler import Scaler, remove_scale
-from metatrain.utils.data.atomic_basis_helpers import(
-    densify_atomic_basis_target,
-    pad_samples_atomic_basis_target,
-    sparsify_atomic_basis_target,
-)
 
 from ..conftest import RESOURCES_PATH
 
@@ -1562,30 +1557,32 @@ SYSTEMS = [
     ),
 ]
 
- 
+
 @pytest.mark.parametrize("batch_size", [1, 2])
 def test_scaler_spherical_per_atom_rank_2(batch_size):
     """Test the calculation of scaling weights for a per-atom rank-2 spherical target
     (keys: o3_lambda_1, o3_sigma_1, o3_lambda_2, o3_sigma_2).
- 
+
     The expected scale for each (lambda_1, lambda_2, atomic_type) is the RMS of all
     component values for that atom type pooled over all atoms and systems, matching
     the convention used for rank-1 targets in test_scaler_spherical_per_atom.
     """
     target_name = "spherical_rank2"
- 
+
     keys = Labels(
         names=["o3_lambda_1", "o3_sigma_1", "o3_lambda_2", "o3_sigma_2"],
         values=torch.tensor([[0, 1, 0, 1], [1, 1, 1, 1]]),
     )
     prop_labels = Labels(names=["property"], values=torch.tensor([[0]]))
- 
-    L_00_sys0 = torch.tensor([[[[1.0]]]]).to(torch.float64)                        # O
-    L_00_sys1 = torch.tensor([[[[2.0]]], [[[3.0]]], [[[4.0]]]]).to(torch.float64)  # H, H, O
- 
+
+    L_00_sys0 = torch.tensor([[[[1.0]]]]).to(torch.float64)  # O
+    L_00_sys1 = torch.tensor([[[[2.0]]], [[[3.0]]], [[[4.0]]]]).to(
+        torch.float64
+    )  # H, H, O
+
     L_11_sys0 = torch.arange(1.0, 10.0).reshape(1, 3, 3, 1).to(torch.float64)
     L_11_sys1 = torch.arange(10.0, 37.0).reshape(3, 3, 3, 1).to(torch.float64)
- 
+
     def _make_tm(L_00, L_11, sys_idx, n_atoms):
         sample_vals = torch.tensor([[sys_idx, a] for a in range(n_atoms)])
         samples = Labels(names=["system", "atom"], values=sample_vals)
@@ -1618,7 +1615,7 @@ def test_scaler_spherical_per_atom_rank_2(batch_size):
                 ),
             ],
         )
- 
+
     dataset = Dataset.from_dict(
         {
             "system": SYSTEMS,
@@ -1628,7 +1625,7 @@ def test_scaler_spherical_per_atom_rank_2(batch_size):
             ],
         }
     )
- 
+
     dataset_info = DatasetInfo(
         length_unit="angstrom",
         atomic_types=[1, 8],
@@ -1653,25 +1650,27 @@ def test_scaler_spherical_per_atom_rank_2(batch_size):
             )
         },
     )
- 
+
     scaler = Scaler(hypers={}, dataset_info=dataset_info).to(torch.float64)
     scaler2 = copy.deepcopy(scaler)
     scaler3 = copy.deepcopy(scaler)
- 
+
     def _rms(vals):
         return (vals.flatten() ** 2).mean().sqrt()
- 
-    H_00 = L_00_sys1[:2].flatten()                                    # [2.0, 3.0]
+
+    H_00 = L_00_sys1[:2].flatten()  # [2.0, 3.0]
     O_00 = torch.cat([L_00_sys0.flatten(), L_00_sys1[2:].flatten()])  # [1.0, 4.0]
- 
-    H_11 = L_11_sys1[:2].flatten()                                    # arange(10, 28)
-    O_11 = torch.cat([L_11_sys0.flatten(), L_11_sys1[2:].flatten()])  # arange(1,10) + arange(28,37)
- 
+
+    H_11 = L_11_sys1[:2].flatten()  # arange(10, 28)
+    O_11 = torch.cat(
+        [L_11_sys0.flatten(), L_11_sys1[2:].flatten()]
+    )  # arange(1,10) + arange(28,37)
+
     expected = {
-        (0, 0, 1, 1): {0: _rms(H_00), 1: _rms(O_00)}, 
+        (0, 0, 1, 1): {0: _rms(H_00), 1: _rms(O_00)},
         (1, 1, 1, 1): {0: _rms(H_11), 1: _rms(O_11)},
     }
- 
+
     for sc, dset in [
         (scaler, dataset),
         (scaler2, [dataset, dataset]),
@@ -1683,7 +1682,7 @@ def test_scaler_spherical_per_atom_rank_2(batch_size):
             batch_size=batch_size,
             is_distributed=False,
         )
- 
+
     for sc in [scaler, scaler2, scaler3]:
         scales_tm = sc.model.scales[target_name]
         for key in scales_tm.keys:
@@ -1704,27 +1703,28 @@ def test_scaler_spherical_per_atom_rank_2(batch_size):
                     atol=1e-5,
                 )
 
+
 def test_scaler_spherical_per_atom_rank_2_rotation_invariance():
     """Test that scaling weights for a per-atom rank-2 spherical target are invariant
     under fitting on a randomly rotated version of the dataset.
- 
+
     The Frobenius norm (and hence the RMS) of a rank-2 tensor is preserved under
     rotation, so the scales must be identical regardless of orientation.
     """
     target_name = "spherical_rank2"
     num_checks = 5
- 
+
     keys = Labels(
         names=["o3_lambda_1", "o3_sigma_1", "o3_lambda_2", "o3_sigma_2"],
         values=torch.tensor([[0, 1, 0, 1], [1, 1, 1, 1]]),
     )
     prop_labels = Labels(names=["property"], values=torch.tensor([[0]]))
- 
+
     L_00_sys0 = torch.tensor([[[[1.0]]]]).to(torch.float64)
     L_00_sys1 = torch.tensor([[[[2.0]]], [[[3.0]]], [[[4.0]]]]).to(torch.float64)
     L_11_sys0 = torch.arange(1.0, 10.0).reshape(1, 3, 3, 1).to(torch.float64)
     L_11_sys1 = torch.arange(10.0, 37.0).reshape(3, 3, 3, 1).to(torch.float64)
- 
+
     def _make_tm(L_00, L_11, sys_idx, n_atoms):
         sample_vals = torch.tensor([[sys_idx, a] for a in range(n_atoms)])
         samples = Labels(names=["system", "atom"], values=sample_vals)
@@ -1757,12 +1757,12 @@ def test_scaler_spherical_per_atom_rank_2_rotation_invariance():
                 ),
             ],
         )
- 
+
     tensor_maps = [
         _make_tm(L_00_sys0, L_11_sys0, sys_idx=0, n_atoms=1),
         _make_tm(L_00_sys1, L_11_sys1, sys_idx=1, n_atoms=3),
     ]
- 
+
     dataset_info = DatasetInfo(
         length_unit="angstrom",
         atomic_types=[1, 8],
@@ -1787,17 +1787,15 @@ def test_scaler_spherical_per_atom_rank_2_rotation_invariance():
             )
         },
     )
- 
+
     dataset = Dataset.from_dict({"system": SYSTEMS, target_name: tensor_maps})
     scaler = Scaler(hypers={}, dataset_info=dataset_info).to(torch.float64)
-    scaler.train_model(
-        dataset, additive_models=[], batch_size=1, is_distributed=False
-    )
- 
+    scaler.train_model(dataset, additive_models=[], batch_size=1, is_distributed=False)
+
     rotational_augmenter = RotationalAugmenter(
         dataset_info.targets, extra_data_info_dict={}
     )
- 
+
     for _ in range(num_checks):
         systems_rot, targets_rot = [], []
         for system_, tm_ in zip(SYSTEMS, tensor_maps, strict=False):
@@ -1808,7 +1806,7 @@ def test_scaler_spherical_per_atom_rank_2_rotation_invariance():
             )
             systems_rot.append(sys_r[0])
             targets_rot.append(tgts_r[target_name])
- 
+
         dataset_rot = Dataset.from_dict(
             {"system": systems_rot, target_name: targets_rot}
         )
@@ -1816,7 +1814,7 @@ def test_scaler_spherical_per_atom_rank_2_rotation_invariance():
         scaler_rot.train_model(
             dataset_rot, additive_models=[], batch_size=1, is_distributed=False
         )
- 
+
         scales = scaler.model.scales[target_name]
         scales_rot = scaler_rot.model.scales[target_name]
         for key in scales.keys:
@@ -1826,6 +1824,7 @@ def test_scaler_spherical_per_atom_rank_2_rotation_invariance():
                 block.values, block_rot.values, rtol=1e-5, atol=1e-5
             )
 
+
 @pytest.mark.parametrize("missing_type", [False, True])
 def test_scaler_spherical_atomic_basis_rank_2(missing_type):
     """Test the calculation of scaling weights for a per-atom rank-2 atomic-basis
@@ -1833,20 +1832,20 @@ def test_scaler_spherical_atomic_basis_rank_2(missing_type):
     atom_type) is correct.
     """
     target_name = "spherical_atomic_basis_rank2"
- 
+
     key_names = ["o3_lambda_1", "o3_sigma_1", "o3_lambda_2", "o3_sigma_2", "atom_type"]
     prop = Labels(names=["_"], values=torch.tensor([[0]]))
     mu1_1 = Labels(names=["o3_mu_1"], values=torch.tensor([[0]]))
     mu2_1 = Labels(names=["o3_mu_2"], values=torch.tensor([[0]]))
     mu1_3 = Labels(names=["o3_mu_1"], values=torch.arange(-1, 2).reshape(-1, 1))
     mu2_3 = Labels(names=["o3_mu_2"], values=torch.arange(-1, 2).reshape(-1, 1))
- 
+
     sys0_vals_00_O = torch.tensor([[[[1.0]]]], dtype=torch.float64)  # (1,1,1,1)
     sys0_vals_11_O = torch.tensor(
         [1.5, 0.8, 3.2, 0.4, 2.1, 0.9, 1.2, 3.0, 0.6], dtype=torch.float64
     ).reshape(1, 3, 3, 1)
     samples_sys0 = Labels(names=["system", "atom"], values=torch.tensor([[0, 0]]))
- 
+
     tensor_map_1 = TensorMap(
         keys=Labels(
             names=key_names,
@@ -1867,13 +1866,13 @@ def test_scaler_spherical_atomic_basis_rank_2(missing_type):
             ),
         ],
     )
- 
+
     sys1_vals_00_H = torch.tensor([1.0, 1.5], dtype=torch.float64).reshape(2, 1, 1, 1)
     sys1_vals_00_O = torch.tensor([[[[2.0]]]], dtype=torch.float64)
     sys1_vals_11_O = torch.tensor(
         [0.2, 3.0, 1.1, 2.5, 0.7, 1.8, 0.3, 2.2, 1.0], dtype=torch.float64
     ).reshape(1, 3, 3, 1)
- 
+
     tensor_map_2 = TensorMap(
         keys=Labels(
             names=key_names,
@@ -1891,27 +1890,23 @@ def test_scaler_spherical_atomic_basis_rank_2(missing_type):
             ),
             TensorBlock(
                 values=sys1_vals_00_O,
-                samples=Labels(
-                    names=["system", "atom"], values=torch.tensor([[1, 2]])
-                ),
+                samples=Labels(names=["system", "atom"], values=torch.tensor([[1, 2]])),
                 components=[mu1_1, mu2_1],
                 properties=prop,
             ),
             TensorBlock(
                 values=sys1_vals_11_O,
-                samples=Labels(
-                    names=["system", "atom"], values=torch.tensor([[1, 2]])
-                ),
+                samples=Labels(names=["system", "atom"], values=torch.tensor([[1, 2]])),
                 components=[mu1_3, mu2_3],
                 properties=prop,
             ),
         ],
     )
- 
+
     dataset = Dataset.from_dict(
         {"system": SYSTEMS, target_name: [tensor_map_1, tensor_map_2]}
     )
- 
+
     atomic_types = [1, 8]
     irreps = {
         1: [{"o3_lambda": 0, "o3_sigma": 1}],
@@ -1923,7 +1918,7 @@ def test_scaler_spherical_atomic_basis_rank_2(missing_type):
     if missing_type:
         atomic_types.append(9)
         irreps[9] = [{"o3_lambda": 0, "o3_sigma": 1}]
- 
+
     dataset_info = DatasetInfo(
         length_unit="angstrom",
         atomic_types=atomic_types,
@@ -1945,22 +1940,18 @@ def test_scaler_spherical_atomic_basis_rank_2(missing_type):
             )
         },
     )
- 
+
     scaler = Scaler(hypers={}, dataset_info=dataset_info).to(torch.float64)
-    scaler.train_model(
-        dataset, additive_models=[], batch_size=1, is_distributed=False
-    )
- 
-    o_11_all = torch.cat(
-        [sys0_vals_11_O.flatten(), sys1_vals_11_O.flatten()]
-    )
+    scaler.train_model(dataset, additive_models=[], batch_size=1, is_distributed=False)
+
+    o_11_all = torch.cat([sys0_vals_11_O.flatten(), sys1_vals_11_O.flatten()])
     expected_scales = {
         (0, 0, 1, 1, 1): (torch.tensor([1.0, 1.5]) ** 2).mean().sqrt(),
         (0, 0, 1, 1, 8): (torch.tensor([1.0, 2.0]) ** 2).mean().sqrt(),
-        (1, 1, 1, 1, 8): (o_11_all ** 2).mean().sqrt(),
+        (1, 1, 1, 1, 8): (o_11_all**2).mean().sqrt(),
         (0, 0, 1, 1, 9): torch.tensor(1.0, dtype=torch.float64),
     }
- 
+
     scales_tm = scaler.model.scales[target_name]
     for key in scales_tm.keys:
         block = scales_tm.block(key)
@@ -1986,6 +1977,7 @@ def test_scaler_spherical_atomic_basis_rank_2(missing_type):
             torch.arange(len(atomic_types)) != atom_type_index, 0
         ]
         torch.testing.assert_close(other_scales, torch.ones_like(other_scales))
+
 
 @pytest.mark.parametrize("missing_type", [False, True])
 def test_scaler_spherical_atomic_basis_rank_2_rotation_invariance(missing_type):
@@ -2057,17 +2049,13 @@ def test_scaler_spherical_atomic_basis_rank_2_rotation_invariance(missing_type):
             ),
             TensorBlock(
                 values=sys1_vals_00_O,
-                samples=Labels(
-                    names=["system", "atom"], values=torch.tensor([[1, 2]])
-                ),
+                samples=Labels(names=["system", "atom"], values=torch.tensor([[1, 2]])),
                 components=[mu1_1, mu2_1],
                 properties=prop,
             ),
             TensorBlock(
                 values=sys1_vals_11_O,
-                samples=Labels(
-                    names=["system", "atom"], values=torch.tensor([[1, 2]])
-                ),
+                samples=Labels(names=["system", "atom"], values=torch.tensor([[1, 2]])),
                 components=[mu1_3, mu2_3],
                 properties=prop,
             ),
@@ -2112,9 +2100,7 @@ def test_scaler_spherical_atomic_basis_rank_2_rotation_invariance(missing_type):
 
     dataset = Dataset.from_dict({"system": SYSTEMS, target_name: tensor_maps})
     scaler = Scaler(hypers={}, dataset_info=dataset_info).to(torch.float64)
-    scaler.train_model(
-        dataset, additive_models=[], batch_size=1, is_distributed=False
-    )
+    scaler.train_model(dataset, additive_models=[], batch_size=1, is_distributed=False)
 
     for _ in range(num_checks):
         # Rotate only the atomic positions; keep target values unchanged since
@@ -2146,7 +2132,8 @@ def test_scaler_spherical_atomic_basis_rank_2_rotation_invariance(missing_type):
             torch.testing.assert_close(
                 block.values, block_rot.values, rtol=1e-5, atol=1e-5
             )
- 
+
+
 def test_scaler_torchscript(tmpdir):
     """Test the torchscripting, saving and loading of a scaler model."""
 

--- a/tests/utils/test_scaler.py
+++ b/tests/utils/test_scaler.py
@@ -1539,6 +1539,46 @@ def test_scaler_rotation_invariance():
         )
 
 
+def test_scaler_spherical_per_atom_rank_2():
+    """
+    Test the calculation of scales for a spherical per-atom rank 2 target (keys:
+    o3_lambda_1, o3_sigma_1, o3_lambda_2, o3_sigma_2) is correct.
+    """
+    # TODO!
+    raise NotImplementedError
+
+
+def test_scaler_spherical_per_atom_rank_2_rotation_invariance():
+    """
+    Test the calculation of scales for a spherical per-atom rank 2 target (keys:
+    o3_lambda_1, o3_sigma_1, o3_lambda_2, o3_sigma_2) is invariant under fitting on a
+    rotated version of the dataset.
+    """
+    # TODO!
+    raise NotImplementedError
+
+
+@pytest.mark.parametrize("missing_type", [False, True])
+def test_scaler_spherical_atomic_basis_rank_2(missing_type):
+    """
+    Test the calculation of scales for a spherical per-atom rank 2 atomic basis target
+    (keys: o3_lambda_1, o3_sigma_1, o3_lambda_2, o3_sigma_2, atom_type) is correct.
+    """
+    # TODO!
+    raise NotImplementedError
+
+
+@pytest.mark.parametrize("missing_type", [False, True])
+def test_scaler_spherical_atomic_basis_rank_2_rotation_invariance(missing_type):
+    """
+    Test the calculation of scales for a spherical per-atom rank 2 atomic basis target
+    (keys: o3_lambda_1, o3_sigma_1, o3_lambda_2, o3_sigma_2, atom_type) is invariant
+    under fitting on a rotated version of the dataset.
+    """
+    # TODO!
+    raise NotImplementedError
+
+
 def test_scaler_torchscript(tmpdir):
     """Test the torchscripting, saving and loading of a scaler model."""
 

--- a/tests/utils/test_scaler.py
+++ b/tests/utils/test_scaler.py
@@ -17,6 +17,11 @@ from metatrain.utils.data.target_info import (
     get_generic_target_info,
 )
 from metatrain.utils.scaler import Scaler, remove_scale
+from metatrain.utils.data.atomic_basis_helpers import(
+    densify_atomic_basis_target,
+    pad_samples_atomic_basis_target,
+    sparsify_atomic_basis_target,
+)
 
 from ..conftest import RESOURCES_PATH
 
@@ -1539,46 +1544,609 @@ def test_scaler_rotation_invariance():
         )
 
 
-def test_scaler_spherical_per_atom_rank_2():
-    """
-    Test the calculation of scales for a spherical per-atom rank 2 target (keys:
-    o3_lambda_1, o3_sigma_1, o3_lambda_2, o3_sigma_2) is correct.
-    """
-    # TODO!
-    raise NotImplementedError
+SYSTEMS = [
+    System(
+        positions=torch.tensor([[0.0, 0.0, 0.0]], dtype=torch.float64),
+        types=torch.tensor([8]),
+        cell=torch.eye(3, dtype=torch.float64),
+        pbc=torch.tensor([True, True, True]),
+    ),
+    System(
+        positions=torch.tensor(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            dtype=torch.float64,
+        ),
+        types=torch.tensor([1, 1, 8]),
+        cell=torch.eye(3, dtype=torch.float64),
+        pbc=torch.tensor([True, True, True]),
+    ),
+]
 
+ 
+@pytest.mark.parametrize("batch_size", [1, 2])
+def test_scaler_spherical_per_atom_rank_2(batch_size):
+    """Test the calculation of scaling weights for a per-atom rank-2 spherical target
+    (keys: o3_lambda_1, o3_sigma_1, o3_lambda_2, o3_sigma_2).
+ 
+    The expected scale for each (lambda_1, lambda_2, atomic_type) is the RMS of all
+    component values for that atom type pooled over all atoms and systems, matching
+    the convention used for rank-1 targets in test_scaler_spherical_per_atom.
+    """
+    target_name = "spherical_rank2"
+ 
+    keys = Labels(
+        names=["o3_lambda_1", "o3_sigma_1", "o3_lambda_2", "o3_sigma_2"],
+        values=torch.tensor([[0, 1, 0, 1], [1, 1, 1, 1]]),
+    )
+    prop_labels = Labels(names=["property"], values=torch.tensor([[0]]))
+ 
+    L_00_sys0 = torch.tensor([[[[1.0]]]]).to(torch.float64)                        # O
+    L_00_sys1 = torch.tensor([[[[2.0]]], [[[3.0]]], [[[4.0]]]]).to(torch.float64)  # H, H, O
+ 
+    L_11_sys0 = torch.arange(1.0, 10.0).reshape(1, 3, 3, 1).to(torch.float64)
+    L_11_sys1 = torch.arange(10.0, 37.0).reshape(3, 3, 3, 1).to(torch.float64)
+ 
+    def _make_tm(L_00, L_11, sys_idx, n_atoms):
+        sample_vals = torch.tensor([[sys_idx, a] for a in range(n_atoms)])
+        samples = Labels(names=["system", "atom"], values=sample_vals)
+        return TensorMap(
+            keys=keys,
+            blocks=[
+                TensorBlock(
+                    values=L_00,
+                    samples=samples,
+                    components=[
+                        Labels(names=["o3_mu_1"], values=torch.tensor([[0]])),
+                        Labels(names=["o3_mu_2"], values=torch.tensor([[0]])),
+                    ],
+                    properties=prop_labels,
+                ),
+                TensorBlock(
+                    values=L_11,
+                    samples=samples,
+                    components=[
+                        Labels(
+                            names=["o3_mu_1"],
+                            values=torch.arange(-1, 2).reshape(-1, 1),
+                        ),
+                        Labels(
+                            names=["o3_mu_2"],
+                            values=torch.arange(-1, 2).reshape(-1, 1),
+                        ),
+                    ],
+                    properties=prop_labels,
+                ),
+            ],
+        )
+ 
+    dataset = Dataset.from_dict(
+        {
+            "system": SYSTEMS,
+            target_name: [
+                _make_tm(L_00_sys0, L_11_sys0, sys_idx=0, n_atoms=1),
+                _make_tm(L_00_sys1, L_11_sys1, sys_idx=1, n_atoms=3),
+            ],
+        }
+    )
+ 
+    dataset_info = DatasetInfo(
+        length_unit="angstrom",
+        atomic_types=[1, 8],
+        targets={
+            target_name: get_generic_target_info(
+                target_name,
+                {
+                    "quantity": "",
+                    "unit": "",
+                    "type": {
+                        "spherical": {
+                            "product": "cartesian",
+                            "irreps": [
+                                {"o3_lambda": 0, "o3_sigma": 1},
+                                {"o3_lambda": 1, "o3_sigma": 1},
+                            ],
+                        }
+                    },
+                    "per_atom": True,
+                    "num_subtargets": 1,
+                },
+            )
+        },
+    )
+ 
+    scaler = Scaler(hypers={}, dataset_info=dataset_info).to(torch.float64)
+    scaler2 = copy.deepcopy(scaler)
+    scaler3 = copy.deepcopy(scaler)
+ 
+    def _rms(vals):
+        return (vals.flatten() ** 2).mean().sqrt()
+ 
+    H_00 = L_00_sys1[:2].flatten()                                    # [2.0, 3.0]
+    O_00 = torch.cat([L_00_sys0.flatten(), L_00_sys1[2:].flatten()])  # [1.0, 4.0]
+ 
+    H_11 = L_11_sys1[:2].flatten()                                    # arange(10, 28)
+    O_11 = torch.cat([L_11_sys0.flatten(), L_11_sys1[2:].flatten()])  # arange(1,10) + arange(28,37)
+ 
+    expected = {
+        (0, 0, 1, 1): {0: _rms(H_00), 1: _rms(O_00)}, 
+        (1, 1, 1, 1): {0: _rms(H_11), 1: _rms(O_11)},
+    }
+ 
+    for sc, dset in [
+        (scaler, dataset),
+        (scaler2, [dataset, dataset]),
+        (scaler3, [dataset, dataset, dataset]),
+    ]:
+        sc.train_model(
+            dset,
+            additive_models=[],
+            batch_size=batch_size,
+            is_distributed=False,
+        )
+ 
+    for sc in [scaler, scaler2, scaler3]:
+        scales_tm = sc.model.scales[target_name]
+        for key in scales_tm.keys:
+            key_tuple = (
+                key["o3_lambda_1"],
+                key["o3_lambda_2"],
+                key["o3_sigma_1"],
+                key["o3_sigma_2"],
+            )
+            if key_tuple not in expected:
+                continue
+            block = scales_tm.block(key)
+            for type_idx, exp_scale in expected[key_tuple].items():
+                torch.testing.assert_close(
+                    block.values[type_idx, 0],
+                    exp_scale.to(torch.float64),
+                    rtol=1e-5,
+                    atol=1e-5,
+                )
 
 def test_scaler_spherical_per_atom_rank_2_rotation_invariance():
+    """Test that scaling weights for a per-atom rank-2 spherical target are invariant
+    under fitting on a randomly rotated version of the dataset.
+ 
+    The Frobenius norm (and hence the RMS) of a rank-2 tensor is preserved under
+    rotation, so the scales must be identical regardless of orientation.
     """
-    Test the calculation of scales for a spherical per-atom rank 2 target (keys:
-    o3_lambda_1, o3_sigma_1, o3_lambda_2, o3_sigma_2) is invariant under fitting on a
-    rotated version of the dataset.
-    """
-    # TODO!
-    raise NotImplementedError
-
+    target_name = "spherical_rank2"
+    num_checks = 5
+ 
+    keys = Labels(
+        names=["o3_lambda_1", "o3_sigma_1", "o3_lambda_2", "o3_sigma_2"],
+        values=torch.tensor([[0, 1, 0, 1], [1, 1, 1, 1]]),
+    )
+    prop_labels = Labels(names=["property"], values=torch.tensor([[0]]))
+ 
+    L_00_sys0 = torch.tensor([[[[1.0]]]]).to(torch.float64)
+    L_00_sys1 = torch.tensor([[[[2.0]]], [[[3.0]]], [[[4.0]]]]).to(torch.float64)
+    L_11_sys0 = torch.arange(1.0, 10.0).reshape(1, 3, 3, 1).to(torch.float64)
+    L_11_sys1 = torch.arange(10.0, 37.0).reshape(3, 3, 3, 1).to(torch.float64)
+ 
+    def _make_tm(L_00, L_11, sys_idx, n_atoms):
+        sample_vals = torch.tensor([[sys_idx, a] for a in range(n_atoms)])
+        samples = Labels(names=["system", "atom"], values=sample_vals)
+        return TensorMap(
+            keys=keys,
+            blocks=[
+                TensorBlock(
+                    values=L_00,
+                    samples=samples,
+                    components=[
+                        Labels(names=["o3_mu_1"], values=torch.tensor([[0]])),
+                        Labels(names=["o3_mu_2"], values=torch.tensor([[0]])),
+                    ],
+                    properties=prop_labels,
+                ),
+                TensorBlock(
+                    values=L_11,
+                    samples=samples,
+                    components=[
+                        Labels(
+                            names=["o3_mu_1"],
+                            values=torch.arange(-1, 2).reshape(-1, 1),
+                        ),
+                        Labels(
+                            names=["o3_mu_2"],
+                            values=torch.arange(-1, 2).reshape(-1, 1),
+                        ),
+                    ],
+                    properties=prop_labels,
+                ),
+            ],
+        )
+ 
+    tensor_maps = [
+        _make_tm(L_00_sys0, L_11_sys0, sys_idx=0, n_atoms=1),
+        _make_tm(L_00_sys1, L_11_sys1, sys_idx=1, n_atoms=3),
+    ]
+ 
+    dataset_info = DatasetInfo(
+        length_unit="angstrom",
+        atomic_types=[1, 8],
+        targets={
+            target_name: get_generic_target_info(
+                target_name,
+                {
+                    "quantity": "",
+                    "unit": "",
+                    "type": {
+                        "spherical": {
+                            "product": "cartesian",
+                            "irreps": [
+                                {"o3_lambda": 0, "o3_sigma": 1},
+                                {"o3_lambda": 1, "o3_sigma": 1},
+                            ],
+                        }
+                    },
+                    "per_atom": True,
+                    "num_subtargets": 1,
+                },
+            )
+        },
+    )
+ 
+    dataset = Dataset.from_dict({"system": SYSTEMS, target_name: tensor_maps})
+    scaler = Scaler(hypers={}, dataset_info=dataset_info).to(torch.float64)
+    scaler.train_model(
+        dataset, additive_models=[], batch_size=1, is_distributed=False
+    )
+ 
+    rotational_augmenter = RotationalAugmenter(
+        dataset_info.targets, extra_data_info_dict={}
+    )
+ 
+    for _ in range(num_checks):
+        systems_rot, targets_rot = [], []
+        for system_, tm_ in zip(SYSTEMS, tensor_maps, strict=False):
+            sys_r, tgts_r, _ = rotational_augmenter.apply_random_augmentations(
+                [system_],
+                {target_name: tm_},
+                extra_data={},
+            )
+            systems_rot.append(sys_r[0])
+            targets_rot.append(tgts_r[target_name])
+ 
+        dataset_rot = Dataset.from_dict(
+            {"system": systems_rot, target_name: targets_rot}
+        )
+        scaler_rot = Scaler(hypers={}, dataset_info=dataset_info).to(torch.float64)
+        scaler_rot.train_model(
+            dataset_rot, additive_models=[], batch_size=1, is_distributed=False
+        )
+ 
+        scales = scaler.model.scales[target_name]
+        scales_rot = scaler_rot.model.scales[target_name]
+        for key in scales.keys:
+            block = scales.block(key)
+            block_rot = scales_rot.block(key)
+            torch.testing.assert_close(
+                block.values, block_rot.values, rtol=1e-5, atol=1e-5
+            )
 
 @pytest.mark.parametrize("missing_type", [False, True])
 def test_scaler_spherical_atomic_basis_rank_2(missing_type):
+    """Test the calculation of scaling weights for a per-atom rank-2 atomic-basis
+    spherical target (keys: o3_lambda_1, o3_sigma_1, o3_lambda_2, o3_sigma_2,
+    atom_type) is correct.
     """
-    Test the calculation of scales for a spherical per-atom rank 2 atomic basis target
-    (keys: o3_lambda_1, o3_sigma_1, o3_lambda_2, o3_sigma_2, atom_type) is correct.
-    """
-    # TODO!
-    raise NotImplementedError
+    target_name = "spherical_atomic_basis_rank2"
+ 
+    key_names = ["o3_lambda_1", "o3_sigma_1", "o3_lambda_2", "o3_sigma_2", "atom_type"]
+    prop = Labels(names=["_"], values=torch.tensor([[0]]))
+    mu1_1 = Labels(names=["o3_mu_1"], values=torch.tensor([[0]]))
+    mu2_1 = Labels(names=["o3_mu_2"], values=torch.tensor([[0]]))
+    mu1_3 = Labels(names=["o3_mu_1"], values=torch.arange(-1, 2).reshape(-1, 1))
+    mu2_3 = Labels(names=["o3_mu_2"], values=torch.arange(-1, 2).reshape(-1, 1))
+ 
+    sys0_vals_00_O = torch.tensor([[[[1.0]]]], dtype=torch.float64)  # (1,1,1,1)
+    sys0_vals_11_O = torch.tensor(
+        [1.5, 0.8, 3.2, 0.4, 2.1, 0.9, 1.2, 3.0, 0.6], dtype=torch.float64
+    ).reshape(1, 3, 3, 1)
+    samples_sys0 = Labels(names=["system", "atom"], values=torch.tensor([[0, 0]]))
+ 
+    tensor_map_1 = TensorMap(
+        keys=Labels(
+            names=key_names,
+            values=torch.tensor([[0, 1, 0, 1, 8], [1, 1, 1, 1, 8]]),
+        ),
+        blocks=[
+            TensorBlock(
+                values=sys0_vals_00_O,
+                samples=samples_sys0,
+                components=[mu1_1, mu2_1],
+                properties=prop,
+            ),
+            TensorBlock(
+                values=sys0_vals_11_O,
+                samples=samples_sys0,
+                components=[mu1_3, mu2_3],
+                properties=prop,
+            ),
+        ],
+    )
+ 
+    sys1_vals_00_H = torch.tensor([1.0, 1.5], dtype=torch.float64).reshape(2, 1, 1, 1)
+    sys1_vals_00_O = torch.tensor([[[[2.0]]]], dtype=torch.float64)
+    sys1_vals_11_O = torch.tensor(
+        [0.2, 3.0, 1.1, 2.5, 0.7, 1.8, 0.3, 2.2, 1.0], dtype=torch.float64
+    ).reshape(1, 3, 3, 1)
+ 
+    tensor_map_2 = TensorMap(
+        keys=Labels(
+            names=key_names,
+            values=torch.tensor([[0, 1, 0, 1, 1], [0, 1, 0, 1, 8], [1, 1, 1, 1, 8]]),
+        ),
+        blocks=[
+            TensorBlock(
+                values=sys1_vals_00_H,
+                samples=Labels(
+                    names=["system", "atom"],
+                    values=torch.tensor([[1, 0], [1, 1]]),
+                ),
+                components=[mu1_1, mu2_1],
+                properties=prop,
+            ),
+            TensorBlock(
+                values=sys1_vals_00_O,
+                samples=Labels(
+                    names=["system", "atom"], values=torch.tensor([[1, 2]])
+                ),
+                components=[mu1_1, mu2_1],
+                properties=prop,
+            ),
+            TensorBlock(
+                values=sys1_vals_11_O,
+                samples=Labels(
+                    names=["system", "atom"], values=torch.tensor([[1, 2]])
+                ),
+                components=[mu1_3, mu2_3],
+                properties=prop,
+            ),
+        ],
+    )
+ 
+    dataset = Dataset.from_dict(
+        {"system": SYSTEMS, target_name: [tensor_map_1, tensor_map_2]}
+    )
+ 
+    atomic_types = [1, 8]
+    irreps = {
+        1: [{"o3_lambda": 0, "o3_sigma": 1}],
+        8: [
+            {"o3_lambda": 0, "o3_sigma": 1},
+            {"o3_lambda": 1, "o3_sigma": 1},
+        ],
+    }
+    if missing_type:
+        atomic_types.append(9)
+        irreps[9] = [{"o3_lambda": 0, "o3_sigma": 1}]
+ 
+    dataset_info = DatasetInfo(
+        length_unit="angstrom",
+        atomic_types=atomic_types,
+        targets={
+            target_name: get_generic_target_info(
+                target_name,
+                {
+                    "quantity": "",
+                    "unit": "",
+                    "type": {
+                        "spherical": {
+                            "product": "cartesian",
+                            "irreps": irreps,
+                        }
+                    },
+                    "per_atom": True,
+                    "num_subtargets": 1,
+                },
+            )
+        },
+    )
+ 
+    scaler = Scaler(hypers={}, dataset_info=dataset_info).to(torch.float64)
+    scaler.train_model(
+        dataset, additive_models=[], batch_size=1, is_distributed=False
+    )
+ 
+    o_11_all = torch.cat(
+        [sys0_vals_11_O.flatten(), sys1_vals_11_O.flatten()]
+    )
+    expected_scales = {
+        (0, 0, 1, 1, 1): (torch.tensor([1.0, 1.5]) ** 2).mean().sqrt(),
+        (0, 0, 1, 1, 8): (torch.tensor([1.0, 2.0]) ** 2).mean().sqrt(),
+        (1, 1, 1, 1, 8): (o_11_all ** 2).mean().sqrt(),
+        (0, 0, 1, 1, 9): torch.tensor(1.0, dtype=torch.float64),
+    }
+ 
+    scales_tm = scaler.model.scales[target_name]
+    for key in scales_tm.keys:
+        block = scales_tm.block(key)
+        atom_type = key["atom_type"]
+        atom_type_index = atomic_types.index(atom_type)
 
+        key_tuple = (
+            key["o3_lambda_1"],
+            key["o3_lambda_2"],
+            key["o3_sigma_1"],
+            key["o3_sigma_2"],
+            atom_type,
+        )
+
+        if key_tuple not in expected_scales:
+            continue
+
+        computed_scale = block.values[atom_type_index, 0]
+        expected_scale = expected_scales[key_tuple].to(torch.float64)
+        torch.testing.assert_close(computed_scale, expected_scale)
+
+        other_scales = block.values[
+            torch.arange(len(atomic_types)) != atom_type_index, 0
+        ]
+        torch.testing.assert_close(other_scales, torch.ones_like(other_scales))
 
 @pytest.mark.parametrize("missing_type", [False, True])
 def test_scaler_spherical_atomic_basis_rank_2_rotation_invariance(missing_type):
-    """
-    Test the calculation of scales for a spherical per-atom rank 2 atomic basis target
-    (keys: o3_lambda_1, o3_sigma_1, o3_lambda_2, o3_sigma_2, atom_type) is invariant
-    under fitting on a rotated version of the dataset.
-    """
-    # TODO!
-    raise NotImplementedError
+    """Test that scaling weights for a per-atom rank-2 atomic-basis spherical target
+    are invariant under fitting on a randomly rotated version of the dataset.
 
+    The scaler computes RMS norms which are rotation-invariant by construction.
+    We verify this by training on randomly rotated copies of the systems while
+    keeping the target values the same (since orbital coefficients in a fixed
+    basis are not affected by rotating the molecule).
+    """
+    target_name = "spherical_atomic_basis_rank2"
+    num_checks = 5
 
+    key_names = ["o3_lambda_1", "o3_sigma_1", "o3_lambda_2", "o3_sigma_2", "atom_type"]
+    prop = Labels(names=["_"], values=torch.tensor([[0]]))
+    mu1_1 = Labels(names=["o3_mu_1"], values=torch.tensor([[0]]))
+    mu2_1 = Labels(names=["o3_mu_2"], values=torch.tensor([[0]]))
+    mu1_3 = Labels(names=["o3_mu_1"], values=torch.arange(-1, 2).reshape(-1, 1))
+    mu2_3 = Labels(names=["o3_mu_2"], values=torch.arange(-1, 2).reshape(-1, 1))
+
+    sys0_vals_00_O = torch.tensor([[[[1.0]]]], dtype=torch.float64)
+    sys0_vals_11_O = torch.tensor(
+        [1.5, 0.8, 3.2, 0.4, 2.1, 0.9, 1.2, 3.0, 0.6], dtype=torch.float64
+    ).reshape(1, 3, 3, 1)
+    samples_sys0 = Labels(names=["system", "atom"], values=torch.tensor([[0, 0]]))
+
+    tensor_map_1 = TensorMap(
+        keys=Labels(
+            names=key_names,
+            values=torch.tensor([[0, 1, 0, 1, 8], [1, 1, 1, 1, 8]]),
+        ),
+        blocks=[
+            TensorBlock(
+                values=sys0_vals_00_O,
+                samples=samples_sys0,
+                components=[mu1_1, mu2_1],
+                properties=prop,
+            ),
+            TensorBlock(
+                values=sys0_vals_11_O,
+                samples=samples_sys0,
+                components=[mu1_3, mu2_3],
+                properties=prop,
+            ),
+        ],
+    )
+
+    sys1_vals_00_H = torch.tensor([1.0, 1.5], dtype=torch.float64).reshape(2, 1, 1, 1)
+    sys1_vals_00_O = torch.tensor([[[[2.0]]]], dtype=torch.float64)
+    sys1_vals_11_O = torch.tensor(
+        [0.2, 3.0, 1.1, 2.5, 0.7, 1.8, 0.3, 2.2, 1.0], dtype=torch.float64
+    ).reshape(1, 3, 3, 1)
+
+    tensor_map_2 = TensorMap(
+        keys=Labels(
+            names=key_names,
+            values=torch.tensor([[0, 1, 0, 1, 1], [0, 1, 0, 1, 8], [1, 1, 1, 1, 8]]),
+        ),
+        blocks=[
+            TensorBlock(
+                values=sys1_vals_00_H,
+                samples=Labels(
+                    names=["system", "atom"],
+                    values=torch.tensor([[1, 0], [1, 1]]),
+                ),
+                components=[mu1_1, mu2_1],
+                properties=prop,
+            ),
+            TensorBlock(
+                values=sys1_vals_00_O,
+                samples=Labels(
+                    names=["system", "atom"], values=torch.tensor([[1, 2]])
+                ),
+                components=[mu1_1, mu2_1],
+                properties=prop,
+            ),
+            TensorBlock(
+                values=sys1_vals_11_O,
+                samples=Labels(
+                    names=["system", "atom"], values=torch.tensor([[1, 2]])
+                ),
+                components=[mu1_3, mu2_3],
+                properties=prop,
+            ),
+        ],
+    )
+
+    tensor_maps = [tensor_map_1, tensor_map_2]
+
+    atomic_types = [1, 8]
+    irreps = {
+        1: [{"o3_lambda": 0, "o3_sigma": 1}],
+        8: [
+            {"o3_lambda": 0, "o3_sigma": 1},
+            {"o3_lambda": 1, "o3_sigma": 1},
+        ],
+    }
+    if missing_type:
+        atomic_types.append(9)
+        irreps[9] = [{"o3_lambda": 0, "o3_sigma": 1}]
+
+    dataset_info = DatasetInfo(
+        length_unit="angstrom",
+        atomic_types=atomic_types,
+        targets={
+            target_name: get_generic_target_info(
+                target_name,
+                {
+                    "quantity": "",
+                    "unit": "",
+                    "type": {
+                        "spherical": {
+                            "product": "cartesian",
+                            "irreps": irreps,
+                        }
+                    },
+                    "per_atom": True,
+                    "num_subtargets": 1,
+                },
+            )
+        },
+    )
+
+    dataset = Dataset.from_dict({"system": SYSTEMS, target_name: tensor_maps})
+    scaler = Scaler(hypers={}, dataset_info=dataset_info).to(torch.float64)
+    scaler.train_model(
+        dataset, additive_models=[], batch_size=1, is_distributed=False
+    )
+
+    for _ in range(num_checks):
+        # Rotate only the atomic positions; keep target values unchanged since
+        # the scaler computes RMS norms which are independent of orientation.
+        R = torch.linalg.qr(torch.randn(3, 3, dtype=torch.float64))[0]
+        systems_rot = [
+            System(
+                positions=system_.positions @ R.T,
+                types=system_.types,
+                cell=system_.cell,
+                pbc=system_.pbc,
+            )
+            for system_ in SYSTEMS
+        ]
+
+        dataset_rot = Dataset.from_dict(
+            {"system": systems_rot, target_name: tensor_maps}
+        )
+        scaler_rot = Scaler(hypers={}, dataset_info=dataset_info).to(torch.float64)
+        scaler_rot.train_model(
+            dataset_rot, additive_models=[], batch_size=1, is_distributed=False
+        )
+
+        scales = scaler.model.scales[target_name]
+        scales_rot = scaler_rot.model.scales[target_name]
+        for key in scales.keys:
+            block = scales.block(key)
+            block_rot = scales_rot.block(key)
+            torch.testing.assert_close(
+                block.values, block_rot.values, rtol=1e-5, atol=1e-5
+            )
+ 
 def test_scaler_torchscript(tmpdir):
     """Test the torchscripting, saving and loading of a scaler model."""
 


### PR DESCRIPTION
This is the second part of #1098. It adds the possibility that spherical targets are rank 2.

The changes are quite straightforward and limited:
- Spherical targets now accept `product: "cartesian"`, and the code in `target_info.py` handles creating the rank 2 target layouts. The naming for these follows the convention for cartesian targets of rank 2: components are named `o3_mu_1`, `o3_mu_2`. The keys of the blocks are `o3_lambda_1`, `o3_lambda_2`, `o3_sigma_1`, `o3_sigma_2`.
- Make the composition model deal with these kind of targets by simply fitting the trace of these blocks.
- Make the rotational augmenter support them by transforming on both sides.
- The rest are just tests, which represent the majority of added lines in this PR.

No changes done to models. PET supports these targets out-of-the-box, all other models don't support them.

To be merged after #1107 


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1121.org.readthedocs.build/en/1121/

<!-- readthedocs-preview metatrain end -->