### PR TITLE
Add possibility to avoid warm up in mtt eval

### DIFF
--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -30,6 +30,8 @@ Fixed
 Added
 #####
 
+- Possibility to avoid warm-up in ``mtt eval`` with the ``--no-warm-up`` flag.
+
 Changed
 #######
 

--- a/src/metatrain/cli/eval.py
+++ b/src/metatrain/cli/eval.py
@@ -120,11 +120,11 @@ def _add_eval_model_parser(subparser: argparse._SubParsersAction) -> None:
         dest="warm_up",
         default=True,
         help=(
-            "whether to do a warm-up of the model before evaluation (default: %(default)s)."
-            " The warm-up is done by running 10 model evaluations. "
-            "This will give timings that are more representative of the model's performance"
-            "on a large dataset. However, it will delay evaluation, which might be undesirable"
-            "for expensive evaluations. "
+            "whether to do a warm-up of the model before evaluation "
+            "(default: %(default)s). The warm-up is done by running 10 "
+            "model evaluations. This will give timings that are more representative "
+            "of the model's performance on a large dataset. However, it will delay "
+            "evaluation, which might be undesirable for expensive evaluations."
         ),
     )
 

--- a/src/metatrain/cli/eval.py
+++ b/src/metatrain/cli/eval.py
@@ -114,6 +114,19 @@ def _add_eval_model_parser(subparser: argparse._SubParsersAction) -> None:
         action="store_true",
         help="whether to run consistency checks (default: %(default)s)",
     )
+    parser.add_argument(
+        "--warm-up",
+        action=argparse.BooleanOptionalAction,
+        dest="warm_up",
+        default=True,
+        help=(
+            "whether to do a warm-up of the model before evaluation (default: %(default)s)."
+            " The warm-up is done by running 10 model evaluations. "
+            "This will give timings that are more representative of the model's performance"
+            "on a large dataset. However, it will delay evaluation, which might be undesirable"
+            "for expensive evaluations. "
+        ),
+    )
 
 
 def _prepare_eval_model_args(args: argparse.Namespace) -> None:
@@ -136,6 +149,7 @@ def _eval_targets(
     batch_size: int = 1,
     check_consistency: bool = False,
     writer: Optional[Writer] = None,
+    warm_up: bool = True,
 ) -> None:
     """
     Evaluate `model` on `dataset`, accumulate RMSE/MAE, and (if `writer` is provided)
@@ -147,6 +161,7 @@ def _eval_targets(
     :param batch_size: Batch size for evaluation.
     :param check_consistency: Whether to run consistency checks during model evaluation.
     :param writer: Optional writer to write out per-sample predictions.
+    :param warm_up: Whether to do a warm-up of the model before evaluation.
     """
     # Disable static fusion. Besides the fact that atomistic batches have variable
     # sizes, statically fused CUDA kernels cannot allocate new tensors at runtime,
