### PR TITLE
DiskDataset now makes use of the key of targets

### DIFF
--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -38,6 +38,9 @@ Added
 Changed
 #######
 
+- The ``DiskDataset`` now uses the ``key`` option of targets (i.e. it looks for that key
+  in the dataset, instead of looking for the target name).
+
 Removed
 #######
 

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -683,11 +683,21 @@ class DiskDataset(torch.utils.data.Dataset):
 
     :param path: Path to the zip file containing the dataset.
     :param fields: List of fields to read from the dataset.
-        If None, all fields will be read.
+        If None, all fields will be read. If it is a dictionary,
+        it is treated as the target configuration, and we search for a "key"
+        entry that maps the target name to the field name in the dataset.
     """
 
-    def __init__(self, path: Union[str, Path], fields: Optional[List[str]] = None):
+    def __init__(
+        self,
+        path: Union[str, Path],
+        fields: Optional[list[str] | dict[str, Any]] = None,
+    ):
         self.zip_file_path = path
+
+        if isinstance(fields, dict):
+            fields = {options.get("key", key): key for key, options in fields.items()}
+
         self._field_names = ["system"]
         # check that we have at least one sample:
         with zipfile.ZipFile(path, "r") as zip_file:
@@ -720,7 +730,10 @@ class DiskDataset(torch.utils.data.Dataset):
 
         self._fields_to_read.append("mtt::aux::system_index")
 
-        self._sample_class = namedtuple("Sample", self._fields_to_read)
+        fields_map: dict = fields if isinstance(fields, dict) else {}
+        self._sample_class = namedtuple(
+            "Sample", [fields_map.get(field, field) for field in self._fields_to_read]
+        )
 
         # Do not open file in the main process and start sub-processes with None
         self.zip_file: Optional[zipfile.ZipFile] = None
@@ -796,7 +809,8 @@ class DiskDataset(torch.utils.data.Dataset):
                 and target["num_subtargets"] == 1
                 and target["type"] == "scalar"
             )
-            tensor_map = self[0][target_key]  # always > 0 samples, see above
+            field_key = target.get("key", target_key)
+            tensor_map = self[0][field_key]  # always > 0 samples, see above
             if is_energy:
                 if len(tensor_map) != 1:
                     raise ValueError("Energy TensorMaps should have exactly one block.")

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -718,19 +718,19 @@ class DiskDataset(torch.utils.data.Dataset):
             self._fields_to_read = self._field_names
         else:
             # Check that the requested fields are present in the dataset
-            fields = ["system", *fields]
-            missing_fields = set(fields) - set(self._field_names)
+            fields_to_read = ["system", *fields]
+            missing_fields = set(fields_to_read) - set(self._field_names)
             if missing_fields:
                 raise ValueError(
                     f"Fields {list(missing_fields)} were requested but "
                     "are not present in this disk dataset. "
                     f"Available fields: {self._field_names[1:]}"
                 )
-            self._fields_to_read = fields
+            self._fields_to_read = fields_to_read
 
         self._fields_to_read.append("mtt::aux::system_index")
 
-        fields_map: dict = fields if isinstance(fields, dict) else {}
+        fields_map = fields if isinstance(fields, dict) else {}
         self._sample_class = namedtuple(
             "Sample", [fields_map.get(field, field) for field in self._fields_to_read]
         )
@@ -809,8 +809,7 @@ class DiskDataset(torch.utils.data.Dataset):
                 and target["num_subtargets"] == 1
                 and target["type"] == "scalar"
             )
-            field_key = target.get("key", target_key)
-            tensor_map = self[0][field_key]  # always > 0 samples, see above
+            tensor_map = self[0][target_key]  # always > 0 samples, see above
             if is_energy:
                 if len(tensor_map) != 1:
                     raise ValueError("Energy TensorMaps should have exactly one block.")

--- a/src/metatrain/utils/data/get_dataset.py
+++ b/src/metatrain/utils/data/get_dataset.py
@@ -32,7 +32,7 @@ def get_dataset(
     if options["systems"]["read_from"].endswith(".zip"):  # disk dataset
         dataset = DiskDataset(
             options["systems"]["read_from"],
-            fields=[*options["targets"], *options.get("extra_data", {})],
+            fields={**options["targets"], **options.get("extra_data", {})},
         )
         target_info_dictionary = dataset.get_target_info(options["targets"])
         extra_data_info_dictionary = dataset.get_target_info(

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -1315,11 +1315,10 @@ def test_train_disk_dataset(monkeypatch, tmp_path, options):
             keys=Labels.single(),
             blocks=[energy_block],
         )
-        disk_dataset_writer.write([system], {"energy": energy})
+        disk_dataset_writer.write([system], {"U0": energy})
     disk_dataset_writer.finish()
 
     options["training_set"]["systems"]["read_from"] = "carbon.zip"
-    options["training_set"]["targets"]["energy"]["read_from"] = "carbon.zip"
     train_model(options)
 
 


### PR DESCRIPTION
Until now, the disk dataset just ignored the `key` in targets, which was confusing and sometimes even limiting when for some reason the model's target name did not match the name of the target in the dataset.

Here I make sure that the disk dataset correctly makes use of `key`.

I can't find tests for the disk dataset, do we have any? :sweat_smile: 




<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1195.org.readthedocs.build/en/1195/

<!-- readthedocs-preview metatrain end -->