### PR TITLE
Fix NCCL distributed initialization for CUDA trainers

### DIFF
--- a/src/metatrain/experimental/dpa3/trainer.py
+++ b/src/metatrain/experimental/dpa3/trainer.py
@@ -19,7 +19,7 @@ from metatrain.utils.data import (
 from metatrain.utils.distributed.distributed_data_parallel import (
     DistributedDataParallel,
 )
-from metatrain.utils.distributed.slurm import DistributedEnvironment
+from metatrain.utils.distributed.slurm import initialize_slurm_nccl_process_group
 from metatrain.utils.evaluate_model import evaluate_model
 from metatrain.utils.io import check_file_extension
 from metatrain.utils.logging import ROOT_LOGGER, MetricLogger
@@ -80,10 +80,9 @@ class Trainer(TrainerInterface[TrainerHypers]):
         is_distributed = self.hypers["distributed"]
 
         if is_distributed:
-            distr_env = DistributedEnvironment(self.hypers["distributed_port"])
-            torch.distributed.init_process_group(backend="nccl")
-            world_size = torch.distributed.get_world_size()
-            rank = torch.distributed.get_rank()
+            device, world_size, rank = initialize_slurm_nccl_process_group(
+                self.hypers["distributed_port"]
+            )
         else:
             rank = 0
 
@@ -94,10 +93,6 @@ class Trainer(TrainerInterface[TrainerHypers]):
                     " If you want to run distributed training with DPA3, please "
                     "set `device` to cuda."
                 )
-            # the calculation of the device number works both when GPUs on different
-            # processes are not visible to each other and when they are
-            device_number = distr_env.local_rank % torch.cuda.device_count()
-            device = torch.device("cuda", device_number)
         else:
             device = devices[
                 0

--- a/src/metatrain/experimental/flashmd/trainer.py
+++ b/src/metatrain/experimental/flashmd/trainer.py
@@ -25,7 +25,7 @@ from metatrain.utils.distributed.batch_utils import should_skip_batch
 from metatrain.utils.distributed.distributed_data_parallel import (
     DistributedDataParallel,
 )
-from metatrain.utils.distributed.slurm import DistributedEnvironment
+from metatrain.utils.distributed.slurm import initialize_slurm_nccl_process_group
 from metatrain.utils.evaluate_model import evaluate_model
 from metatrain.utils.io import check_file_extension
 from metatrain.utils.logging import ROOT_LOGGER, MetricLogger
@@ -134,10 +134,9 @@ class Trainer(TrainerInterface[TrainerHypers]):
         is_finetune = self.hypers["finetune"]["read_from"] is not None
 
         if is_distributed:
-            distr_env = DistributedEnvironment(self.hypers["distributed_port"])
-            torch.distributed.init_process_group(backend="nccl")
-            world_size = torch.distributed.get_world_size()
-            rank = torch.distributed.get_rank()
+            device, world_size, rank = initialize_slurm_nccl_process_group(
+                self.hypers["distributed_port"]
+            )
         else:
             rank = 0
 
@@ -148,10 +147,6 @@ class Trainer(TrainerInterface[TrainerHypers]):
                     " If you want to run distributed training with SOAP-BPNN, please "
                     "set `device` to cuda."
                 )
-            # the calculation of the device number works both when GPUs on different
-            # processes are not visible to each other and when they are
-            device_number = distr_env.local_rank % torch.cuda.device_count()
-            device = torch.device("cuda", device_number)
         else:
             device = devices[0]
             # only one device, as we don't support non-distributed multi-gpu for now

--- a/src/metatrain/experimental/flashmd_symplectic/trainer.py
+++ b/src/metatrain/experimental/flashmd_symplectic/trainer.py
@@ -24,7 +24,7 @@ from metatrain.utils.data import (
 from metatrain.utils.distributed.distributed_data_parallel import (
     DistributedDataParallel,
 )
-from metatrain.utils.distributed.slurm import DistributedEnvironment
+from metatrain.utils.distributed.slurm import initialize_slurm_nccl_process_group
 from metatrain.utils.evaluate_model import evaluate_model
 from metatrain.utils.io import check_file_extension
 from metatrain.utils.logging import ROOT_LOGGER, MetricLogger
@@ -130,10 +130,9 @@ class Trainer(TrainerInterface):
         is_finetune = "finetune" in self.hypers
 
         if is_distributed:
-            distr_env = DistributedEnvironment(self.hypers["distributed_port"])
-            torch.distributed.init_process_group(backend="nccl")
-            world_size = torch.distributed.get_world_size()
-            rank = torch.distributed.get_rank()
+            device, world_size, rank = initialize_slurm_nccl_process_group(
+                self.hypers["distributed_port"]
+            )
         else:
             rank = 0
 
@@ -144,10 +143,6 @@ class Trainer(TrainerInterface):
                     " If you want to run distributed training with SOAP-BPNN, please "
                     "set `device` to cuda."
                 )
