### PR TITLE
Evaluation now uses indices passed in the yaml file

### DIFF
--- a/src/metatrain/cli/eval.py
+++ b/src/metatrain/cli/eval.py
@@ -12,6 +12,7 @@ import tqdm
 from metatensor.torch import Labels, TensorBlock, TensorMap
 from metatomic.torch import AtomisticModel, ModelOutput
 from omegaconf import DictConfig, OmegaConf
+from torch.utils.data import Subset
 
 from metatrain.cli.formatter import CustomHelpFormatter
 from metatrain.utils.data import (
@@ -19,6 +20,7 @@ from metatrain.utils.data import (
     Dataset,
     TargetInfo,
     get_dataset,
+    load_indices,
     read_systems,
     unpack_batch,
 )
@@ -336,6 +338,12 @@ def eval_model(
                     model_output.sample_kind = "system"  # type: ignore
 
             eval_dataset = Dataset.from_dict({"system": eval_systems, **eval_targets})
+
+        if "indices" in options:
+            eval_indices = options["indices"]
+            if isinstance(options["indices"], str):
+                eval_indices = load_indices(eval_indices)
+            eval_dataset = Subset(eval_dataset, eval_indices)
 
         # run evaluation & writing
         try:

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -660,7 +660,7 @@ def load_indices(indices_spec: Union[List[int], str]) -> List[int]:
             path = Path.cwd() / path
         if not path.exists():
             raise ValueError(f"Indices file not found: {path}")
-        indices = np.loadtxt(path, dtype=int).tolist()
+        indices = np.loadtxt(path, dtype=int).reshape(-1).tolist()
 
     if indices and any(i < 0 for i in indices):
         raise ValueError("Indices must be non-negative integers")

--- a/tests/cli/test_eval_model.py
+++ b/tests/cli/test_eval_model.py
@@ -258,3 +258,41 @@ def test_eval_disk_dataset(monkeypatch, tmp_path, caplog, suffix, MODEL_PATH):
     else:
         pred = DiskDataset("foo.zip")
         assert pred[0]["energy"].keys == Labels(["_"], torch.tensor([[0]]))
+
+
+@pytest.mark.parametrize("indices_mode", ["list", "file"])
+def test_eval_indices(monkeypatch, tmp_path, caplog, options, MODEL_PATH, indices_mode):
+    """Checks that the indices option is correctly used to evaluate only a subset"""
+    monkeypatch.chdir(tmp_path)
+    caplog.set_level(logging.INFO)
+
+    shutil.copy(RESOURCES_PATH / "qm9_reduced_100.xyz", "qm9_reduced_100.xyz")
+
+    options = options.copy()
+    if indices_mode == "file":
+        with open("indices.txt", "w") as f:
+            f.write("0\n")
+        options["indices"] = "indices.txt"
+    else:
+        options["indices"] = [0]
+
+    model = torch.jit.load(MODEL_PATH)
+
+    eval_model(
+        model=model,
+        options=options,
+        output="foo.xyz",
+        check_consistency=True,
+    )
+
+    # Test target predictions
+    log = "".join([rec.message for rec in caplog.records])
+    assert "energy RMSE (per atom)" in log
+    assert "energy MAE (per atom)" in log
+    assert "dataset with index" not in log
+    assert "Evaluation time" in log
+    assert "ms per atom" in log
+
+    # Test file is written predictions
+    frames = read("foo.xyz", ":")
+    assert len(frames) == 1


### PR DESCRIPTION
Not long ago `indices` was introduced to the yaml file so that one could ask to train and validate on specific subsets of a given dataset.

However, managing the `indices` input was not implemented in `mtt eval`, which meant that again you needed to create a new dataset file with only the samples that you wanted to evaluate.

This PR adds the `indices` functionality to `mtt eval`, and also fixes a bug in which it was not possible to pass a single index as a file.


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1158.org.readthedocs.build/en/1158/

<!-- readthedocs-preview metatrain end -->