### PR TITLE
Revise DOS loss to shift agnostic MSE loss function

### DIFF
--- a/docs/src/concepts/loss-functions.rst
+++ b/docs/src/concepts/loss-functions.rst
@@ -179,49 +179,35 @@ The values of the masks must be passed as ``extra_data`` in the training set, an
 Shift Agnostic MSE Loss Function
 ---------------------------------
 
-The shift agnostic MSE loss function is a specialized loss function designed for training on targets where the reference is not fixed. The loss function also supports masking by setting the target where the loss should not be computed as nan. The mask is then generated on-the-fly using:
+The shift agnostic MSE loss function is a specialized loss function designed for training on targets where the reference is not fixed.
+It finds the rigid shift between targets and predictions that minimizes the MSE. Then it returns the MSE for that shift. NaNs in the
+target are simply ignored.
+
+An example of such a target is the electronic density of states (DOS), where the energy reference is not well defined.
+
+For the optimal rigid shift, two additional components might be added to the loss function:
+
+- A penalty on the gradient for regions where the target is NaN, to make the predictions for that region smoother.
 
 .. code-block:: python
 
-    mask = (~torch.isnan(target)).float()
+    gradient_penalty_loss = torch.trapezoid(aligned_predictions_gradient[NaN_mask]**2, x_axis = tmap_properties_grid)
 
-An example of such a target is the electronic density of states (DOS), where the energy reference is not well defined and there are regions on the energy grid where the DOS is not well-defined due to truncation introduced during electronic structure computations. The loss function achieves shift invariance by first padding the model predictions as follows
-
-.. code-block:: python
-
-    convolution_pad = torch.zeros_like(predictions)
-    padded_predictions = torch.hstack([convolution_pad, predictions, convolution_pad])
-
-Then, the loss function uses convolutions to find the continuous region in the padded_predictions that minimizes the loss when compared against the target. The loss is only defined on the region where the loss is a minimum, achieving shift invariance. At this step, the loss is defined as an integrated loss on the masked values
+- A contribution from the cumulative profiles.
 
 .. code-block:: python
 
-    masked_DOS_loss = torch.trapezoid((padded_predictions[start:end] - targets)**2 * mask)
-
-
-Afterwards, the continuous regions in the predictions where the loss is a minimum is obtained and two additional components of the loss function is calculated:
-
-- an integrated loss on the gradient of the *unmasked* DOS values, to ensure that values outside the masked region are also learned smoothly
-
-.. code-block:: python
-
-    unmasked_gradient_loss = torch.trapezoid(aligned_predictions_gradient**2 * (~mask), x_axis = energy_grid)
-
-- an integrated loss on the cumulative DOS values in the masked region
-
-.. code-block:: python
-
-    cumulative_aligned_predictions = torch.cumulative_trapezoid(aligned_predictions, x = energy_grid)
-    cumulative_targets = torch.cumulative_trapezoid(targets, x = energy_grid)
-    masked_cumulative_DOS_loss = torch.trapezoid((cumulative_aligned_predictions - cumulative_targets)**2 * mask, x_axis = energy_grid[1:])
+    cumulative_aligned_predictions = torch.cumulative_trapezoid(aligned_predictions, x = tmap_properties_grid)
+    cumulative_targets = torch.cumulative_trapezoid(targets, x = tmap_properties_grid)
+    cumulative_loss = torch.trapezoid((cumulative_aligned_predictions - cumulative_targets)**2, x_axis = tmap_properties_grid[1:])
 
 Each component can be weighted independently to tailor the loss function to specific training needs.
 
 .. code-block:: python
 
-    loss = (masked_DOS_loss +
-            grad_penalty_weight  * unmasked_gradient_loss +
-            int_weight * masked_cumulative_DOS_loss)
+    loss = (mse +
+            grad_penalty_weight  * gradient_penalty_loss +
+            int_weight * cumulative_loss)
 
 To use this loss function, you can refer to this code snippet for the ``loss`` section in your YAML configuration file:
 
@@ -234,12 +220,7 @@ To use this loss function, you can refer to this code snippet for the ``loss`` s
         int_weight: 2.0
         reduction: "mean"
 
-:param grad_penalty_weight : Multiplier for the gradient of the unmasked DOS component.
-:param int_weight: Multiplier for the cumulative DOS component.
-:param reduction: reduction mode for torch loss. Options are "mean", "sum", or "none".
-
 The values used in the above example are the ones used for PETMADDOS training and can be a reasonable starting point for other applications.