-            # the calculation of the device number works both when GPUs on different
-            # processes are not visible to each other and when they are
-            device_number = distr_env.local_rank % torch.cuda.device_count()
-            device = torch.device("cuda", device_number)
         else:
             device = devices[
                 0

--- a/src/metatrain/experimental/mace/trainer.py
+++ b/src/metatrain/experimental/mace/trainer.py
@@ -29,7 +29,7 @@ from metatrain.utils.distributed.batch_utils import should_skip_batch
 from metatrain.utils.distributed.distributed_data_parallel import (
     DistributedDataParallel,
 )
-from metatrain.utils.distributed.slurm import DistributedEnvironment
+from metatrain.utils.distributed.slurm import initialize_slurm_nccl_process_group
 from metatrain.utils.evaluate_model import evaluate_model
 from metatrain.utils.io import check_file_extension
 from metatrain.utils.logging import ROOT_LOGGER, MetricLogger
@@ -170,12 +170,9 @@ class Trainer(TrainerInterface):
                 )
             # the calculation of the device number works both when GPUs on different
             # processes are not visible to each other and when they are
-            distr_env = DistributedEnvironment(self.hypers["distributed_port"])
-            device_number = distr_env.local_rank % torch.cuda.device_count()
-            device = torch.device("cuda", device_number)
-            torch.distributed.init_process_group(backend="nccl", device_id=device)
-            world_size = torch.distributed.get_world_size()
-            rank = torch.distributed.get_rank()
+            device, world_size, rank = initialize_slurm_nccl_process_group(
+                self.hypers["distributed_port"]
+            )
         else:
             rank = 0
             device = devices[0]

--- a/src/metatrain/experimental/phace/trainer.py
+++ b/src/metatrain/experimental/phace/trainer.py
@@ -26,7 +26,7 @@ from metatrain.utils.data import (
 from metatrain.utils.data.atomic_basis_helpers import (
     get_prepare_atomic_basis_targets_transform,
 )
-from metatrain.utils.distributed.slurm import DistributedEnvironment
+from metatrain.utils.distributed.slurm import initialize_slurm_nccl_process_group
 from metatrain.utils.io import check_file_extension
 from metatrain.utils.logging import ROOT_LOGGER, MetricLogger
 from metatrain.utils.loss import LossAggregator, LossSpecification
@@ -171,12 +171,9 @@ class Trainer(TrainerInterface[TrainerHypers]):
                 )
             # the calculation of the device number works both when GPUs on different
             # processes are not visible to each other and when they are
-            distr_env = DistributedEnvironment(self.hypers["distributed_port"])
-            device_number = distr_env.local_rank % torch.cuda.device_count()
-            device = torch.device("cuda", device_number)
-            torch.distributed.init_process_group(backend="nccl", device_id=device)
-            world_size = torch.distributed.get_world_size()
-            rank = torch.distributed.get_rank()
+            device, world_size, rank = initialize_slurm_nccl_process_group(
+                self.hypers["distributed_port"]
+            )
         else:
             rank = 0
             device = devices[0]

--- a/src/metatrain/llpr/trainer.py
+++ b/src/metatrain/llpr/trainer.py
@@ -23,7 +23,7 @@ from metatrain.utils.distributed.batch_utils import should_skip_batch
 from metatrain.utils.distributed.distributed_data_parallel import (
     DistributedDataParallel,
 )
-from metatrain.utils.distributed.slurm import DistributedEnvironment
+from metatrain.utils.distributed.slurm import initialize_slurm_nccl_process_group
 from metatrain.utils.evaluate_model import evaluate_model
 from metatrain.utils.io import check_file_extension, model_from_checkpoint
 from metatrain.utils.logging import ROOT_LOGGER, MetricLogger
@@ -126,12 +126,9 @@ class Trainer(TrainerInterface[TrainerHypers]):
                     "set `device` to cuda."
                 )
             # Initialize distributed environment for calibration
