### PR TITLE
Fix overriding the model weights upon restarting the PET fine-tuning run

### DIFF
--- a/src/metatrain/pet/trainer.py
+++ b/src/metatrain/pet/trainer.py
@@ -93,6 +93,8 @@ class Trainer(TrainerInterface[TrainerHypers]):
         self.best_metric: Optional[float] = None
         self.best_model_state_dict: Optional[Dict[str, Any]] = None
         self.best_optimizer_state_dict: Optional[Dict[str, Any]] = None
+        self.is_restart: bool = False
+        self.is_finetune: bool = hypers.get("finetune", {}).get("read_from") is not None
 
     def train(
         self,
@@ -106,7 +108,6 @@ class Trainer(TrainerInterface[TrainerHypers]):
         assert dtype in PET.__supported_dtypes__
 
         is_distributed = self.hypers["distributed"]
-        is_finetune = self.hypers["finetune"]["read_from"] is not None
 
         if is_distributed:
             if len(devices) > 1:
@@ -131,28 +132,34 @@ class Trainer(TrainerInterface[TrainerHypers]):
         else:
             logging.info(f"Training on device {device} with dtype {dtype}")
 
-        # Apply fine-tuning strategy if provided
-        if is_finetune:
-            assert self.hypers["finetune"]["read_from"] is not None  # for mypy
-            model = apply_finetuning_strategy(model, self.hypers["finetune"])
-            method = self.hypers["finetune"]["method"]
+        # Apply fine-tuning strategy if provided.
+        # On restart, the strategy was already applied in Model.load_checkpoint(),
+        # so we must not re-apply it (inherit_heads would overwrite learned weights).
+        if self.is_finetune:
+            if not self.is_restart:
+                assert self.hypers["finetune"]["read_from"] is not None  # for mypy
+                model = apply_finetuning_strategy(model, self.hypers["finetune"])
+                method = self.hypers["finetune"]["method"]
+                logging.info(f"Applied finetuning strategy: {method}")
+                inherit_heads = self.hypers["finetune"]["inherit_heads"]
+                if inherit_heads:
+                    logging.info(
+                        "Inheriting initial weights for heads and last layers "
+                        f"for targets: from {list(inherit_heads.values())} to "
+                        f"{list(inherit_heads.keys())}"
+                    )
+            else:
+                method = model.finetune_config["method"]
+                logging.info(f"Restarting finetuned model (strategy: {method})")
+
             num_params = sum(p.numel() for p in model.parameters())
             num_trainable_params = sum(
                 p.numel() for p in model.parameters() if p.requires_grad
             )
-
-            logging.info(f"Applied finetuning strategy: {method}")
             logging.info(
                 f"Number of trainable parameters: {num_trainable_params} "
                 f"[{num_trainable_params / num_params:.2%} %]"
             )
-            inherit_heads = self.hypers["finetune"]["inherit_heads"]
-            if inherit_heads:
-                logging.info(
-                    "Inheriting initial weights for heads and last layers for targets: "
-                    f"from {list(inherit_heads.values())} to "
-                    f"{list(inherit_heads.keys())}"
-                )
 
         # Move the model to the device and dtype:
         model.to(device=device, dtype=dtype)
@@ -699,6 +706,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
         trainer.scheduler_state_dict = checkpoint["scheduler_state_dict"]
         if context == "restart":
             trainer.epoch = checkpoint["epoch"]
+            trainer.is_restart = True
         else:
             assert context == "finetune"
             trainer.epoch = None  # interpreted as zero in the training loop


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

This PR fixes the pathological behavior of the PET class that arises upon restarting the interrupted fine-tuning run with `inherit_heads` option activated. 

The way it works ATM is that if one doesn't switch off the fine-tuning flag in the `options.yaml` upon restarting the fine-tuning run, the trainer first loads the model and the optimizer state dicts, and then re-applies the `apply_finetuning_strategy`, and in particular - `inherit_heads`, therefore corrupting the checkpoint.

This PR fixes that behavior by checking if the training run is a restart, and doesn't reapply the fine-tuning strategy second time in that case. The initial technical call for `apply_finetuning_strategy` that is required to spawn the correct modules namespace before loading the model weights from the checkpoint should've been already done at this point in `PET.load_checkpoint`. 

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Maintainer/Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1139.org.readthedocs.build/en/1139/

<!-- readthedocs-preview metatrain end -->