### PR TITLE
replace removed labels.view() with column()

### DIFF
--- a/src/metatrain/experimental/mace/utils/structures.py
+++ b/src/metatrain/experimental/mace/utils/structures.py
@@ -39,18 +39,25 @@ def create_batch(
         # TODO: make this faster?
         atom_types.append(atomic_types_to_species_index[system.types])
 
-        shifts = neighbors.samples.view(
-            ["cell_shift_a", "cell_shift_b", "cell_shift_c"]
-        ).values
-
+        shifts = torch.stack(
+            [
+                neighbors.samples.column("cell_shift_a"),
+                neighbors.samples.column("cell_shift_b"),
+                neighbors.samples.column("cell_shift_c"),
+            ],
+            dim=-1,
+        )
         unit_shifts.append(shifts)
         cell_shifts.append(shifts.to(dtype) @ system.cell)
-        edge_index.append(
-            neighbors.samples.view(["first_atom", "second_atom"]).values.T.to(
-                torch.int64
-            )
-            + start_index
-        )
+
+        neightbor_atoms = torch.stack(
+            [
+                neighbors.samples.column("first_atom"),
+                neighbors.samples.column("second_atom"),
+            ],
+            dim=0,
+        ).to(torch.int64)
+        edge_index.append(neightbor_atoms + start_index)
 
         n_atoms = len(system)
         batch.append(torch.full((n_atoms,), system_i))

--- a/src/metatrain/utils/long_range.py
+++ b/src/metatrain/utils/long_range.py
@@ -132,9 +132,13 @@ class LongRangeFeaturizer(torch.nn.Module):
             last_len_nodes += len(system)
 
             neighbor_list = system.get_neighbor_list(self.neighbor_list_options)
-            neighbor_indices_system = neighbor_list.samples.view(
-                ["first_atom", "second_atom"]
-            ).values
+            neighbor_indices_system = torch.stack(
+                [
+                    neighbor_list.samples.column("first_atom"),
+                    neighbor_list.samples.column("second_atom"),
+                ],
+                dim=-1,
+            )
 
             neighbor_distances_system = neighbor_distances[
                 last_len_edges : last_len_edges + len(neighbor_indices_system)


### PR DESCRIPTION
`Labels.view()` was removed in metatensor `main`, currently metatrain pins `metatensor-torch <0.9` so tests still pass but the next metatensor release would break it

see https://github.com/metatensor/metatrain/pull/1126

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1127.org.readthedocs.build/en/1127/

<!-- readthedocs-preview metatrain end -->