### PR TITLE
Bump uv to make CI run with the new metatensor releases

### DIFF
--- a/.github/workflows/architecture-tests.yml
+++ b/.github/workflows/architecture-tests.yml
@@ -30,9 +30,8 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
-        version: "0.9.0"
         python-version: "3.13"
         enable-cache: true
         activate-environment: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,8 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
-        version: "0.9.0"
         python-version: "3.13"
         enable-cache: true
         activate-environment: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,9 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.9.0"
           python-version: "3.13"
           enable-cache: true
           activate-environment: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,8 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
-        version: "0.9.0"
         python-version: "3.13"
         enable-cache: true
         activate-environment: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,8 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
-        version: "0.9.0"
         python-version: "3.13"
         enable-cache: true
         activate-environment: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,9 +33,8 @@ jobs:
         touch ~/.zshrc
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
-        version: "0.9.0"
         python-version: ${{ matrix.python-version }}
         enable-cache: true
         activate-environment: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y zsh libfftw3-dev
         touch ~/.zshrc
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v8.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,11 +32,6 @@ jobs:
         sudo apt-get install -y zsh libfftw3-dev
         touch ~/.zshrc
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
-      with:
-        python-version:
-
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y zsh libfftw3-dev
         touch ~/.zshrc
-    
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:


### PR DESCRIPTION
Trying to fix recent CI failures, which are apparently related to https://github.com/pytorch/pytorch/issues/165448

We had uv pinned, which installed python 3.13.8 when the python version was "3.13". This python version has problems with `torch >= 2.11`. For some reason the CI in main is using `torch==2.10` at most and this is why we were not seeing any problem. However, the dependency bump in https://github.com/metatensor/metatrain/pull/1144 makes CI use `torch >= 2.11` and therefore the CI was failing.

This PR bumps both the `setup-uv` action and `uv` itself, which we leave unpinned (latest version is used) so that we don't get problems from old `uv`s in the future.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1146.org.readthedocs.build/en/1146/

<!-- readthedocs-preview metatrain end -->