### PR TITLE
compatibility follow up with metatensor 0.9.0rc6 + metatomic 0.1.12rc2 + featomic 0.6.6

### DIFF
--- a/src/metatrain/experimental/flashmd/model.py
+++ b/src/metatrain/experimental/flashmd/model.py
@@ -588,7 +588,7 @@ class FlashMD(ModelInterface[ModelHypers]):
                                     )
                                 )
                             else:
-                                output_blocks.append(b)
+                                output_blocks.append(b.copy())
                         return_dict[name] = TensorMap(
                             return_dict[name].keys, output_blocks
                         )

--- a/src/metatrain/experimental/flashmd_symplectic/model.py
+++ b/src/metatrain/experimental/flashmd_symplectic/model.py
@@ -643,7 +643,7 @@ class FlashMDSymplectic(ModelInterface):
                                     )
                                 )
                             else:
-                                output_blocks.append(b)
+                                output_blocks.append(b.copy())
                         return_dict[name] = TensorMap(
                             return_dict[name].keys, output_blocks
                         )

--- a/src/metatrain/experimental/mace/model.py
+++ b/src/metatrain/experimental/mace/model.py
@@ -528,7 +528,7 @@ class MetaMACE(ModelInterface[ModelHypers]):
                             )
                         )
                     else:
-                        output_blocks.append(b)
+                        output_blocks.append(b.copy())
                 values[name] = TensorMap(values[name].keys, output_blocks)
 
     def supported_outputs(self) -> Dict[str, ModelOutput]:

--- a/src/metatrain/experimental/phace/model.py
+++ b/src/metatrain/experimental/phace/model.py
@@ -513,7 +513,7 @@ class PhACE(ModelInterface[ModelHypers]):
                                 )
                             )
                         else:
-                            output_blocks.append(b)
+                            output_blocks.append(b.copy())
                     return_dict[name] = TensorMap(return_dict[name].keys, output_blocks)
 
             # For atomic basis targets, sparsify to create blocks with "atom_type"

--- a/src/metatrain/gap/model.py
+++ b/src/metatrain/gap/model.py
@@ -243,9 +243,17 @@ class GAP(ModelInterface[ModelHypers]):
         for idx_key in range(len(self._species_labels)):
             key = self._species_labels.entry(idx_key)
             if soap_features.keys.position(key) is not None:
-                new_blocks.append(soap_features.block(key))
+                block = soap_features.block(key)
+                new_blocks.append(
+                    TensorBlock(
+                        values=block.values,
+                        samples=block.samples,
+                        components=block.components,
+                        properties=block.properties,
+                    )
+                )
             else:
-                new_blocks.append(dummyblock)
+                new_blocks.append(dummyblock.copy())
         soap_features = TensorMap(keys=self._species_labels, blocks=new_blocks)
         soap_features = soap_features.keys_to_samples("center_type")
         # here, we move to properties to use metatensor operations to aggregate
@@ -254,7 +262,18 @@ class GAP(ModelInterface[ModelHypers]):
         soap_features = soap_features.keys_to_properties(
             ["neighbor_1_type", "neighbor_2_type"]
         )
-        soap_features = TensorMap(self._keys, soap_features.blocks())
+        soap_features = TensorMap(
+            self._keys,
+            [
+                TensorBlock(
+                    values=block.values,
+                    samples=block.samples,
+                    components=block.components,
+                    properties=block.properties,
+                )
+                for block in soap_features.blocks()
+            ],
+        )
         output_key = list(outputs.keys())[0]
         energies = self._subset_of_regressors_torch(soap_features)
         return_dict = {output_key: energies}

--- a/src/metatrain/soap_bpnn/model.py
+++ b/src/metatrain/soap_bpnn/model.py
@@ -865,7 +865,7 @@ class SoapBpnn(ModelInterface[ModelHypers]):
                                 )
                             )
                         else:
-                            output_blocks.append(b)
+                            output_blocks.append(b.copy())
                     return_dict[name] = TensorMap(return_dict[name].keys, output_blocks)
 
             # For atomic basis targets, sparsify to create blocks with "atom_type"

