### PR TITLE
sanitize per-atom property names for ASE writer

### DIFF
--- a/src/metatrain/utils/data/writers/ase.py
+++ b/src/metatrain/utils/data/writers/ase.py
@@ -125,7 +125,8 @@ class ASEWriter(Writer):
 
             # assign arrays
             for array_name, array in arrays.items():
-                atoms.arrays[array_name] = array
+                clean_array_name = array_name.replace("::", "_")
+                atoms.arrays[clean_array_name] = array
 
             frames.append(atoms)
 


### PR DESCRIPTION
This PR sanitizes per-atom property names before writing to an ASE-compatible XYZ file. It fixes a bug where double colons (`::`) cause the ASE native reader to break.

Closes #1185



# Contributor (creator of pull-request) checklist

# Contributor (creator of pull-request) checklist

- [ ] Tests updated (for new features and bugfixes)?
- [ ] Documentation updated (for new features)?
- [x] Issue referenced (for PRs that solve an issue)?

# Maintainer/Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1187.org.readthedocs.build/en/1187/

<!-- readthedocs-preview metatrain end -->