### PR TITLE
Avoid reindexing atomic-basis targets to batch-local system ids

### DIFF
--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -34,11 +34,12 @@ Added
 - Optional per-system charge and spin-multiplicity conditioning for PET. Enabled via the
   ``system_conditioning`` model hyperparameter, with per-system ``charge`` and
   ``spin_multiplicity`` provided as ``extra_data``.
-- Avoid reindexing of spherical atomic basis targets during densification and
-  padding of atomic types.
 
 Changed
 #######
+
+- Avoid reindexing of spherical atomic basis targets during densification and
+  padding of atomic types.
 
 Removed
 #######

--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -34,6 +34,8 @@ Added
 - Optional per-system charge and spin-multiplicity conditioning for PET. Enabled via the
   ``system_conditioning`` model hyperparameter, with per-system ``charge`` and
   ``spin_multiplicity`` provided as ``extra_data``.
+- Avoid reindexing of spherical atomic basis targets during densification and 
+  padding of atomic types.
 
 Changed
 #######

--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -34,7 +34,7 @@ Added
 - Optional per-system charge and spin-multiplicity conditioning for PET. Enabled via the
   ``system_conditioning`` model hyperparameter, with per-system ``charge`` and
   ``spin_multiplicity`` provided as ``extra_data``.
-- Avoid reindexing of spherical atomic basis targets during densification and 
+- Avoid reindexing of spherical atomic basis targets during densification and
   padding of atomic types.
 
 Changed

--- a/src/metatrain/utils/data/atomic_basis_helpers.py
+++ b/src/metatrain/utils/data/atomic_basis_helpers.py
@@ -12,60 +12,26 @@ from .target_info import TargetInfo
 # ===== General utilities
 
 