-            distr_env = DistributedEnvironment(self.hypers["distributed_port"])
-            device_number = distr_env.local_rank % torch.cuda.device_count()
-            device = torch.device("cuda", device_number)
-            torch.distributed.init_process_group(backend="nccl", device_id=device)
-            world_size = torch.distributed.get_world_size()
-            rank = torch.distributed.get_rank()
+            device, world_size, rank = initialize_slurm_nccl_process_group(
+                self.hypers["distributed_port"]
+            )
             logging.info(f"Initialized distributed training on {world_size} devices")
         else:
             device = devices[0]

--- a/src/metatrain/pet/trainer.py
+++ b/src/metatrain/pet/trainer.py
@@ -27,7 +27,7 @@ from metatrain.utils.distributed.batch_utils import should_skip_batch
 from metatrain.utils.distributed.distributed_data_parallel import (
     DistributedDataParallel,
 )
-from metatrain.utils.distributed.slurm import DistributedEnvironment
+from metatrain.utils.distributed.slurm import initialize_slurm_nccl_process_group
 from metatrain.utils.evaluate_model import evaluate_model
 from metatrain.utils.io import check_file_extension
 from metatrain.utils.logging import ROOT_LOGGER, MetricLogger
@@ -117,13 +117,9 @@ class Trainer(TrainerInterface[TrainerHypers]):
                 )
             # the calculation of the device number works both when GPUs on different
             # processes are not visible to each other and when they are
-            distr_env = DistributedEnvironment(self.hypers["distributed_port"])
-            device_number = distr_env.local_rank % torch.cuda.device_count()
-            device = torch.device("cuda", device_number)
-            torch.cuda.set_device(device)
-            torch.distributed.init_process_group(backend="nccl", device_id=device)
-            world_size = torch.distributed.get_world_size()
-            rank = torch.distributed.get_rank()
+            device, world_size, rank = initialize_slurm_nccl_process_group(
+                self.hypers["distributed_port"]
+            )
         else:
             rank = 0
             world_size = 1

--- a/src/metatrain/pet/trainer.py
+++ b/src/metatrain/pet/trainer.py
@@ -120,6 +120,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
             distr_env = DistributedEnvironment(self.hypers["distributed_port"])
             device_number = distr_env.local_rank % torch.cuda.device_count()
             device = torch.device("cuda", device_number)
+            torch.cuda.set_device(device)
             torch.distributed.init_process_group(backend="nccl", device_id=device)
             world_size = torch.distributed.get_world_size()
             rank = torch.distributed.get_rank()

--- a/src/metatrain/soap_bpnn/trainer.py
+++ b/src/metatrain/soap_bpnn/trainer.py
@@ -26,7 +26,7 @@ from metatrain.utils.distributed.batch_utils import should_skip_batch
 from metatrain.utils.distributed.distributed_data_parallel import (
     DistributedDataParallel,
 )
-from metatrain.utils.distributed.slurm import DistributedEnvironment
+from metatrain.utils.distributed.slurm import initialize_slurm_nccl_process_group
 from metatrain.utils.evaluate_model import evaluate_model
 from metatrain.utils.io import check_file_extension
 from metatrain.utils.logging import ROOT_LOGGER, MetricLogger
@@ -114,12 +114,9 @@ class Trainer(TrainerInterface[TrainerHypers]):
                 )
             # the calculation of the device number works both when GPUs on different
             # processes are not visible to each other and when they are
-            distr_env = DistributedEnvironment(self.hypers["distributed_port"])
-            device_number = distr_env.local_rank % torch.cuda.device_count()
-            device = torch.device("cuda", device_number)
-            torch.distributed.init_process_group(backend="nccl", device_id=device)
-            world_size = torch.distributed.get_world_size()
-            rank = torch.distributed.get_rank()
+            device, world_size, rank = initialize_slurm_nccl_process_group(
+                self.hypers["distributed_port"]
+            )
         else:
             rank = 0
             device = devices[0]

--- a/src/metatrain/utils/distributed/slurm.py
+++ b/src/metatrain/utils/distributed/slurm.py
@@ -2,6 +2,8 @@ import logging
 import os
 
 import hostlist
+import torch
+import torch.distributed
 
 
 def is_slurm() -> bool:
@@ -58,3 +60,26 @@ class DistributedEnvironment:
             f"WORLD_SIZE={os.environ['WORLD_SIZE']}, "
             f"RANK={os.environ['RANK']}, LOCAL_RANK={os.environ['LOCAL_RANK']}"
         )
