### PR TITLE
Make logging of supported model types a bit prettier

### DIFF
--- a/src/metatrain/cli/train.py
+++ b/src/metatrain/cli/train.py
@@ -570,7 +570,14 @@ def train_model(
         logging.info("Atomic types explicitly defined in options.yaml")
         atomic_types = sorted(options["architecture"]["atomic_types"])
 
-    logging.info(f"Model defined for atomic types: {atomic_types}")
+    if len(atomic_types) > 1:
+        atomic_types_str = (
+            ", ".join(map(str, atomic_types[:-1])) + f" and {atomic_types[-1]}"
+        )
+        logging.info(f"Model defined for atomic types: {atomic_types_str}")
+    else:
+        atomic_types_str = str(atomic_types[0])
+        logging.info(f"Model defined for atomic type: {atomic_types_str}")
 
     dataset_info = DatasetInfo(
         length_unit=options["training_set"][0]["systems"]["length_unit"],


### PR DESCRIPTION
Currently we just print an ugly list like

```
Model defined for atomic types: [1]
Model defined for atomic types: [1, 3, 4, 5]
```

I think it looks nicer now:

```
Model defined for atomic type: 1
Model defined for atomic types: 1, 3, 4 and 5
```

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1148.org.readthedocs.build/en/1148/

<!-- readthedocs-preview metatrain end -->