-
 
 Ensemble Loss Function
 ----------------------

--- a/docs/src/concepts/loss-functions.rst
+++ b/docs/src/concepts/loss-functions.rst
@@ -174,21 +174,31 @@ The values of the masks must be passed as ``extra_data`` in the training set, an
         read_from: my_target_mask.mts
 
 
-.. _dos-loss:
+.. _shift-agnostic-loss:
 
-DOS Loss Function
-^^^^^^^^^^^^^^^^^
+Shift Agnostic MSE Loss Function
+---------------------------------
 
-The masked DOS loss function is a specialized loss designed for training on the electronic density of states (DOS), typically represented on an energy grid. Structures in a dataset can (and usually do) have eigenvalues spanning different energy ranges, and DOS calculations do not share a common absolute energy reference.
-To handle this, the loss uses a user-specified number of extra predicted targets to dynamically shift the energy grid for each structure, aligning the predicted DOS with the reference DOS before computing the loss.
+The shift agnostic MSE loss function is a specialized loss function designed for training on targets where the reference is not fixed. The loss function also supports masking by setting the target where the loss should not be computed as nan. The mask is then generated on-the-fly using:
 
-After this alignment step, the loss function consists of three components:
+.. code-block:: python
+    mask = (~torch.isnan(target)).float()
 
-- an integrated loss on the masked DOS values
+An example of such a target is the electronic density of states (DOS), where the energy reference is not well defined and there are regions on the energy grid where the DOS is not well-defined due to truncation introduced during electronic structure computations. The loss function achieves shift invariance by first padding the model predictions as follows
 
 .. code-block:: python
 
-    masked_DOS_loss = torch.trapezoid((aligned_predictions - targets)**2 * mask, x_axis = energy_grid)
+    convolution_pad = torch.zeros_like(predictions)
+    padded_predictions = torch.hstack([convolution_pad, predictions, convolution_pad])
+
+Then, the loss function uses convolutions to find the continuous region in the padded_predictions that minimizes the loss when compared against the target. The loss is only defined on the region where the loss is a minimum, achieving shift invariance. At this step, the loss is defined as an integrated loss on the masked values
+
+.. code-block:: python
+
+    masked_DOS_loss = torch.trapezoid((padded_predictions[start:end] - targets)**2 * mask)
+
+
+Afterwards, the continuous regions in the predictions where the loss is a minimum is obtained and two additional components of the loss function is calculated:
 
 - an integrated loss on the gradient of the *unmasked* DOS values, to ensure that values outside the masked region are also learned smoothly
 
@@ -209,7 +219,7 @@ Each component can be weighted independently to tailor the loss function to spec
 .. code-block:: python
 
     loss = (masked_DOS_loss +
-            grad_weight * unmasked_gradient_loss +
+            grad_penalty_weight  * unmasked_gradient_loss +
             int_weight * masked_cumulative_DOS_loss)
 
 To use this loss function, you can refer to this code snippet for the ``loss`` section in your YAML configuration file:
@@ -217,17 +227,14 @@ To use this loss function, you can refer to this code snippet for the ``loss`` s
 .. code-block:: yaml
 
     loss:
-      mtt::dos:
-        type: "masked_dos"
-        grad_weight: 1e-4
+      mtt::target_name:
+        type: "shift_agnostic_mse"
+        grad_penalty_weight : 1e-4
         int_weight: 2.0
-        extra_targets: 200
         reduction: "mean"
 
-:param name: key for the dos in the prediction/target dictionary. (mtt::dos in this case)
-:param grad_weight: Multiplier for the gradient of the unmasked DOS component.
+:param grad_penalty_weight : Multiplier for the gradient of the unmasked DOS component.
 :param int_weight: Multiplier for the cumulative DOS component.
-:param extra_targets: Number of extra targets predicted by the model.
 :param reduction: reduction mode for torch loss. Options are "mean", "sum", or "none".
 
 The values used in the above example are the ones used for PETMADDOS training and can be a reasonable starting point for other applications.

