### PR TITLE
Fix bug for metrics that are 0

### DIFF
--- a/src/metatrain/utils/logging.py
+++ b/src/metatrain/utils/logging.py
@@ -347,9 +347,12 @@ def _get_digits(value: float) -> Tuple[int, int]:
     :return: A tuple with the total number of characters and the number of digits
         after the decimal point.
     """
-
     # Get order of magnitude of the value:
-    order = int(np.floor(np.log10(value)))
+    if value != 0:
+        order = int(np.floor(np.log10(value)))
+    else:
+        # Avoid log10(0) error
+        order = 0
 
     # Get the number of digits before the decimal point:
     if order < 0:

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -357,6 +357,7 @@ def test_metric_logger(caplog, monkeypatch, tmp_path):
             "loss": 0.1,
             "baz": 1e-5,
             "energy RMSE": 1.0,
+            "energy MAE": 0.0,
             "energy_positions_gradients MAE": 0.5,
             "mtt::foo RMSE": 1.0,
             "mtt::bar RMSE": 0.1,
@@ -386,6 +387,7 @@ def test_metric_logger(caplog, monkeypatch, tmp_path):
     assert "train loss: 1.000e-01 | " in caplog.text
     assert "train baz: 1.000e-05 | " in caplog.text
     assert "train energy RMSE: 1000.0 meV | " in caplog.text
+    assert "train energy MAE: 0.0000 meV | " in caplog.text
     assert "train energy_positions_gradients MAE: 500.00 meV/A | " in caplog.text
     assert "train mtt::bar RMSE: 0.10000 hartree | " in caplog.text
     assert "train mtt::foo RMSE: 1000.0 meV" in caplog.text  # eV converted to meV
@@ -402,16 +404,18 @@ def test_metric_logger(caplog, monkeypatch, tmp_path):
         "train loss",
         "train baz",
         "train energy RMSE",
+        "train energy MAE",
         "train energy_positions_gradients MAE",
         "train mtt::bar RMSE",
         "train mtt::foo RMSE",
     ]
-    assert rows[1] == ["", "", "", "meV", "meV/A", "hartree", "meV"]
+    assert rows[1] == ["", "", "", "meV", "meV", "meV/A", "hartree", "meV"]
     assert rows[2] == [
         "   1",
         "1.000e-01",
         "1.000e-05",
         "1000.0",
+        "0.0000",
         "500.00",
         "0.10000",
         "1000.0",


### PR DESCRIPTION
When the metric was exactly 0, np.log10(0) was raising an error.

Only very lucky people would have seen this bug :)


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1190.org.readthedocs.build/en/1190/

<!-- readthedocs-preview metatrain end -->