+
+
+def initialize_slurm_nccl_process_group(port: int) -> tuple[torch.device, int, int]:
+    """
+    Initialize the default NCCL process group for a Slurm-launched run.
+
+    The device mapping follows the current metatrain convention: use the local rank
+    modulo the number of visible CUDA devices so the setup works both when ranks see
+    all GPUs on the node and when each rank only sees a single GPU.
+
+    :param port: The port to use for communication in the distributed environment.
+    :return: The local CUDA device, world size, and global rank.
+    """
+
+    distr_env = DistributedEnvironment(port)
+    device_number = distr_env.local_rank % torch.cuda.device_count()
+    device = torch.device("cuda", device_number)
+    torch.cuda.set_device(device)
+    torch.distributed.init_process_group(backend="nccl", device_id=device)
+    world_size = torch.distributed.get_world_size()
+    rank = torch.distributed.get_rank()
+
+    return device, world_size, rank

--- a/tests/utils/test_slurm.py
+++ b/tests/utils/test_slurm.py
@@ -1,0 +1,80 @@
+import torch
+
+from metatrain.utils.distributed.slurm import initialize_slurm_nccl_process_group
+
+
+def test_initialize_slurm_nccl_process_group_single_visible_gpu(monkeypatch):
+    monkeypatch.setenv("SLURM_JOB_ID", "123")
+    monkeypatch.setenv("SLURM_JOB_NODELIST", "node[01-02]")
+    monkeypatch.setenv("SLURM_NTASKS", "4")
+    monkeypatch.setenv("SLURM_PROCID", "3")
+    monkeypatch.setenv("SLURM_LOCALID", "3")
+
+    monkeypatch.setattr(
+        "metatrain.utils.distributed.slurm.hostlist.expand_hostlist",
+        lambda nodelist: ["node01", "node02"],
+    )
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+
+    calls = []
+
+    def fake_set_device(device):
+        calls.append(("set_device", device))
+
+    def fake_init_process_group(*, backend, device_id):
+        calls.append(("init_process_group", backend, device_id))
+
+    monkeypatch.setattr(torch.cuda, "set_device", fake_set_device)
+    monkeypatch.setattr(
+        torch.distributed, "init_process_group", fake_init_process_group
+    )
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 4)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 3)
+
+    device, world_size, rank = initialize_slurm_nccl_process_group(39591)
+
+    assert device == torch.device("cuda", 0)
+    assert world_size == 4
+    assert rank == 3
+    assert calls == [
+        ("set_device", torch.device("cuda", 0)),
+        ("init_process_group", "nccl", torch.device("cuda", 0)),
+    ]
+
+
+def test_initialize_slurm_nccl_process_group_multiple_visible_gpus(monkeypatch):
+    monkeypatch.setenv("SLURM_JOB_ID", "456")
+    monkeypatch.setenv("SLURM_JOB_NODELIST", "node[03-04]")
+    monkeypatch.setenv("SLURM_NTASKS", "8")
+    monkeypatch.setenv("SLURM_PROCID", "2")
+    monkeypatch.setenv("SLURM_LOCALID", "2")
+
+    monkeypatch.setattr(
+        "metatrain.utils.distributed.slurm.hostlist.expand_hostlist",
+        lambda nodelist: ["node03", "node04"],
+    )
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 4)
+
+    set_device_calls = []
+    init_calls = []
+
+    def fake_set_device(device):
+        set_device_calls.append(device)
+
+    def fake_init_process_group(*, backend, device_id):
+        init_calls.append((backend, device_id))
+
+    monkeypatch.setattr(torch.cuda, "set_device", fake_set_device)
+    monkeypatch.setattr(
+        torch.distributed, "init_process_group", fake_init_process_group
+    )
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 8)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 2)
+
+    device, world_size, rank = initialize_slurm_nccl_process_group(39591)
+
+    assert device == torch.device("cuda", 2)
+    assert world_size == 8
+    assert rank == 2
+    assert set_device_calls == [torch.device("cuda", 2)]
+    assert init_calls == [("nccl", torch.device("cuda", 2))]


### PR DESCRIPTION
Fix NCCL distributed initialization for CUDA training on clusters where each rank can see multiple GPUs. 

PyTorch object collectives used during metric finalization rely on the current CUDA device, so the process-local device must be set before init_process_group(). 

This PR centralizes the Slurm/NCCL setup in a small shared helper, updates all distributed CUDA trainers to use it, preserves the existing rank-to-device mapping, and adds unit tests covering both single-visible-GPU and multi-visible-GPU configurations.


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - ~~[ ] Documentation updated (for new features)?~~
 - ~~[ ] Issue referenced (for PRs that solve an issue)?~~

# Maintainer/Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1125.org.readthedocs.build/en/1125/

<!-- readthedocs-preview metatrain end -->