--- a/docs/src/concepts/loss-functions.rst
+++ b/docs/src/concepts/loss-functions.rst
@@ -182,6 +182,7 @@ Shift Agnostic MSE Loss Function
 The shift agnostic MSE loss function is a specialized loss function designed for training on targets where the reference is not fixed. The loss function also supports masking by setting the target where the loss should not be computed as nan. The mask is then generated on-the-fly using:
 
 .. code-block:: python
+
     mask = (~torch.isnan(target)).float()
 
 An example of such a target is the electronic density of states (DOS), where the energy reference is not well defined and there are regions on the energy grid where the DOS is not well-defined due to truncation introduced during electronic structure computations. The loss function achieves shift invariance by first padding the model predictions as follows

--- a/docs/src/concepts/loss-functions.rst
+++ b/docs/src/concepts/loss-functions.rst
@@ -134,6 +134,7 @@ Generally, each loss-function term accepts the following parameters:
 
 :param type: This controls the type of loss to be used. The default value is ``mse``, and other standard options are ``mae`` and ``huber``, which implement the equivalent PyTorch loss functions `MSELoss <https://docs.pytorch.org/docs/stable/generated/torch.nn.MSELoss.html>`_, `L1Loss <https://docs.pytorch.org/docs/stable/generated/torch.nn.L1Loss.html>`_, and `HuberLoss <https://docs.pytorch.org/docs/stable/generated/torch.nn.HuberLoss.html>`_, respectively.
    There are also "masked" versions of these losses, which are useful when using padded targets with values that should be masked before computing the loss. The masked losses are named ``masked_mse``, ``masked_mae``, and ``masked_huber``.
+   All loss types implemented in ``metatrain`` are registered in the :class:`~metatrain.utils.loss.LossType` enumeration, which can be used as a reference for available options.
 :param ``weight``: This controls the weighting of different contributions to the loss (e.g., energy, forces, virial, etc.). The default value of 1.0 for all targets works well for most datasets, but can be adjusted if required.
 :param ``reduction``: This controls how the overall loss is computed across batches. The default for this is to use the ``mean`` of the batch losses. The ``sum`` function is also supported.
 
@@ -221,6 +222,8 @@ To use this loss function, you can refer to this code snippet for the ``loss`` s
         reduction: "mean"
 
 The values used in the above example are the ones used for PETMADDOS training and can be a reasonable starting point for other applications.
+
+See :class:`~metatrain.utils.loss.ShiftAgnosticMSE` for more details on the implementation and parameters of this loss function.
 
 Ensemble Loss Function
 ----------------------

--- a/examples/1-advanced/07-dos-training.py
+++ b/examples/1-advanced/07-dos-training.py
@@ -120,11 +120,8 @@ ase.io.write("DOS.xyz", structures)
 
 # We disable composition contributions because it is difficult to fit the DOS
 # using a composition model, accounting for the ill-defined energy reference of
-# the DOS. ``scale_targets`` is also set to false because it does not support masks.
-# For details regarding the parameters of the loss function, please refer
-# to the :ref:`masked dos loss function <dos-loss>` documentation. Additionally,
-# the mask should be provided as extra data and share the same name as the target
-# DOS with a "_mask" suffix. Due to the small dataset in this example, we set the
+# the DOS. For the same reason, we set ``scale_targets`` to ``False``.
+# Due to the small dataset in this example, we set the
 # validation set to be identical to the train set. In practice, you should use a
 # separate validation set or set it as a fraction of the training set.
 

--- a/examples/1-advanced/07-dos-training.py
+++ b/examples/1-advanced/07-dos-training.py
@@ -4,9 +4,9 @@ Training a DOS model
 
 This tutorial demonstrates how to train a model for the prediction
 of the electronic density of states (DOS), while accounting for the unique properties
-of the DOS using the :ref:`masked dos loss function <dos-loss>`. This procedure can be
-used to train PET-MAD-DOS, a universal model for the electronic density
-of states. (https://arxiv.org/abs/2508.17418)
+of the DOS using the :ref:`Shift Agnostic MSE loss function <shift-agnostic-loss>`.
+This procedure can be used to train PET-MAD-DOS, a universal model for the
+electronic density of states. (https://arxiv.org/abs/2508.17418)
 """
 
 # %%


### PR DESCRIPTION
Updated the documentation to describe the shift agnostic MSE loss function, including its components and usage in YAML configuration.



<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1160.org.readthedocs.build/en/1160/

<!-- readthedocs-preview metatrain end -->