### PR TITLE
Only upload to HF when we are generating the 32-bit model

### DIFF
--- a/tests/resources/run_trainings.sh
+++ b/tests/resources/run_trainings.sh
@@ -67,7 +67,8 @@ if [[ -n "${HUGGINGFACE_TOKEN_METATRAIN:-}" ]]; then
 fi
 set -x
 
-if [ $TOKEN_PRESENT = true ]; then
+if [ $TOKEN_PRESENT = true  && "$MODE" == "32-bit"]; then
+    # Upload model checkpoint 
     hf upload \
         "metatensor/metatrain-test" \
         "model-32-bit-$TRAIN_ID.ckpt" \


### PR DESCRIPTION
Many CSCS jobs are failing because of hugging-face rate limits when uploading the test checkpoint.

We thought about retrying the upload and even not uploading at all, but I just realised that we are trying to upload the 32-bit model everytime that we generate a model. So maybe calling the upload only when generating the 32-bit model already solves the problem, let's see.


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1163.org.readthedocs.build/en/1163/

<!-- readthedocs-preview metatrain end -->