@@ -191,17 +206,18 @@ def _eval_targets(
     mae_acc = MAEAccumulator()
 
     # Warm-up
-    cycled = itertools.cycle(dataloader)
-    for _ in range(10):
-        batch = unpack_batch(next(cycled))
-        systems = [system.to(device=device, dtype=dtype) for system in batch[0]]
-        evaluate_model(
-            model,
-            systems,
-            options,
-            is_training=False,
-            check_consistency=check_consistency,
-        )
+    if warm_up:
+        cycled = itertools.cycle(dataloader)
+        for _ in range(10):
+            batch = unpack_batch(next(cycled))
+            systems = [system.to(device=device, dtype=dtype) for system in batch[0]]
+            evaluate_model(
+                model,
+                systems,
+                options,
+                is_training=False,
+                check_consistency=check_consistency,
+            )
 
     total_time = 0.0
     timings_per_atom = []
@@ -275,6 +291,7 @@ def eval_model(
     batch_size: int = 1,
     check_consistency: bool = False,
     append: Optional[bool] = None,
+    warm_up: bool = True,
 ) -> None:
     """
     Evaluate an exported model on a given data set.
@@ -289,6 +306,7 @@ def eval_model(
     :param batch_size: Batch size for evaluation.
     :param check_consistency: Whether to run consistency checks during model evaluation.
     :param append: If ``True``, open the output file in append mode.
+    :param warm_up: Whether to do a warm-up of the model before evaluation.
     """
     logging.info("Setting up evaluation set.")
     output = Path(output) if isinstance(output, str) else output
@@ -356,6 +374,7 @@ def eval_model(
                 batch_size=batch_size,
                 check_consistency=check_consistency,
                 writer=writer,
+                warm_up=warm_up,
             )
         except Exception as e:
             raise ArchitectureError(e)

--- a/src/metatrain/cli/eval.py
+++ b/src/metatrain/cli/eval.py
@@ -207,6 +207,7 @@ def _eval_targets(
 
     # Warm-up
     if warm_up:
+        logging.info("Warming up the model with 10 batches...")
         cycled = itertools.cycle(dataloader)
         for _ in range(10):
             batch = unpack_batch(next(cycled))
@@ -218,6 +219,8 @@ def _eval_targets(
                 is_training=False,
                 check_consistency=check_consistency,
             )
+    else:
+        logging.info("Skipping warm-up of the model.")
 
     total_time = 0.0
     timings_per_atom = []

--- a/tests/cli/test_eval_model.py
+++ b/tests/cli/test_eval_model.py
@@ -31,6 +31,7 @@ def model(MODEL_PATH):
 def options():
     return OmegaConf.load(EVAL_OPTIONS_PATH)
 
+
 @pytest.mark.parametrize("warm_up", [True, False])
 def test_eval_cli(monkeypatch, tmp_path, MODEL_PATH, warm_up):
     """Test succesful run of the eval script via the CLI with default arguments"""
@@ -63,7 +64,7 @@ def test_eval_cli(monkeypatch, tmp_path, MODEL_PATH, warm_up):
         raise RuntimeError(
             "Failed to evaluate model via CLI. Logs should be printed above."
         )
-    
+
     log_text = result.stdout.decode()
 
     assert "100%|██████████" in log_text

--- a/tests/cli/test_eval_model.py
+++ b/tests/cli/test_eval_model.py
@@ -31,8 +31,8 @@ def model(MODEL_PATH):
 def options():
     return OmegaConf.load(EVAL_OPTIONS_PATH)
 
-
-def test_eval_cli(monkeypatch, tmp_path, MODEL_PATH):
+@pytest.mark.parametrize("warm_up", [True, False])
+def test_eval_cli(monkeypatch, tmp_path, MODEL_PATH, warm_up):
     """Test succesful run of the eval script via the CLI with default arguments"""
     monkeypatch.chdir(tmp_path)
     shutil.copy(RESOURCES_PATH / "qm9_reduced_100.xyz", "qm9_reduced_100.xyz")
@@ -46,6 +46,8 @@ def test_eval_cli(monkeypatch, tmp_path, MODEL_PATH):
         str(MODEL_PATH.parent / "extensions"),
         "--check-consistency",
     ]
+    if not warm_up:
+        command.append("--no-warm-up")
 
     result = subprocess.run(
         command,
@@ -61,9 +63,21 @@ def test_eval_cli(monkeypatch, tmp_path, MODEL_PATH):
         raise RuntimeError(
             "Failed to evaluate model via CLI. Logs should be printed above."
         )
+    
+    log_text = result.stdout.decode()
 
-    assert "100%|██████████" in result.stdout.decode()
-    assert "energy RMSE" in result.stdout.decode()
+    assert "100%|██████████" in log_text
+    assert "energy RMSE" in log_text
+
+    # Check that the warm-up flag is correctly used
+    warm_up_str = "Warming up the model with 10 batches..."
+    no_warm_up_str = "Skipping warm-up of the model."
+    if warm_up:
+        assert warm_up_str in log_text
+        assert no_warm_up_str not in log_text
+    else:
+        assert warm_up_str not in log_text
+        assert no_warm_up_str in log_text
 
     assert Path("output.xyz").is_file()
 


### PR DESCRIPTION
For expensive models, waiting for the warm up is a bit annoying, specially if you don't care about the timings.

This PR adds an argument to the `mtt eval` parser to avoid the warm up run.

If you agree this is fine I will add tests and documentation.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1179.org.readthedocs.build/en/1179/

<!-- readthedocs-preview metatrain end -->