### PR TITLE
Fix flashmd_symplectic requested input names

### DIFF
--- a/src/metatrain/experimental/flashmd_symplectic/model.py
+++ b/src/metatrain/experimental/flashmd_symplectic/model.py
@@ -276,10 +276,10 @@ class FlashMDSymplectic(ModelInterface):
 
     def requested_inputs(self) -> Dict[str, ModelOutput]:
         return {
-            "momenta": ModelOutput(
+            "momentum": ModelOutput(
                 quantity="momentum", unit="(eV*u)^(1/2)", sample_kind="atom"
             ),
-            "masses": ModelOutput(quantity="mass", unit="u", sample_kind="atom"),
+            "mass": ModelOutput(quantity="mass", unit="u", sample_kind="atom"),
         }
 
     def forward(


### PR DESCRIPTION
## Problem

The `flashmd_symplectic` model declares its requested inputs with the deprecated `momenta`/`masses` names:

```python
def requested_inputs(self) -> Dict[str, ModelOutput]:
    return {
        "momenta": ModelOutput(quantity="momentum", ...),
        "masses": ModelOutput(quantity="mass", ...),
    }
```

but its `forward` reads the new names via the shared `flashmd.modules.structures` helper:

```python
if "momentum" not in system.known_data():
    raise ValueError("System does not contain momentum data, which is required for FlashMD.")
tmap = system.get_data("momentum")
```

`metatomic` only guarantees that the *requested* name is present on the `System`. When an engine provides the deprecated `momenta`, metatomic sees the requested `momenta` already present and never bridges in `momentum`, so the model raises:

```
ValueError: System does not contain momentum data, which is required for FlashMD.
```

The regular `flashmd` architecture already requests `momentum`/`mass`, which is why it works (metatomic bridges the engine-provided `momenta` → `momentum`).

## Fix

Request `momentum`/`mass` in `flashmd_symplectic`, matching its `forward` and the `flashmd` architecture. `metatomic` then bridges deprecated names provided by engines to the new ones the model consumes.

## Verification

- `flashmd_symplectic` `test_torchscript.py` + `test_functionality.py` pass.
- Downstream `flashmd` (`lab-cosmo/flashmd`) `test_symplectic.py` passes against a fresh export from this branch, with no downstream workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1174.org.readthedocs.build/en/1174/

<!-- readthedocs-preview metatrain end -->