-def reindex_to_batch_index(
-    tensor: TensorMap,
-    system_ids: torch.tensor,
-) -> TensorMap:
-    """
-    Reindex the system ids in the samples of the blocks of the tensor to have batch ids.
-
-    :param tensor: the input TensorMap with system ids in the samples to reindex.
-    :param system_ids: Tensor containing the actual system ids for each sample in the
-        input ``tensor``.
-
-    :return: the output TensorMap with batch ids in the samples instead of system ids.
-    """
-    id_mapping = torch.ones(system_ids.max().item() + 1, dtype=int) * -1
-    for new_id, old_id in enumerate(system_ids):
-        id_mapping[old_id] = new_id
-
-    blocks = []
-    for block in tensor:
-        system_ids = block.samples.values[:, 0]
-        batch_id = id_mapping[system_ids]
-        block = TensorBlock(
-            samples=Labels(
-                block.samples.names,
-                torch.hstack(
-                    [
-                        batch_id.reshape(-1, 1),
-                        block.samples.values[:, 1:],
-                    ]
-                ),
-            ),
-            components=block.components,
-            properties=block.properties,
-            values=block.values,
-        )
-        blocks.append(block)
-    return TensorMap(tensor.keys, blocks)
-
-
 def get_per_atom_sample_labels(
     systems: List[System],
+    system_ids: torch.Tensor,
 ) -> Labels:
     """
-    Builds the atom sample labels for the input ``systems``, assuming the systems have a
-    batch index (0, ..., n_batch - 1).
+    Builds the atom sample labels for the input ``systems``, labelling each system's
+    atoms with the corresponding entry of ``system_ids`` (rather than assuming the
+    systems have a local batch index 0, ..., n_batch - 1), so the result can be matched
+    directly against a target's own, native "system" sample values.
 
     :param systems: List of systems to build the per-atom sample labels for.
+    :param system_ids: the "system" label value for each system, in the same order as
+        ``systems``.
     :return: The per-atom sample labels.
     """
     system_indices = torch.concatenate(
         [
             torch.full(
                 (len(system),),
-                i_system,
+                int(system_ids[i_system]),
                 device=systems[0].device,
             )
             for i_system, system in enumerate(systems)
@@ -236,8 +202,9 @@ def densify_atomic_basis_target(
 def _pad_samples_per_atom_atomic_basis_target(
     systems: List[System],
     tensor: TensorMap,
+    system_ids: torch.Tensor,
 ) -> TensorMap:
-    sample_labels = get_per_atom_sample_labels(systems)
+    sample_labels = get_per_atom_sample_labels(systems, system_ids)
     new_blocks = []
     for block in tensor:
         new_vals = torch.full(
@@ -261,6 +228,7 @@ def _pad_samples_per_atom_atomic_basis_target(
 def pad_samples_atomic_basis_target(
     systems: List[System],
     tensor: TensorMap,
+    system_ids: torch.Tensor,
 ) -> TensorMap:
     """
     Pad the samples of the atomic basis target to have the same number of samples for
@@ -268,12 +236,14 @@ def pad_samples_atomic_basis_target(
 
     :param systems: List of systems in the batch
     :param tensor: the atomic basis target TensorMap to pad.
+    :param system_ids: the "system" label value for each system, in the same order as
+        ``systems``, matching the tensor's own native "system" sample values.
 
     :return: the padded atomic basis target TensorMap
     """
 
     if "atom" in tensor.sample_names:
-        return _pad_samples_per_atom_atomic_basis_target(systems, tensor)
+        return _pad_samples_per_atom_atomic_basis_target(systems, tensor, system_ids)
     raise NotImplementedError(
         "Currently only padding of per-atom atomic basis targets is implemented."
     )
@@ -287,8 +257,8 @@ def prepare_atomic_basis_targets(
     fill_value: float = torch.nan,
 ) -> TensorMap:
     """
-    Prepare the atomic basis targets for batching by reindexing to batch ids, densifying
-    (moving "atom_type" key dimensions to the samples) and padding the samples.
+    Prepare the atomic basis targets for batching by densifying (moving "atom_type" key
+    dimensions to the samples) and padding the samples.
 
     :param systems: List of systems in the batch.
     :param system_ids: Tensor containing the system ids for each sample in the input
@@ -299,18 +269,15 @@ def prepare_atomic_basis_targets(
     :param fill_value: the value to use for filling in the padded values when densifying
         and padding. Default is NaN, but can be set to 0 if desired (e.g. for
         classification targets).
-    :return: the prepared atomic basis target TensorMap with batch ids, densified and
-        padded.
+    :return: the prepared atomic basis target TensorMap, densified and padded, keeping
+        the tensor's own native "system" ids.
     """
-
-    # Reindex to batch ids
-    tensor = reindex_to_batch_index(tensor, system_ids)
 
     # Densify: "atom type" key dimensions -> samples
     tensor = densify_atomic_basis_target(tensor, layout, fill_value)
 
-    # Pad samples
-    tensor = pad_samples_atomic_basis_target(systems, tensor)
+    # Pad samples, labelling them with the target's own native "system" ids
+    tensor = pad_samples_atomic_basis_target(systems, tensor, system_ids)
 
     return tensor
 
@@ -505,69 +472,13 @@ def sparsify_atomic_basis_target(
 # ===== dataloader transforms
 
 
-def get_reindex_to_batch_index_transform(
-    target_info_dict: dict[str, TargetInfo],
-    extra_data_info_dict: dict[str, TargetInfo],
-) -> Callable:
-    """
-    Get a function that reindexes the systems to have batch ids.
-
-    :param target_info_dict: Dictionary mapping target names to TargetInfo objects.
-    :param extra_data_info_dict: Dictionary mapping extra data names to TargetInfo
-        objects.
-
-    :return: A function that takes in systems, targets and extra data, and returns the
-        systems, targets and extra data with reindexed batch ids.
-    """
-
-    def transform(
-        systems: List[System],
-        targets: Dict[str, TensorMap],
-        extra: Dict[str, TensorMap],
-    ) -> Tuple[List[System], Dict[str, TensorMap], Dict[str, TensorMap]]:
-        """
-        Transform function that reindexes the systems to have batch ids, modifying
-        in-place. Only applied to atomic basis targets and extra data.
-
-        :param systems: List of systems.
-        :param targets: Dictionary containing the targets corresponding to the systems.
-        :param extra: Dictionary containing any extra data.
-        :return: The systems, targets and extra data with reindexed system ids.
-        """
-        assert "mtt::aux::system_index" in extra
-        for name, tensor in targets.items():
-            if name in target_info_dict and target_info_dict[name].is_atomic_basis:
-                targets[name] = reindex_to_batch_index(
-                    tensor,
-                    extra["mtt::aux::system_index"][0]
-                    .values[:, 0]
-                    .to(dtype=torch.int64),
-                )
-
-        for name, tensor in extra.items():
-            if (
-                name in extra_data_info_dict
-                and extra_data_info_dict[name].is_atomic_basis
-            ):
-                extra[name] = reindex_to_batch_index(
-                    tensor,
-                    extra["mtt::aux::system_index"][0]
-                    .values[:, 0]
-                    .to(dtype=torch.int64),
-                )
-
-        return systems, targets, extra
-
-    return transform
-
-
 def get_prepare_atomic_basis_targets_transform(
     target_info_dict: dict[str, TargetInfo],
     extra_data_info_dict: dict[str, TargetInfo],
 ) -> Tuple[Callable, Callable]:
     """
-    Get a function that prepares the atomic basis targets for batching by reindexing to
-    batch ids, densifying and padding.
+    Get a function that prepares the atomic basis targets for batching by densifying
+    and padding.
 
     :param target_info_dict: Dictionary mapping target names to TargetInfo objects.
     :param extra_data_info_dict: Dictionary mapping extra data names to TargetInfo
@@ -584,7 +495,8 @@ def get_prepare_atomic_basis_targets_transform(
     ) -> Tuple[List[System], Dict[str, TensorMap], Dict[str, TensorMap]]:
         """
         Transform function that prepares the atomic basis targets for batching by
-        reindexing to batch ids, densifying and padding, modifying in-place.
+        densifying and padding, modifying in-place. Samples keep the tensor's own
+        native "system" ids throughout.
 
         :param systems: List of systems.
         :param targets: Dictionary containing the targets corresponding to the systems.

--- a/tests/utils/data/test_atomic_basis_helpers.py
+++ b/tests/utils/data/test_atomic_basis_helpers.py
@@ -5,8 +5,12 @@ from metatomic.torch import System
 
 from metatrain.utils.data.atomic_basis_helpers import (
     densify_atomic_basis_target,
+    get_per_atom_sample_labels,
+    get_prepare_atomic_basis_targets_transform,
+    prepare_atomic_basis_targets,
     sparsify_atomic_basis_target,
 )
+from metatrain.utils.data.target_info import TargetInfo
 
 
 # ---------------------------------------------------------------------------
@@ -100,22 +104,29 @@ def _make_systems():
     ]
 
 
-def _make_sparse_tensor():
+def _make_sparse_tensor(system_ids=(0, 1)):
     """
     Construct an atomic basis spherical target in the coupled basis, per-atom, for the
     two systems from ``_make_systems()``.
 
-    Samples within each block are sorted by (system, atom) – this is the ordering that
-    densification produces, so starting from sorted samples ensures the round-trip
-    comparison is straightforward.
+    Samples within each block are ordered following ``_make_systems()`` (system 0's
+    atoms, then system 1's atoms) – this is the order that the padding step in
+    ``prepare_atomic_basis_targets`` produces, so starting from this order makes
+    round-trip comparisons straightforward.
+
+    :param system_ids: the "system" sample label value to use for system 0 and system
+        1 respectively. Defaults to ``(0, 1)``; pass non-contiguous values (e.g. ``(7,
+        2)``) to check that a target's own "system" ids are round-tripped rather than
+        assumed to be batch-local positions.
     """
+    s0, s1 = system_ids
     h_samples = Labels(
         names=["system", "atom"],
-        values=torch.tensor([[0, 0], [1, 0], [1, 1]], dtype=torch.int32),
+        values=torch.tensor([[s0, 0], [s1, 0], [s1, 1]], dtype=torch.int32),
     )
     c_samples = Labels(
         names=["system", "atom"],
-        values=torch.tensor([[0, 1], [1, 2]], dtype=torch.int32),
+        values=torch.tensor([[s0, 1], [s1, 2]], dtype=torch.int32),
     )
     l0_comp = [Labels(names=["o3_mu"], values=torch.tensor([[0]], dtype=torch.int32))]
     l1_comp = [
@@ -260,3 +271,77 @@ def test_densify_nan_padding_structure():
     c_l1_orig = torch.arange(12, dtype=torch.float64).reshape(2, 3, 2) + 300.0
     assert not torch.any(torch.isnan(l1.values[c_idx][..., :]))
     torch.testing.assert_close(l1.values[c_idx][..., :], c_l1_orig)
+
+
+def test_prepare_atomic_basis_targets_nontrivial_system_ids():
+    """
+    ``prepare_atomic_basis_targets`` (densify + pad) must label samples with a
+    target's own "system" ids, not with the position of each system within the batch.
+
+    Uses non-contiguous, non-zero-based ids (system 0 -> 7, system 1 -> 2) so that a
+    regression reintroducing an implicit reindexing to 0, ..., n-1 would be caught by
+    the exact round-trip check below, rather than just a shape/crash check.
+    """
+    system_ids = torch.tensor([7, 2])
+    layout = _make_layout_coupled_per_atom()
+    sparse = _make_sparse_tensor(system_ids=tuple(system_ids.tolist()))
+    systems = _make_systems()
+
+    prepared = prepare_atomic_basis_targets(systems, system_ids, sparse, layout)
+
+    # The padded samples must carry the target's own system ids, in the same order
+    # as `systems`/`system_ids` (not sorted, not renumbered to 0, ..., n-1).
+    expected_samples = get_per_atom_sample_labels(systems, system_ids)
+    for block in prepared.blocks():
+        assert block.samples == expected_samples
+
+    recovered = sparsify_atomic_basis_target(systems, prepared, layout)
+    mts.allclose_raise(recovered, sparse, atol=0.0, rtol=0.0)
+
+
+def test_get_prepare_atomic_basis_targets_transform_batch_from_larger_dataset():
+    """
+    ``get_prepare_atomic_basis_targets_transform`` is the actual function every
+    trainer's collate function uses. This simulates a batch of 2 drawn from a larger
+    dataset (absolute, non-adjacent "system" ids 1 and 3), built the way
+    ``metatensor_learn``'s ``group_and_join`` does: joining per-system tensors while
+    preserving each system's true absolute dataset index (not renumbering to 0, 1).
+
+    A round trip through ``transform`` then ``reverse_transform`` must recover the
+    original per-system data exactly.
+    """
+    system_ids = torch.tensor([1, 3])
+    layout = _make_layout_coupled_per_atom()
+    sparse = _make_sparse_tensor(system_ids=tuple(system_ids.tolist()))
+    systems = _make_systems()
+
+    target_info = TargetInfo(layout=layout)
+    assert target_info.is_atomic_basis
+
+    system_index_extra = TensorMap(
+        keys=Labels(names=["_"], values=torch.tensor([[0]])),
+        blocks=[
+            TensorBlock(
+                values=system_ids.reshape(-1, 1).to(torch.float64),
+                samples=Labels(names=["system"], values=system_ids.reshape(-1, 1)),
+                components=[],
+                properties=Labels(names=["_"], values=torch.tensor([[0]])),
+            )
+        ],
+    )
+
+    transform, reverse_transform = get_prepare_atomic_basis_targets_transform(
+        {"target": target_info}, {}
+    )
+
+    _, prepared, _ = transform(
+        systems,
+        {"target": sparse},
+        {"mtt::aux::system_index": system_index_extra},
+    )
+    expected_samples = get_per_atom_sample_labels(systems, system_ids)
+    for block in prepared["target"].blocks():
+        assert block.samples == expected_samples
+
+    _, recovered, _ = reverse_transform(systems, prepared, {})
+    mts.allclose_raise(recovered["target"], sparse, atol=0.0, rtol=0.0)


### PR DESCRIPTION
Atomic-basis target padding previously reindexed each target's "system" sample labels to a batch-local 0..n-1 numbering before densifying/padding, purely to satisfy a label-value match inside pad_samples_atomic_basis_target.

Padding now matches directly against each target's own native "system" values, so the reindex step is no longer needed.

Loss computation (BaseTensorMapLoss.compute_flattened) and sparsify_atomic_basis_target are purely positional and never depended on the reindexed numbering, so this is a behavior-preserving simplification.

Some dead functions (`...reindex...`) have been deleted.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - ~~[ ] Documentation updated (for new features)?~~
 - ~~[ ] Issue referenced (for PRs that solve an issue)?~~

# Maintainer/Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1191.org.readthedocs.build/en/1191/

<!-- readthedocs-preview metatrain end -->