### PR TITLE
Workaround for Xet warning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,9 @@ jobs:
       env:
         # Use the CPU only version of torch when building/running the code
         PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
+        # Temporary workaround: avoid the deprecated hf_xet.download_files() path 
+        # until huggingface_hub switches to the new Xet API.
+        HF_HUB_DISABLE_XET: 1
         HUGGINGFACE_TOKEN_METATRAIN: ${{ secrets.HUGGINGFACE_TOKEN }}
 
     - name: upload to codecov.io


### PR DESCRIPTION
Update CI to set `HF_HUB_DISABLE_XET=1` in `.github/workflows/tests.yml` as a temporary workaround for Hugging Face download tests failing with:

```
DeprecationWarning: hf_xet.download_files() is deprecated. Use XetSession().new_file_download_group().start_download_file() instead.
```

If approved, I'll open an issue with the TODO of removing this line when `huggingface_hub` is updated.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1135.org.readthedocs.build/en/1135/

<!-- readthedocs-preview metatrain end -->