### PR TITLE
Speedup PET evaluation

### DIFF
--- a/src/metatrain/experimental/flashmd/modules/structures.py
+++ b/src/metatrain/experimental/flashmd/modules/structures.py
@@ -156,7 +156,7 @@ def systems_to_batch(
 
     # Convert to NEF (Node-Edge-Feature) format:
     nef_indices, nef_to_edges_neighbor, nef_mask = get_nef_indices(
-        centers, num_nodes, max_edges_per_node
+        centers, num_neighbors, max_edges_per_node
     )
 
     # Element indices
@@ -169,18 +169,13 @@ def systems_to_batch(
         element_indices_neighbors, nef_indices
     )
 
-    corresponding_edges = get_corresponding_edges(
-        torch.concatenate(
-            [centers.unsqueeze(-1), neighbors.unsqueeze(-1), cell_shifts],
-            dim=-1,
-        )
-    )
+    corresponding_edges = get_corresponding_edges(centers, neighbors, cell_shifts)
 
     # These are the two arrays we need for message passing with edge reversals,
     # if indexing happens in a two-dimensional way:
     # edges_ji = edges_ij[reversed_neighbor_list, neighbors_index]
     reversed_neighbor_list = compute_reversed_neighbor_list(
-        nef_indices, corresponding_edges, nef_mask
+        nef_indices, corresponding_edges, nef_to_edges_neighbor, nef_mask
     )
     neighbors_index = edge_array_to_nef(neighbors, nef_indices).to(torch.int64)
 
@@ -193,8 +188,9 @@ def systems_to_batch(
     # creates too many of the same index which slows down backward enormously.
     # (See see https://github.com/pytorch/pytorch/issues/41162)
     # We therefore replace the padded indices with a sequence of unique indices.
+    num_padded = reverse_neighbor_index.numel() - centers.shape[0]
     reverse_neighbor_index[~nef_mask] = torch.arange(
-        int(torch.sum(~nef_mask)), device=reverse_neighbor_index.device
+        num_padded, device=reverse_neighbor_index.device
     )
 
     return (

--- a/src/metatrain/pet/modules/nef.py
+++ b/src/metatrain/pet/modules/nef.py
@@ -13,13 +13,13 @@ edge arrays with shape (n_edges, ...) and NEF arrays with shape
 (n_nodes, n_edges_per_node, ...).
 """
 
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 import torch
 
 
 def get_nef_indices(
-    centers: torch.Tensor, n_nodes: int, n_edges_per_node: int
+    centers: torch.Tensor, num_neighbors: torch.Tensor, n_edges_per_node: int
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Computes tensors of indices useful to convert between edge
@@ -30,7 +30,10 @@ def get_nef_indices(
     :param centers: A 1D tensor of shape (n_edges,) containing the
         indices of the center nodes for each edge, with the center nodes
         being the "i" node in an "i -> j" edge.
-    :param n_nodes: The number of nodes in the graph.
+    :param num_neighbors: A 1D tensor of shape (n_nodes,) containing
+        the number of neighbors for each node. Typically obtained from
+        ``torch.bincount(centers, minlength=n_nodes)`` at the caller,
+        where it is already needed to size the NEF grid.
     :param n_edges_per_node: The maximum number of edges per node.
 
     :return: A tuple with three tensors (nef_indices, nef_to_edges_neighbor, nef_mask).
@@ -42,99 +45,88 @@ def get_nef_indices(
         nodes will have, in general, different number of edges.
     """
 
-    bincount = torch.bincount(centers, minlength=n_nodes)
+    n_nodes = num_neighbors.shape[0]
 
     arange = torch.arange(n_edges_per_node, device=centers.device)
-    arange_expanded = arange.view(1, -1).expand(n_nodes, -1)
-    nef_mask = arange_expanded < bincount.view(-1, 1)
+    nef_mask = arange.view(1, -1).expand(n_nodes, -1) < num_neighbors.view(-1, 1)
 
     argsort = torch.argsort(centers, stable=True)
 
+    n_edges = centers.shape[0]
+    sorted_centers = centers.index_select(0, argsort)
+    starts = torch.cumsum(num_neighbors, dim=0) - num_neighbors
+    position_within = torch.arange(
+        n_edges, device=centers.device
+    ) - starts.index_select(0, sorted_centers)
+
     nef_indices = torch.zeros(
-        (n_nodes, n_edges_per_node), dtype=torch.long, device=centers.device
+        n_nodes * n_edges_per_node, dtype=torch.long, device=centers.device
     )
-    nef_indices[nef_mask] = argsort
+    flat_target = sorted_centers * n_edges_per_node + position_within
+    nef_indices[flat_target] = argsort
+    nef_indices = nef_indices.view(n_nodes, n_edges_per_node)
 
     nef_to_edges_neighbor = torch.empty_like(centers, dtype=torch.long)
-    nef_to_edges_neighbor[argsort] = arange_expanded[nef_mask]
+    nef_to_edges_neighbor[argsort] = position_within
 
     return nef_indices, nef_to_edges_neighbor, nef_mask
 
 
-def get_corresponding_edges(array: torch.Tensor) -> torch.Tensor:
+def get_corresponding_edges(
+    centers: torch.Tensor,
+    neighbors: torch.Tensor,
+    cell_shifts: torch.Tensor,
+) -> torch.Tensor:
     """
     Computes the corresponding edge (i.e., the edge that goes in the
     opposite direction) for each edge in the array; this is useful
     in the message-passing operation.
 
-    :param array: A 2D tensor of shape (n_edges, 5). For each i -> j
-        edge, the first column contains the index of the center node i,
-        the second column contains the index of the neighbor node j,
-        and the last three columns contain the cell shifts along x, y, and z
-        directions, respectively.
+    :param centers: A 1D tensor of shape (n_edges,) containing, for each
+        ``i -> j`` edge, the index of the center node ``i``.
+    :param neighbors: A 1D tensor of shape (n_edges,) containing, for each
+        ``i -> j`` edge, the index of the neighbor node ``j``.
+    :param cell_shifts: A 2D tensor of shape (n_edges, 3) with the cell shifts
+        along x, y, z for each edge.
 
     :return: A 1D tensor of shape (n_edges,) containing, for each edge,
         the index of the corresponding edge (i.e., the edge that goes
-        in the opposite direction). If the input array is empty, an
-        empty tensor is returned.
+        in the opposite direction). If the input is empty, an empty
+        tensor is returned.
     """
 
-    if array.numel() == 0:
-        return torch.empty((0,), dtype=array.dtype, device=array.device)
+    if centers.numel() == 0:
+        return torch.empty((0,), dtype=torch.int64, device=centers.device)
 
-    array = array.to(torch.int64)  # avoid overflow
+    centers = centers.to(torch.int64)
+    neighbors = neighbors.to(torch.int64)
+    cell_shifts = cell_shifts.to(torch.int64)
 
-    centers = array[:, 0]
-    neighbors = array[:, 1]
-    cell_shifts_x = array[:, 2]
-    cell_shifts_y = array[:, 3]
-    cell_shifts_z = array[:, 4]
+    min_per_axis = cell_shifts.amin(dim=0)
+    cs_norm = cell_shifts - min_per_axis
+    neg_cs_norm = -cell_shifts - min_per_axis
 
-    # will be useful later
-    negative_cell_shifts_x = -cell_shifts_x
-    negative_cell_shifts_y = -cell_shifts_y
-    negative_cell_shifts_z = -cell_shifts_z
+    max_per_axis = cs_norm.amax(dim=0) + 1
+    max_centers_neighbors = centers.amax() + 1
 
-    # create a unique identifier for each edge
-    # first, we shift the cell_shifts so that the minimum value is 0
-    min_cell_shift_x = cell_shifts_x.min()
-    cell_shifts_x = cell_shifts_x - min_cell_shift_x
-    negative_cell_shifts_x = negative_cell_shifts_x - min_cell_shift_x
-
-    min_cell_shift_y = cell_shifts_y.min()
-    cell_shifts_y = cell_shifts_y - min_cell_shift_y
-    negative_cell_shifts_y = negative_cell_shifts_y - min_cell_shift_y
-
-    min_cell_shift_z = cell_shifts_z.min()
-    cell_shifts_z = cell_shifts_z - min_cell_shift_z
-    negative_cell_shifts_z = negative_cell_shifts_z - min_cell_shift_z
-
-    max_centers_neigbors = centers.max() + 1  # same as neighbors.max() + 1
-    max_shift_x = cell_shifts_x.max() + 1
-    max_shift_y = cell_shifts_y.max() + 1
-    max_shift_z = cell_shifts_z.max() + 1
-
-    size_1 = max_shift_z
-    size_2 = max_shift_y * size_1
-    size_3 = max_shift_x * size_2
-    size_4 = max_centers_neigbors * size_3
+    size_z = max_per_axis[2]
+    size_yz = max_per_axis[1] * size_z
+    size_xyz = max_per_axis[0] * size_yz
+    size_total = max_centers_neighbors * size_xyz
 
     unique_id = (
-        centers * size_4
-        + neighbors * size_3
-        + cell_shifts_x * size_2
-        + cell_shifts_y * size_1
-        + cell_shifts_z
+        centers * size_total
+        + neighbors * size_xyz
+        + cs_norm[:, 0] * size_yz
+        + cs_norm[:, 1] * size_z
+        + cs_norm[:, 2]
     )
-
-    # the inverse is the same, but centers and neighbors are swapped
-    # and we use the negative values of the cell_shifts
     unique_id_inverse = (
-        neighbors * size_4
-        + centers * size_3
-        + negative_cell_shifts_x * size_2
-        + negative_cell_shifts_y * size_1
-        + negative_cell_shifts_z
+        neighbors * size_total
+        + centers * size_xyz
+        + neg_cs_norm[:, 0] * size_yz
+        + neg_cs_norm[:, 1] * size_z
+        + neg_cs_norm[:, 2]
     )
 
     unique_id_argsort = unique_id.argsort()
@@ -143,7 +135,7 @@ def get_corresponding_edges(array: torch.Tensor) -> torch.Tensor:
     corresponding_edges = torch.empty_like(centers)
     corresponding_edges[unique_id_argsort] = unique_id_inverse_argsort
 
-    return corresponding_edges.to(array.dtype)
+    return corresponding_edges
 
 
 def edge_array_to_nef(
@@ -201,6 +193,7 @@ def nef_array_to_edges(
 def compute_reversed_neighbor_list(
     nef_indices: torch.Tensor,
     corresponding_edges: torch.Tensor,
+    nef_to_edges_neighbor: torch.Tensor,
     nef_mask: torch.Tensor,
 ) -> torch.Tensor:
     """
@@ -213,36 +206,18 @@ def compute_reversed_neighbor_list(
         as returned by the ``get_nef_indices`` function.
     :param corresponding_edges: The indices of the corresponding edges,
         as returned by the ``get_corresponding_edges`` function.
+    :param nef_to_edges_neighbor: Per-edge within-row position in the NEF
+        grid, as returned by the ``get_nef_indices`` function. Acts directly
+        as the ``edge_index -> position`` lookup that the previous
+        implementation built on the fly.
     :param nef_mask: A boolean mask of shape (n_nodes, n_edges_per_node),
         as returned by the ``get_nef_indices`` function.
     :return: A tensor of the same shape as ``nef_indices``,
         where each entry contains the position of the center
         atom in the neighborlist of the corresponding neighbor atom.
     """
-    num_atoms, max_num_neighbors = nef_indices.shape
-
-    flat_edge_indices = nef_indices.reshape(-1)
-    flat_positions = torch.arange(max_num_neighbors, device=nef_indices.device).repeat(
-        num_atoms
-    )
-    flat_mask = nef_mask.reshape(-1)
-
-    if flat_edge_indices.numel() == 0:
-        max_edge_index = 0
-    else:
-        max_edge_index = int(flat_edge_indices.max().item()) + 1
-    size: List[int] = [max_edge_index]
-
-    edge_index_to_position = torch.full(
-        size,
-        0,
-        dtype=torch.long,
-        device=nef_indices.device,
-    )
-    edge_index_to_position[flat_edge_indices[flat_mask]] = flat_positions[flat_mask]
-
     reverse_edge_idx = corresponding_edges[nef_indices]
-    reversed_neighbor_list = edge_index_to_position[reverse_edge_idx]
+    reversed_neighbor_list = nef_to_edges_neighbor[reverse_edge_idx]
     reversed_neighbor_list = reversed_neighbor_list.masked_fill(~nef_mask, 0)
 
     return reversed_neighbor_list

--- a/src/metatrain/pet/modules/structures.py
+++ b/src/metatrain/pet/modules/structures.py
@@ -36,54 +36,64 @@ def concatenate_structures(
         species, cells, cell shifts, system indices, and sample labels.
     """
 
-    positions: List[torch.Tensor] = []
-    centers: List[torch.Tensor] = []
-    neighbors: List[torch.Tensor] = []
-    species: List[torch.Tensor] = []
-    cell_shifts: List[torch.Tensor] = []
-    cells: List[torch.Tensor] = []
-    system_indices: List[torch.Tensor] = []
-    atom_indices: List[torch.Tensor] = []
-    node_counter = 0
+    device = systems[0].positions.device
 
-    for i, system in enumerate(systems):
+    positions_list: List[torch.Tensor] = []
+    species_list: List[torch.Tensor] = []
+    cells_list: List[torch.Tensor] = []
+    nl_values_list: List[torch.Tensor] = []
+    sizes: List[int] = []
+    num_edges: List[int] = []
+    node_offsets_list: List[int] = []
+
+    node_counter = 0
+    for system in systems:
         assert len(system.known_neighbor_lists()) >= 1, "no neighbor list found"
         neighbor_list = system.get_neighbor_list(neighbor_list_options)
         nl_values = neighbor_list.samples.values
 
-        centers_values = nl_values[:, 0]
-        neighbors_values = nl_values[:, 1]
-        cell_shifts_values = nl_values[:, 2:]
+        positions_list.append(system.positions)
+        species_list.append(system.types)
+        cells_list.append(system.cell)
+        nl_values_list.append(nl_values)
 
         system_size = len(system)
-        positions.append(system.positions)
-        species.append(system.types)
-
-        centers.append(centers_values + node_counter)
-        neighbors.append(neighbors_values + node_counter)
-        cell_shifts.append(cell_shifts_values)
-
-        cells.append(system.cell)
-
+        node_offsets_list.append(node_counter)
+        sizes.append(system_size)
+        num_edges.append(nl_values.shape[0])
         node_counter += system_size
-        system_indices.append(
-            torch.full((system_size,), i, device=system.positions.device)
-        )
-        atom_indices.append(torch.arange(system_size, device=system.positions.device))
 
-    positions = torch.cat(positions)
-    centers = torch.cat(centers)
-    neighbors = torch.cat(neighbors)
-    species = torch.cat(species)
-    cells = torch.stack(cells)
-    cell_shifts = torch.cat(cell_shifts)
-    system_indices = torch.cat(system_indices)
-    atom_indices = torch.cat(atom_indices)
+    positions = torch.cat(positions_list)
+    species = torch.cat(species_list)
+    cells = torch.stack(cells_list)
+    nl_values = torch.cat(nl_values_list)
 
-    sample_values = torch.stack(
-        [system_indices, atom_indices],
-        dim=1,
+    centers = nl_values[:, 0]
+    neighbors = nl_values[:, 1]
+    cell_shifts = nl_values[:, 2:]
+
+    num_systems = len(systems)
+    total_edges = sum(num_edges)
+    sizes_tensor = torch.tensor(sizes, device=device, dtype=torch.long)
+    num_edges_tensor = torch.tensor(num_edges, device=device, dtype=torch.long)
+    node_offsets = torch.tensor(node_offsets_list, device=device, dtype=torch.long)
+
+    edge_offsets = torch.repeat_interleave(
+        node_offsets, num_edges_tensor, output_size=total_edges
+    ).to(dtype=centers.dtype)
+    centers = centers + edge_offsets
+    neighbors = neighbors + edge_offsets
+
+    system_indices = torch.repeat_interleave(
+        torch.arange(num_systems, device=device),
+        sizes_tensor,
+        output_size=node_counter,
     )
+    atom_indices = torch.arange(
+        node_counter, device=device, dtype=torch.long
+    ) - torch.repeat_interleave(node_offsets, sizes_tensor, output_size=node_counter)
+
+    sample_values = torch.stack([system_indices, atom_indices], dim=1)
     sample_labels = Labels(
         names=["system", "atom"],
         values=sample_values,
@@ -212,15 +222,13 @@ def systems_to_batch(
             # due to its corresponding edge indexing ij -> ji)
             pair_cutoffs = (atomic_cutoffs[centers] + atomic_cutoffs[neighbors]) / 2.0
         with torch.profiler.record_function("PET::adaptive_cutoff_masking"):
-            # Apply cutoff mask
-            cutoff_mask = edge_distances <= pair_cutoffs
-
-            pair_cutoffs = pair_cutoffs[cutoff_mask]
-            centers = centers[cutoff_mask]
-            neighbors = neighbors[cutoff_mask]
-            edge_vectors = edge_vectors[cutoff_mask]
-            cell_shifts = cell_shifts[cutoff_mask]
-            edge_distances = edge_distances[cutoff_mask]
+            keep = torch.nonzero(edge_distances <= pair_cutoffs).squeeze(-1)
+            pair_cutoffs = pair_cutoffs.index_select(0, keep)
+            centers = centers.index_select(0, keep)
+            neighbors = neighbors.index_select(0, keep)
+            edge_vectors = edge_vectors.index_select(0, keep)
+            cell_shifts = cell_shifts.index_select(0, keep)
+            edge_distances = edge_distances.index_select(0, keep)
     else:
         pair_cutoffs = options.cutoff * torch.ones(
             len(centers), device=positions.device, dtype=positions.dtype
@@ -249,8 +257,9 @@ def systems_to_batch(
         )
 
     # Convert to NEF (Node-Edge-Feature) format:
+    # Pass `num_neighbors` in so `get_nef_indices` doesn't re-run bincount.
     nef_indices, nef_to_edges_neighbor, nef_mask = get_nef_indices(
-        centers, num_nodes, max_edges_per_node
+        centers, num_neighbors, max_edges_per_node
     )
 
     # Element indices
@@ -265,18 +274,13 @@ def systems_to_batch(
     )
     cutoff_factors = edge_array_to_nef(cutoff_factors, nef_indices, nef_mask, 0.0)
 
-    corresponding_edges = get_corresponding_edges(
-        torch.concatenate(
-            [centers.unsqueeze(-1), neighbors.unsqueeze(-1), cell_shifts],
-            dim=-1,
-        )
-    )
+    corresponding_edges = get_corresponding_edges(centers, neighbors, cell_shifts)
 
     # These are the two arrays we need for message passing with edge reversals,
     # if indexing happens in a two-dimensional way:
     # edges_ji = edges_ij[reversed_neighbor_list, neighbors_index]
     reversed_neighbor_list = compute_reversed_neighbor_list(
-        nef_indices, corresponding_edges, nef_mask
+        nef_indices, corresponding_edges, nef_to_edges_neighbor, nef_mask
     )
     neighbors_index = edge_array_to_nef(neighbors, nef_indices).to(torch.int64)
 
@@ -289,8 +293,11 @@ def systems_to_batch(
     # creates too many of the same index which slows down backward enormously.
     # (See see https://github.com/pytorch/pytorch/issues/41162)
     # We therefore replace the padded indices with a sequence of unique indices.
+    # The count of padded slots equals total slots minus real edges — derive it
+    # from shapes to avoid a `torch.sum(...).item()` host sync every forward.
+    num_padded = reverse_neighbor_index.numel() - centers.shape[0]
     reverse_neighbor_index[~nef_mask] = torch.arange(
-        int(torch.sum(~nef_mask)), device=reverse_neighbor_index.device
+        num_padded, device=reverse_neighbor_index.device
     )
 
     return (


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

This PR targets certain parts of the PET forward pass. The list of changes and the overall gain in speed is listed below. 

## Summary

Reduces PET inference latency by 7-10% (wall time) and up to 23% (steady-state throughput) by cutting CPU kernel launches and eliminating GPU-CPU host synchronizations in the `systems_to_batch` preprocessing pipeline.

The model is launch-bound on GPU (H100): most time is spent in CPU-side dispatch, not GPU compute. These changes target `src/metatrain/pet/modules/` (`nef.py`, `structures.py`) and propagate the updated function signatures to FlashMD.

## Changes

### `structures.py` — `concatenate_structures`
Replaced per-system `torch.full` / `torch.arange` / offset-add in a Python loop with a single `repeat_interleave(output_size=...)` call that offsets all edges and builds system/atom indices in batch. The `output_size` parameter is critical — without it, `repeat_interleave` does a host sync to read the sum of repeats off the GPU.

### `structures.py` — adaptive cutoff masking
Six separate boolean-indexing operations (`x[bool_mask]`), each internally running its own `aten::nonzero` kernel, replaced with a single `torch.nonzero(...).squeeze(-1)` followed by six `index_select` calls that reuse the precomputed index.

### `nef.py` — `get_nef_indices`
- Accepts pre-computed `num_neighbors` tensor (from the caller's `bincount`) instead of re-running `bincount` internally.
- Replaced boolean-mask scatter (`nef_indices[nef_mask] = argsort`) with flat-index scatter via `cumsum` + direct index computation, eliminating a hidden `nonzero` kernel.

### `nef.py` — `get_corresponding_edges`
- Accepts `(centers, neighbors, cell_shifts)` as separate arguments, removing a `torch.concatenate` at the call site.
- Vectorized 6 separate `.min()` / `.max()` reduction kernels into 2 calls to `.amin(dim=0)` / `.amax(dim=0)`.

### `nef.py` — `compute_reversed_neighbor_list`
Accepts `nef_to_edges_neighbor` (already computed by `get_nef_indices`) as a direct edge-to-position lookup, replacing the previous approach that built a full-size lookup table via boolean-mask gather/scatter and a `.max().item()` host sync.

### `structures.py` — host sync elimination
Replaced `int(torch.sum(~nef_mask))` (GPU-to-CPU sync every forward pass) with `reverse_neighbor_index.numel() - centers.shape[0]` (pure shape arithmetic).

### FlashMD
Updated `experimental/flashmd/modules/structures.py` to match the new function signatures and applied the same host sync fix.

## Benchmark results

Benchmarked on H100 with `pet-mad-xs-v1.5.0` checkpoint, 20 warmup + 100 timed iterations.

### Per-iteration wall time (with per-iteration `cuda.synchronize`)

| Preset | Atoms | Systems | main (ms) | this PR (ms) | Speedup |
|---|---|---|---|---|---|
| c8 | 8 | 1 | 9.07 | 8.37 | **-7.7%** |
| c216 | 216 | 1 | 12.64 | 11.78 | **-6.8%** |
| cu-batch-32 | 128 | 32 | 46.47 | 41.86 | **-9.9%** |

### Steady-state throughput (single sync at end)

| Preset | main (ms/iter) | this PR (ms/iter) | Speedup |
|---|---|---|---|
| c8 | 9.07 | 8.34 | **-8.1%** |
| c216 | 15.24 | 11.75 | **-22.9%** |
| cu-batch-32 | 45.50 | 40.74 | **-10.5%** |

The throughput improvement on c216 (23%) is larger than the latency improvement (7%) because the eliminated host syncs were breaking GPU pipelining across iterations: mid-iteration `.item()` calls and implicit syncs from boolean indexing forced the CPU to wait for prior GPU work, preventing overlap between consecutive iterations.

### Per-stage breakdown (profiled iteration, CPU time)

| Stage | c8 | c216 | cu-batch-32 |
|---|---|---|---|
| `systems_to_batch` | -14.2% | -10.4% | **-42.0%** |
| `adaptive_cutoff_masking` | **-51.5%** | -15.1% | **-52.6%** |
| `_calculate_features` | -5.2% | -1.7% | -2.1% |
| `post-processing` | -2.9% | -4.1% | +0.3% |

# Contributor (creator of pull-request) checklist

 - ~~[ ] Tests updated (for new features and bugfixes)?~~
 - ~~[ ] Documentation updated (for new features)?~~
 - ~~[ ] Issue referenced (for PRs that solve an issue)?~~

# Maintainer/Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1122.org.readthedocs.build/en/1122/

<!-- readthedocs-preview metatrain end -->