### PR TITLE
DiskDataset: avoid confusing error on garbage collection

### DIFF
--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -831,7 +831,7 @@ class DiskDataset(torch.utils.data.Dataset):
         return target_info_dict
 
     def __del__(self) -> None:
-        if self.zip_file is not None:
+        if hasattr(self, "zip_file") and self.zip_file is not None:
             self.zip_file.close()
 
 


### PR DESCRIPTION
Sometimes when there is an error in metatrain, python tries to delete the disk dataset before an `ArchitectureError` is raised. If the disk dataset was not properly initialized this raises an error of the `zip_file` attribute not existing, which hides the real error.

I was tired of getting this :)


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1186.org.readthedocs.build/en/1186/

<!-- readthedocs-preview metatrain end -->