### PR TITLE
Avoid latest scaler checkpoint update if targets are not scaled

### DIFF
--- a/src/metatrain/utils/scaler/checkpoints.py
+++ b/src/metatrain/utils/scaler/checkpoints.py
@@ -16,7 +16,8 @@ def update_per_property_scales(checkpoint: dict, scaler_key: str = "scaler") -> 
     :param scaler_key: The key under which the scaler is stored in the state_dict
       of the model.
     """
-    if checkpoint["train_hypers"]["scale_targets"]:
+    targets_scaled = checkpoint.get("train_hypers", {}).get("scale_targets", True)
+    if targets_scaled:
         # If the model checkpoint can output targets with multiple blocks and/or
         # multiple properties per-block, this version of metatrain cannot be used.
         # This doesn't affect MLIP checkpoints.

--- a/src/metatrain/utils/scaler/checkpoints.py
+++ b/src/metatrain/utils/scaler/checkpoints.py
@@ -16,21 +16,23 @@ def update_per_property_scales(checkpoint: dict, scaler_key: str = "scaler") -> 
     :param scaler_key: The key under which the scaler is stored in the state_dict
       of the model.
     """
-    # If the model checkpoint can output targets with multiple blocks and/or multiple
-    # properties per-block, this version of metatrain cannot be used. This doesn't
-    # affect MLIP checkpoints.
-    for target_name, target_info in checkpoint["model_data"][
-        "dataset_info"
-    ].targets.items():
-        layout = target_info.layout
-        if len(layout.keys) > 1 or len(layout[0].properties) > 1:
-            raise ValueError(
-                f"Target '{target_name}' has multiple blocks or multiple properties "
-                f"per block. Upgrading checkpoints for such targets is not supported, "
-                f"as it would require re-computing per-target scales from the original "
-                f"training data. Please install from source the older version of "
-                f"metatrain (before the per-target/per-property scale separation)."
-            )
+    if checkpoint["model_data"]["hypers"]["scale_targets"]:
+        # If the model checkpoint can output targets with multiple blocks and/or
+        # multiple properties per-block, this version of metatrain cannot be used.
+        # This doesn't affect MLIP checkpoints.
+        for target_name, target_info in checkpoint["model_data"][
+            "dataset_info"
+        ].targets.items():
+            layout = target_info.layout
+            if len(layout.keys) > 1 or len(layout[0].properties) > 1:
+                raise ValueError(
+                    f"Target '{target_name}' has multiple blocks or multiple "
+                    "properties per block. Upgrading checkpoints for such targets is "
+                    "not supported, as it would require re-computing per-target "
+                    "scales from the original training data. Please install from "
+                    "source the older version of metatrain (before the "
+                    "per-target/per-property scale separation)."
+                )
 
     # For single-block, single-property targets (e.g. MLIPs): the old `scales`
     # TensorMap can be used directly as `per_target_scales`, and `per_property_scales`

--- a/src/metatrain/utils/scaler/checkpoints.py
+++ b/src/metatrain/utils/scaler/checkpoints.py
@@ -16,7 +16,7 @@ def update_per_property_scales(checkpoint: dict, scaler_key: str = "scaler") -> 
     :param scaler_key: The key under which the scaler is stored in the state_dict
       of the model.
     """
-    if checkpoint["model_data"]["hypers"]["scale_targets"]:
+    if checkpoint["train_hypers"]["scale_targets"]:
         # If the model checkpoint can output targets with multiple blocks and/or
         # multiple properties per-block, this version of metatrain cannot be used.
         # This doesn't affect MLIP checkpoints.


### PR DESCRIPTION
This was breaking the ability to export old PET-MAD-DOS checkpoints, even though they don't use scales.

@HowWeiBin can you test that this works?

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1156.org.readthedocs.build/en/1156/

<!-- readthedocs-preview metatrain end -->