### PR TITLE
Skip walking through dataset if unnecessary

### DIFF
--- a/src/metatrain/utils/scaler/scaler.py
+++ b/src/metatrain/utils/scaler/scaler.py
@@ -1,5 +1,5 @@
-from typing import Callable, Dict, List, Optional, Sequence, Union
 import logging
+from typing import Callable, Dict, List, Optional, Sequence, Union
 
 import metatensor.torch as mts
 import torch
@@ -229,7 +229,10 @@ class Scaler(torch.nn.Module):
                         torch.distributed.all_reduce(N_block.values)
                         torch.distributed.all_reduce(Y2_block.values)
         else:
-            logging.info("Skipping weight calculation: fixed_weights provided for all targets to fit.")
+            logging.info(
+                "Skipping weight calculation: fixed_weights provided for all targets "
+                "to fit."
+            )
 
         # Compute the scales on all ranks
         self.model.fit(fixed_weights=fixed_weights, targets_to_fit=self.new_outputs)

--- a/src/metatrain/utils/scaler/scaler.py
+++ b/src/metatrain/utils/scaler/scaler.py
@@ -1,4 +1,5 @@
 from typing import Callable, Dict, List, Optional, Sequence, Union
+import logging
 
 import metatensor.torch as mts
 import torch
@@ -178,50 +179,57 @@ class Scaler(torch.nn.Module):
         if len(self.target_infos) == 0:  # no (new) targets to fit
             return
 
-        # Create dataloader for the training datasets
-        dataloader = self._get_dataloader(
-            datasets,
-            batch_size,
-            is_distributed=is_distributed,
-            initial_transforms=initial_transforms,
+        skip_accumulation = fixed_weights is not None and all(
+            t in fixed_weights for t in self.new_outputs
         )
 
         device = self.dummy_buffer.device
 
-        # accumulate
-        for batch in dataloader:
-            systems, targets, extra_data = unpack_batch(batch)
-            systems, targets, extra_data = batch_to(
-                systems, targets, extra_data, device=device
+        if not skip_accumulation:
+            # Create dataloader for the training datasets
+            dataloader = self._get_dataloader(
+                datasets,
+                batch_size,
+                is_distributed=is_distributed,
+                initial_transforms=initial_transforms,
             )
-            if len(targets) == 0:
-                break
 
-            # remove additive contributions from these targets
-            for additive_model in additive_models:
-                targets = remove_additive(
-                    systems,
-                    targets,
-                    additive_model,
-                    {
-                        target_name: self.target_infos[target_name]
-                        for target_name in targets
-                    },
+            # accumulate
+            for batch in dataloader:
+                systems, targets, extra_data = unpack_batch(batch)
+                systems, targets, extra_data = batch_to(
+                    systems, targets, extra_data, device=device
                 )
-            targets = average_by_num_atoms(targets, systems, [])
-            self.model.accumulate(systems, targets, extra_data)
+                if len(targets) == 0:
+                    break
 
-        if is_distributed:
-            torch.distributed.barrier()
-            # All-reduce the accumulated TensorMaps across all processes
-            for target_name in self.new_outputs:
-                for N_block, Y2_block in zip(
-                    self.model.N[target_name],
-                    self.model.Y2[target_name],
-                    strict=True,
-                ):
-                    torch.distributed.all_reduce(N_block.values)
-                    torch.distributed.all_reduce(Y2_block.values)
+                # remove additive contributions from these targets
+                for additive_model in additive_models:
+                    targets = remove_additive(
+                        systems,
+                        targets,
+                        additive_model,
+                        {
+                            target_name: self.target_infos[target_name]
+                            for target_name in targets
+                        },
+                    )
+                targets = average_by_num_atoms(targets, systems, [])
+                self.model.accumulate(systems, targets, extra_data)
+
+            if is_distributed:
+                torch.distributed.barrier()
+                # All-reduce the accumulated TensorMaps across all processes
+                for target_name in self.new_outputs:
+                    for N_block, Y2_block in zip(
+                        self.model.N[target_name],
+                        self.model.Y2[target_name],
+                        strict=True,
+                    ):
+                        torch.distributed.all_reduce(N_block.values)
+                        torch.distributed.all_reduce(Y2_block.values)
+        else:
+            logging.info("Skipping weight calculation: fixed_weights provided for all targets to fit.")
 
         # Compute the scales on all ranks
         self.model.fit(fixed_weights=fixed_weights, targets_to_fit=self.new_outputs)

--- a/tests/utils/test_scaler.py
+++ b/tests/utils/test_scaler.py
@@ -2134,6 +2134,34 @@ def test_scaler_spherical_atomic_basis_rank_2_rotation_invariance(missing_type):
             )
 
 
+def test_scaler_skips_accumulation(caplog):
+    """Test that the scaler skips the dataset walk if all fixed weights are provided."""
+    import logging
+
+    scaler = Scaler(
+        hypers={},
+        dataset_info=DatasetInfo(
+            length_unit="angstrom",
+            atomic_types=[1, 8],
+            targets={"energy": get_energy_target_info("energy", {"unit": "eV"})},
+        ),
+    )
+
+    with caplog.at_level(logging.INFO):
+        scaler.train_model(
+            datasets=[],
+            additive_models=[],
+            batch_size=1,
+            is_distributed=False,
+            fixed_weights={"energy": 0.1},
+        )
+
+    assert (
+        "Skipping weight calculation: fixed_weights provided for all targets to fit."
+        in caplog.text
+    )
+
+
 def test_scaler_torchscript(tmpdir):
     """Test the torchscripting, saving and loading of a scaler model."""
 


### PR DESCRIPTION
Even if all the scales are provided as `fixed_scaling_weights`, the `Scaler` still walks through the entire dataset. This is not necessary. This PR fixes this by adding a check that only executes the loop if there is a target without a scaling weight associated to it.


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1138.org.readthedocs.build/en/1138/

<!-- readthedocs-preview metatrain end -->