### PR TITLE
Fix final model checkpoint copy for absolute output paths

### DIFF
--- a/examples/1-advanced/04-flashmd.py
+++ b/examples/1-advanced/04-flashmd.py
@@ -47,7 +47,7 @@ dyn = Langevin(
 dyn.run(1000)  # 2 ps equilibration (around 10 ps is better in practice)
 
 # Then, we run a production simulation in the NVE ensemble.
-trajectory = []
+trajectory: list[ase.Atoms] = []
 
 
 def store_trajectory():

--- a/examples/1-advanced/09-symplectic-flashmd.py
+++ b/examples/1-advanced/09-symplectic-flashmd.py
@@ -46,7 +46,7 @@ dyn = Langevin(
 dyn.run(1000)  # 2 ps equilibration (around 10 ps is better in practice)
 
 # Then, we run a production simulation in the NVE ensemble.
-trajectory = []
+trajectory: list[ase.Atoms] = []
 
 
 def store_trajectory():

--- a/src/metatrain/cli/train.py
+++ b/src/metatrain/cli/train.py
@@ -750,9 +750,13 @@ def train_model(
         logging.info(f"Extensions path: {extensions.absolute().resolve()}")
 
     if checkpoint_dir.absolute().resolve() != Path.cwd():
-        shutil.copy(output, checkpoint_dir / output)
+        checkpoint_output_path = checkpoint_dir / output
+        if checkpoint_output_path.resolve() != output.resolve():
+            shutil.copy(output, checkpoint_output_path)
         if checkpoint_output.exists():
-            shutil.copy(checkpoint_output, checkpoint_dir / checkpoint_output)
+            checkpoint_copy_path = checkpoint_dir / checkpoint_output
+            if checkpoint_copy_path.resolve() != checkpoint_output.resolve():
+                shutil.copy(checkpoint_output, checkpoint_copy_path)
 
     ###########################
     # EVALUATE FINAL MODEL ####

--- a/src/metatrain/cli/train.py
+++ b/src/metatrain/cli/train.py
@@ -750,6 +750,9 @@ def train_model(
         logging.info(f"Extensions path: {extensions.absolute().resolve()}")
 
     if checkpoint_dir.absolute().resolve() != Path.cwd():
+        # Copy checkpoint and exported model to the requested path,
+        # with checks to make sure that the requested path is not the path
+        # where the files already are (copy would raise a SameFileError)
         checkpoint_output_path = checkpoint_dir / output
         if checkpoint_output_path.resolve() != output.resolve():
             shutil.copy(output, checkpoint_output_path)

--- a/src/metatrain/utils/hypers.py
+++ b/src/metatrain/utils/hypers.py
@@ -79,7 +79,7 @@ def init_with_defaults(hypers_cls: Type[HypersType]) -> dict:
 
 
 # Private global dictionary to store overwritten defaults
-_OVERWRITTEN_DEFAULTS = {}
+_OVERWRITTEN_DEFAULTS: dict[Type, dict] = {}
 
 
 def overwrite_defaults(


### PR DESCRIPTION
If you pass an absolute path for the model output, e.g.:

```bash
mtt train options.yaml -o /tmp/model.pt
```

The training run ends with an error (`shutil.copy(...)` raises `SameFileError`.) 

The fix is to handle absolute outputs explicitly when copying final artifacts into `checkpoint_dir`.


# Contributor (creator of pull-request) checklist

- ~~[ ] Tests updated (for new features and bugfixes)?~~
- ~~[ ] Documentation updated (for new features)?~~
- ~~[ ] Issue referenced (for PRs that solve an issue)?~~

# Maintainer/Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1134.org.readthedocs.build/en/1134/

<!-- readthedocs-preview metatrain end -->