### PR TITLE
DPA3: ensure correct unscaling of targets and predictions before metric computation

### DIFF
--- a/src/metatrain/experimental/dpa3/trainer.py
+++ b/src/metatrain/experimental/dpa3/trainer.py
@@ -400,6 +400,23 @@ class Trainer(TrainerInterface[TrainerHypers]):
                     if self.hypers["log_mae"]:
                         train_mae_calculator.update(predictions, targets)
 
+                # Reapply scales and accumulate quantities for computing train metrics,
+                # but only if this is an epoch to log
+                if epoch == start_epoch or epoch % self.hypers["log_interval"] == 0:
+                    scaled_predictions = (
+                        model.module if is_distributed else model
+                    ).scaler(systems, predictions)
+                    scaled_targets = (model.module if is_distributed else model).scaler(
+                        systems, targets
+                    )
+                    train_rmse_calculator.update(
+                        scaled_predictions, scaled_targets, extra_data
+                    )
+                    if self.hypers["log_mae"]:
+                        train_mae_calculator.update(
+                            scaled_predictions, scaled_targets, extra_data
+                        )
+
             # Compute train metrics if they are to be logged this epoch:
             if epoch == start_epoch or epoch % self.hypers["log_interval"] == 0:
                 finalized_train_info = train_rmse_calculator.finalize(
@@ -465,11 +482,23 @@ class Trainer(TrainerInterface[TrainerHypers]):
                     torch.distributed.all_reduce(val_loss_batch)
                 val_loss += val_loss_batch.item()
 
-                # Accumulate quantities for computing val metrics. This is done for
-                # every epoch as validation metrics are needed for model selection
-                val_rmse_calculator.update(predictions, targets)
+                # Reapply scales and accumulate quantities for computing val
+                # metrics. This is done for every epoch as validation metrics are
+                # needed for model selection
+                scaled_predictions = (model.module if is_distributed else model).scaler(
+                    systems, predictions
+                )
+                scaled_targets = (model.module if is_distributed else model).scaler(
+                    systems, targets
+                )
+
+                val_rmse_calculator.update(
+                    scaled_predictions, scaled_targets, extra_data
+                )
                 if self.hypers["log_mae"]:
-                    val_mae_calculator.update(predictions, targets)
+                    val_mae_calculator.update(
+                        scaled_predictions, scaled_targets, extra_data
+                    )
 
             # Compute val metrics:
             finalized_val_info = val_rmse_calculator.finalize(

--- a/src/metatrain/experimental/dpa3/trainer.py
+++ b/src/metatrain/experimental/dpa3/trainer.py
@@ -393,13 +393,6 @@ class Trainer(TrainerInterface[TrainerHypers]):
                     torch.distributed.all_reduce(train_loss_batch)
                 train_loss += train_loss_batch.item()
 
-                # Accumulate quantities for computing train metrics,
-                # but only if this is an epoch to log
-                if epoch == start_epoch or epoch % self.hypers["log_interval"] == 0:
-                    train_rmse_calculator.update(predictions, targets)
-                    if self.hypers["log_mae"]:
-                        train_mae_calculator.update(predictions, targets)
-
                 # Reapply scales and accumulate quantities for computing train metrics,
                 # but only if this is an epoch to log
                 if epoch == start_epoch or epoch % self.hypers["log_interval"] == 0:


### PR DESCRIPTION
Currently in the DPA3 trainer, the targets and predictions are not unscaled prior to train/validation metric computation.

# Contributor (creator of pull-request) checklist

 - ~[ ] Tests updated (for new features and bugfixes)?~
 - ~[ ] Documentation updated (for new features)?~
 - ~[ ] Issue referenced (for PRs that solve an issue)?~

# Maintainer/Reviewer checklist

 - ~[ ] CHANGELOG updated with public API or any other important changes?~
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1141.org.readthedocs.build/en/1141/

<!-- readthedocs-preview metatrain end -->