--- a/src/metatrain/utils/data/target_info.py
+++ b/src/metatrain/utils/data/target_info.py
@@ -758,7 +758,10 @@ def is_auxiliary_output(name: str) -> bool:
     :return: `True` if the target is an auxiliary output, `False` otherwise.
     """
     is_auxiliary = (
-        name == "features" or name == "energy_ensemble" or name.startswith("mtt::aux::")
+        name == "features"
+        or name == "feature"
+        or name == "energy_ensemble"
+        or name.startswith("mtt::aux::")
     )
     return is_auxiliary
 

--- a/src/metatrain/utils/evaluate_model.py
+++ b/src/metatrain/utils/evaluate_model.py
@@ -62,7 +62,7 @@ def evaluate_model(
     energy_targets_that_require_strain_gradients = []
     for target_name in targets.keys():
         # Check if the target is an energy:
-        if model_outputs[target_name].quantity == "energy":
+        if targets[target_name].quantity == "energy":
             energy_targets.append(target_name)
             if isinstance(targets[target_name], TargetInfo):
                 # Check if the energy requires gradients:

--- a/src/metatrain/utils/scaler/_base_scaler.py
+++ b/src/metatrain/utils/scaler/_base_scaler.py
@@ -831,11 +831,11 @@ class BaseScaler(torch.nn.Module):
 
         self.scales[target_name] = TensorMap(
             self.Y2[target_name].keys.to(device=block.values.device),
-            [block],
+            [block.copy()],
         )
         self.per_target_scales[target_name] = TensorMap(
             self.Y2[target_name].keys.to(device=block.values.device),
-            [block],
+            [block.copy()],
         )
 
     def _sync_device_dtype(self, device: torch.device, dtype: torch.dtype) -> None:

--- a/src/metatrain/utils/testing/output.py
+++ b/src/metatrain/utils/testing/output.py
@@ -627,7 +627,7 @@ class OutputTests(ArchitectureTests):
 
         features_output_options = ModelOutput(
             quantity="",
-            unit="unitless",
+            unit="",
             per_atom=per_atom,
         )
         model = model.to(system.positions.dtype)
@@ -705,7 +705,7 @@ class OutputTests(ArchitectureTests):
         # last-layer features per atom:
         ll_output_options = ModelOutput(
             quantity="",
-            unit="unitless",
+            unit="",
             per_atom=per_atom,
         )
         model = model.to(system.positions.dtype)

--- a/tests/utils/data/test_readers.py
+++ b/tests/utils/data/test_readers.py
@@ -52,7 +52,9 @@ def test_read_unknonw_library():
 
 def test_unsupported_target_name():
     conf = {"free_energy": {"quantity": "energy"}}
-    with pytest.raises(ValueError, match="invalid model output name 'free_energy'"):
+    with pytest.raises(
+        ValueError, match="Invalid name for model output: 'free_energy'"
+    ):
         read_targets(OmegaConf.create(conf))
 
 

--- a/tests/utils/data/test_readers.py
+++ b/tests/utils/data/test_readers.py
@@ -52,9 +52,7 @@ def test_read_unknonw_library():
 
 def test_unsupported_target_name():
     conf = {"free_energy": {"quantity": "energy"}}
-    with pytest.raises(
-        ValueError, match="Invalid name for model output: 'free_energy'"
-    ):
+    with pytest.raises(ValueError, match="invalid model output name 'free_energy'"):
         read_targets(OmegaConf.create(conf))
 
 


### PR DESCRIPTION
tested versions:

```
metatensor-{core,torch,operations,learn} 0.2.0rc4/0.9.0rc6/0.5.0rc2/0.5.0rc2
metatomic-{torch,ase} 0.1.12rc2/0.1.1rc1
featomic 0.6.6rc1
featomic-torch 0.7.4rc2
```

some fixes:
2da11ce6 - use `targets[name].quantity` as deprecated on ModelOutput
903841ef -  `is_auxiliary_output` also matches singular `"feature"` (renamed in metatomic)
f0d92ea3 a66b3f55  and afcb3131- recreate or copy tensorblocks
f2d96df1 - `unit="unitless"` => `""`

not fixed here:
in llpr: `compute_cholesky_decomposition` error, see https://github.com/metatensor/metatrain/pull/1128#issuecomment-4428919907


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1128.org.readthedocs.build/en/1128/

<!-- readthedocs-preview metatrain end -->