### PR TITLE
Constrain sphericart until 2.0.0 works with docs.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ build-backend = "setuptools.build_meta"
 [project.optional-dependencies]
 soap-bpnn = [
     "torch-spex>=0.1,<0.2",
+    'sphericart-torch < 2.0.0', # 2.0.0 breaks the docs with "module 'sphericart.torch' has no attribute '_lib_path'"
     'sphericart-torch == 1.0.8 ; platform_system == "Windows"', # for some reason sphericart-torch 1.0.9 can't load on windows
     "wigners",
 ]


### PR DESCRIPTION
With the new release of sphericart, docs are failing: https://github.com/metatensor/metatrain/actions/runs/27619182795/job/81863193389#step:5:118


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1162.org.readthedocs.build/en/1162/

<!-- readthedocs-preview metatrain end -->