### PR TITLE
Support max_atoms_per_batch for DiskDataset and make DiskDataset scale to large zips

### DIFF
--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -27,9 +27,15 @@ Unreleased
 Fixed
 #####
 
+- ``DiskDatasetWriter`` in append mode now continues the entry numbering of the
+  existing zip instead of restarting from zero.
+
 Added
 #####
 
+- ``max_atoms_per_batch`` now works with ``DiskDataset``: ``DiskDatasetWriter``
+  stores the number of atoms of every structure in a ``metadata/atom_counts.npy``
+  file, which the sampler reads without opening every entry in the zip.
 - Possibility to avoid warm-up in ``mtt eval`` with the ``--no-warm-up`` flag.
 - Optional per-system charge and spin-multiplicity conditioning for PET. Enabled via the
   ``system_conditioning`` model hyperparameter, with per-system ``charge`` and
@@ -49,6 +55,10 @@ Added
 Changed
 #######
 
+- ``DiskDataset`` reading now scales to zips with millions of files: the archive is
+  indexed once at construction and dataloader workers read from the index, instead of
+  each re-parsing the whole zip (which could take minutes and tens of GB of RAM). The
+  format is also validated at construction, with clear error messages for invalid zips.
 - The ``DiskDataset`` now uses the ``key`` option of targets (i.e. it looks for that key
   in the dataset, instead of looking for the target name).
 - Avoid reindexing of spherical atomic basis targets during densification and

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -46,50 +46,6 @@ from metatrain.utils.external_naming import to_external_name
 from metatrain.utils.units import get_gradient_units
 
 
-# The dataset-level informative files live under `metadata/`; currently only
-# the atom counts, more may be added in the future.
-ATOM_COUNTS_MEMBER = "metadata/atom_counts.npy"
-
-
-def _parse_disk_dataset_member_name(name: str) -> Optional[Tuple[int, str]]:
-    """Parse a DiskDataset zip member name into ``(entry_number, field_name)``.
-
-    Valid members are exactly ``<N>/system.mta`` and ``<N>/<field>.mts`` with
-    ``N`` an unpadded decimal number (``00/`` would silently alias ``0/``).
-
-    :param name: The zip member name.
-    :return: ``(entry, field)`` with ``field == "system"`` for the system
-        member, or ``None`` when the name is not valid DiskDataset content.
-    """
-    slash = name.find("/")
-    if slash <= 0:
-        return None
-    head = name[:slash]
-    if not head.isdigit() or (len(head) > 1 and head[0] == "0"):
-        return None
-    tail = name[slash + 1 :]
-    if "/" in tail:
-        return None
-    if tail == "system.mta":
-        return int(head), "system"
-    if tail.endswith(".mts") and len(tail) > len(".mts"):
-        return int(head), tail[: -len(".mts")]
-    return None
-
-
-def _format_member_names(names: List[str], limit: int = 10) -> str:
-    """Format a capped list of zip member names for messages.
-
-    :param names: The member names.
-    :param limit: Maximum number of names to spell out.
-    :return: The formatted list.
-    """
-    formatted = str(names[:limit])
-    if len(names) > limit:
-        formatted += f" (+{len(names) - limit} more)"
-    return formatted
-
-
 def _set(values: List[int]) -> List[int]:
     """This function just does `list(set(values))`.
 
@@ -712,6 +668,50 @@ def load_indices(indices_spec: Union[List[int], str]) -> List[int]:
         raise ValueError("Indices must be non-negative integers")
 
     return indices
+
+
+# The dataset-level informative files live under `metadata/`; currently only
+# the atom counts, more may be added in the future.
+ATOM_COUNTS_MEMBER = "metadata/atom_counts.npy"
+
+
+def _parse_disk_dataset_member_name(name: str) -> Optional[Tuple[int, str]]:
+    """Parse a DiskDataset zip member name into ``(entry_number, field_name)``.
+
+    Valid members are exactly ``<N>/system.mta`` and ``<N>/<field>.mts`` with
+    ``N`` an unpadded decimal number (``00/`` would silently alias ``0/``).
+
+    :param name: The zip member name.
+    :return: ``(entry, field)`` with ``field == "system"`` for the system
+        member, or ``None`` when the name is not valid DiskDataset content.
+    """
+    slash = name.find("/")
+    if slash <= 0:
+        return None
+    head = name[:slash]
+    if not head.isdigit() or (len(head) > 1 and head[0] == "0"):
+        return None
+    tail = name[slash + 1 :]
+    if "/" in tail:
+        return None
+    if tail == "system.mta":
+        return int(head), "system"
+    if tail.endswith(".mts") and len(tail) > len(".mts"):
+        return int(head), tail[: -len(".mts")]
+    return None
+
+
+def _format_member_names(names: List[str], limit: int = 10) -> str:
+    """Format a capped list of zip member names for messages.
+
+    :param names: The member names.
+    :param limit: Maximum number of names to spell out.
+    :return: The formatted list.
+    """
+    formatted = str(names[:limit])
+    if len(names) > limit:
+        formatted += f" (+{len(names) - limit} more)"
+    return formatted
 
 
 class _MemberScan(NamedTuple):

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -1,10 +1,12 @@
+import io
 import math
 import multiprocessing
 import os
 import warnings
 import zipfile
+import zlib
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import IO, Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import torch
@@ -42,6 +44,77 @@ from metatrain.utils.data.target_info import (
 )
 from metatrain.utils.external_naming import to_external_name
 from metatrain.utils.units import get_gradient_units
+
+
+# The dataset-level informative files live under `metadata/`; currently only
+# the atom counts, more may be added in the future.
+ATOM_COUNTS_MEMBER = "metadata/atom_counts.npy"
+
+
+def _parse_disk_dataset_member_name(name: str) -> Optional[Tuple[int, str]]:
+    """Parse a DiskDataset zip member name into ``(entry_number, field_name)``.
+
+    Valid members are exactly ``<N>/system.mta`` and ``<N>/<field>.mts`` with
+    ``N`` an unpadded decimal number (``00/`` would silently alias ``0/``).
+
+    :param name: The zip member name.
+    :return: ``(entry, field)`` with ``field == "system"`` for the system
+        member, or ``None`` when the name is not valid DiskDataset content.
+    """
+    slash = name.find("/")
+    if slash <= 0:
+        return None
+    head = name[:slash]
+    if not head.isdigit() or (len(head) > 1 and head[0] == "0"):
+        return None
+    tail = name[slash + 1 :]
+    if "/" in tail:
+        return None
+    if tail == "system.mta":
+        return int(head), "system"
+    if tail.endswith(".mts") and len(tail) > len(".mts"):
+        return int(head), tail[: -len(".mts")]
+    return None
+
+
+if hasattr(os, "pread"):
+
+    def _read_at(handle: IO[bytes], n: int, offset: int) -> bytes:
+        """Read ``n`` bytes at ``offset`` without moving the shared position,
+        so concurrent reads from one process cannot interleave.
+
+        :param handle: Open binary file handle.
+        :param n: Number of bytes to read.
+        :param offset: Absolute offset to read at.
+        :return: The bytes read.
+        """
+        return os.pread(handle.fileno(), n, offset)
+
+else:  # pragma: no cover (Windows: os.pread is Unix-only)
+
+    def _read_at(handle: IO[bytes], n: int, offset: int) -> bytes:
+        """Windows fallback (no ``os.pread``): plain seek and read.
+
+        :param handle: Open binary file handle.
+        :param n: Number of bytes to read.
+        :param offset: Absolute offset to read at.
+        :return: The bytes read.
+        """
+        handle.seek(offset)
+        return handle.read(n)
+
+
+def _format_member_names(names: List[str], limit: int = 10) -> str:
+    """Format a capped list of zip member names for messages.
+
+    :param names: The member names.
+    :param limit: Maximum number of names to spell out.
+    :return: The formatted list.
+    """
+    formatted = str(names[:limit])
+    if len(names) > limit:
+        formatted += f" (+{len(names) - limit} more)"
+    return formatted
 
 
 def _set(values: List[int]) -> List[int]:
@@ -702,23 +775,122 @@ class DiskDataset(torch.utils.data.Dataset):
             fields = {options.get("key", key): key for key, options in fields.items()}
 
         self._field_names = ["system"]
-        # check that we have at least one sample:
+        # Parse the zip's central directory once, into compact numpy arrays
+        # of member locations. Opening a zipfile.ZipFile per process instead
+        # does not scale: it materializes one Python object per member (about
+        # 10 GB of RAM and 80 s for a zip with 13 million members), repeated
+        # in every dataloader worker. __getitem__ reads members directly at
+        # these offsets instead.
+        #
+        # The entry members `<N>/system.mta` and `<N>/<field>.mts` must be
+        # STORED (uncompressed) and are validated strictly; any other file is
+        # ignored with a single warning below. A zip of a dataset folder made
+        # with standard tools (from inside the folder, without compression)
+        # therefore works like DiskDatasetWriter output. Directory entries
+        # are skipped silently.
         with zipfile.ZipFile(path, "r") as zip_file:
-            namelist = zip_file.namelist()
-            if "0/system.mta" not in namelist:
-                raise ValueError(
-                    "Could not find `0/system.mta` in the zip file. "
-                    "The dataset format might be wrong, or the dataset might be empty. "
-                    "Empty disk datasets are not supported."
+            infos = zip_file.infolist()
+            n_members = len(infos)
+            member_entries = np.full(n_members, -1, dtype=np.int64)
+            member_offsets = np.empty(n_members, dtype=np.int64)
+            member_sizes = np.empty(n_members, dtype=np.int64)
+            member_crcs = np.empty(n_members, dtype=np.int64)
+            member_field_ids = np.full(n_members, -1, dtype=np.int64)
+            field_ids: Dict[str, int] = {}
+            ignored_names: List[str] = []
+            has_atom_counts = False
+            for i, info in enumerate(infos):
+                name = info.filename
+                if name == ATOM_COUNTS_MEMBER:
+                    has_atom_counts = True
+                    continue
+                if info.is_dir():
+                    continue
+                parsed = _parse_disk_dataset_member_name(name)
+                if parsed is None:
+                    ignored_names.append(name)
+                    continue
+                if info.compress_type != zipfile.ZIP_STORED:
+                    raise ValueError(
+                        f"'{path}' is not a valid DiskDataset zip: member "
+                        f"'{name}' is compressed. DiskDataset zips must be "
+                        "uncompressed (STORED); re-create the zip without "
+                        "compression, e.g. `zip -rX -Z store <dataset>.zip .` "
+                        "from inside the dataset folder."
+                    )
+                if info.flag_bits & 0x1:
+                    raise ValueError(
+                        f"'{path}' is not a valid DiskDataset zip: member "
+                        f"'{name}' is encrypted."
+                    )
+                entry, field = parsed
+                member_entries[i] = entry
+                member_offsets[i] = info.header_offset
+                member_sizes[i] = info.file_size
+                member_crcs[i] = info.CRC
+                member_field_ids[i] = field_ids.setdefault(field, len(field_ids))
+            self._field_names += [f for f in field_ids if f != "system"]
+
+            if "system" not in field_ids:
+                message = (
+                    "Could not find any `<N>/system.mta` member in the zip file. "
+                    "The dataset format might be wrong, or the dataset might be "
+                    "empty. Empty disk datasets are not supported."
                 )
-            for file_name in namelist:
-                if file_name.startswith("0/") and file_name.endswith(".mts"):
-                    self._field_names.append(file_name[2:-4])
-            self._len = len([f for f in namelist if f.endswith(".mta")])
+                if ignored_names:
+                    message += (
+                        " The zip does contain members that are not part of the "
+                        f"format: {_format_member_names(ignored_names)}."
+                    )
+                    first_component = ignored_names[0].split("/", 1)[0]
+                    if all(n.startswith(f"{first_component}/") for n in ignored_names):
+                        message += (
+                            " They all share the prefix "
+                            f"'{first_component}/'; if you zipped a dataset "
+                            "folder from outside, re-create the zip from inside "
+                            f"it: `cd {first_component} && zip -rX -Z store "
+                            "../<dataset>.zip .`"
+                        )
+                raise ValueError(message)
+            entry_numbers = member_entries[member_field_ids == field_ids["system"]]
+            # Entries are read positionally as "0/", "1/", ...: require exactly
+            # the dense range, and fail loudly on duplicated entry names (e.g.
+            # produced by appending with an older, buggy DiskDatasetWriter that
+            # restarted indexing at 0 -- reading those would silently return
+            # the last-written copy) or on gaps.
+            if not np.array_equal(
+                np.sort(entry_numbers), np.arange(len(entry_numbers))
+            ):
+                raise ValueError(
+                    "This DiskDataset zip file does not contain a dense range of "
+                    "entries `0/`, `1/`, ...: it has gaps or duplicated entry "
+                    "numbers and cannot be read reliably; re-write the dataset."
+                )
+            self._len = len(entry_numbers)
+
+            # Optional atom-count file (written by DiskDatasetWriter), keyed by
+            # sample index. Lets get_num_atoms()/get_all_atom_counts() below answer
+            # without opening/deserializing every system, which is what makes this
+            # dataset usable with MaxAtomDistributedBatchSampler.
+            self._atom_counts: Optional[np.ndarray] = None
+            if has_atom_counts:
+                with zip_file.open(ATOM_COUNTS_MEMBER, "r") as f:
+                    atom_counts = np.load(f)
+                if len(atom_counts) >= self._len:
+                    self._atom_counts = atom_counts[: self._len].astype(
+                        np.int64, copy=False
+                    )
+                else:
+                    warnings.warn(
+                        f"Ignoring '{ATOM_COUNTS_MEMBER}' in this DiskDataset: "
+                        f"it has {len(atom_counts)} entries, fewer than the "
+                        f"{self._len} samples found. It is likely stale.",
+                        stacklevel=2,
+                    )
 
         # Determine which fields are going to be read
         if fields is None:
-            self._fields_to_read = self._field_names
+            self._fields_to_read = self._field_names.copy()
         else:
             # Check that the requested fields are present in the dataset
             fields_to_read = ["system", *fields]
@@ -738,8 +910,60 @@ class DiskDataset(torch.utils.data.Dataset):
             "Sample", [fields_map.get(field, field) for field in self._fields_to_read]
         )
 
+        # Per-(entry, field) member locations, over ALL fields present in the
+        # zip: (header_offset, file_size, crc32). This is the only zip metadata
+        # workers need to read samples.
+        self._member_cols: Dict[str, int] = {
+            f: c for c, f in enumerate(self._field_names)
+        }
+        locs = np.full((self._len, len(self._field_names), 3), -1, dtype=np.int64)
+        for field_name, col in self._member_cols.items():
+            # entries are the dense range 0..N-1, so they index rows directly
+            mask = (member_field_ids == field_ids[field_name]) & (
+                member_entries < self._len
+            )
+            rows = member_entries[mask]
+            sel = np.flatnonzero(mask)
+            locs[rows, col, 0] = member_offsets[sel]
+            locs[rows, col, 1] = member_sizes[sel]
+            locs[rows, col, 2] = member_crcs[sel]
+        self._member_locs = locs
+
+        # Every entry must carry the same fields ("homogeneous" format): a
+        # missing member would otherwise only surface as a failure whenever
+        # that particular sample happens to be read.
+        missing = np.argwhere(locs[:, :, 0] < 0)
+        if len(missing):
+            entry, col = (int(v) for v in missing[0])
+            raise ValueError(
+                f"This DiskDataset zip is not homogeneous: entry {entry} has no "
+                f"'{self._field_names[col]}' member while other entries do "
+                f"({len(missing)} missing members in total). Every entry must "
+                "contain the same fields; re-write the dataset."
+            )
+        # With no member missing, a valid zip has exactly one member per
+        # (entry, field) cell. A surplus means field members for entries
+        # without a system, or duplicated names; both are out of spec.
+        n_valid_members = int((member_field_ids >= 0).sum())
+        if n_valid_members != locs.shape[0] * locs.shape[1]:
+            raise ValueError(
+                "This DiskDataset zip contains duplicated members or field "
+                "members for entries that have no `system.mta` (e.g. "
+                "`7/energy.mts` without `7/system.mta`); re-write the dataset."
+            )
+
+        # The dataset is valid: report ignored members, once.
+        # DiskDatasetWriter output never triggers this.
+        if ignored_names:
+            warnings.warn(
+                f"Ignoring {len(ignored_names)} zip member(s) of "
+                f"'{path}' that are not part of the DiskDataset format: "
+                f"{_format_member_names(ignored_names)}.",
+                stacklevel=2,
+            )
+
         # Do not open file in the main process and start sub-processes with None
-        self.zip_file: Optional[zipfile.ZipFile] = None
+        self.zip_file: Optional[IO[bytes]] = None
         self._zip_file_pid: Optional[int] = None
 
     def _open_zip_once(self) -> None:
@@ -747,11 +971,99 @@ class DiskDataset(torch.utils.data.Dataset):
         if self._zip_file_pid != pid:
             if self.zip_file is not None:
                 self.zip_file.close()
-            self.zip_file = zipfile.ZipFile(self.zip_file_path, "r")
+            # A plain handle, not a zipfile.ZipFile: members are read via
+            # the offsets indexed at construction, so per-process opens are
+            # O(1) in memory and time.
+            self.zip_file = open(self.zip_file_path, "rb")
             self._zip_file_pid = pid
+
+    def _read_member(self, index: int, field_name: str) -> io.BytesIO:
+        """Read one zip member by its indexed offset, bypassing the central
+        directory.
+
+        Members are STORED (validated at construction), so the bytes are
+        read directly at the indexed offset and verified against the member's
+        CRC-32 from the central directory. :func:`_read_at` does not touch
+        the handle's shared position, so concurrent reads from one process
+        are safe.
+
+        :param index: Positional dataset index (row in the member index).
+        :param field_name: Field to read ("system" or a target/extra field).
+        :return: The member contents.
+        """
+        if not 0 <= index < self._len:
+            raise IndexError(
+                f"index {index} is out of range for a DiskDataset with "
+                f"{self._len} samples"
+            )
+        offset, size, crc = (
+            int(v) for v in self._member_locs[index, self._member_cols[field_name]]
+        )
+        assert self.zip_file is not None
+        header = _read_at(self.zip_file, 30, offset)
+        if len(header) != 30 or header[:4] != b"PK\x03\x04":
+            raise zipfile.BadZipFile(
+                f"Bad local file header at offset {offset} in "
+                f"'{self.zip_file_path}': the file is corrupted"
+            )
+        name_len = int.from_bytes(header[26:28], "little")
+        extra_len = int.from_bytes(header[28:30], "little")
+        data = _read_at(self.zip_file, size, offset + 30 + name_len + extra_len)
+        if len(data) != size or zlib.crc32(data) != crc:
+            raise zipfile.BadZipFile(
+                f"Bad CRC-32 for member '{index}/{field_name}' in "
+                f"'{self.zip_file_path}': the file is corrupted"
+            )
+        return io.BytesIO(data)
 
     def __len__(self) -> int:
         return self._len
+
+    def _require_atom_counts(self) -> np.ndarray:
+        """The dataset's atom counts, or a clear error when the zip lacks them.
+
+        The reader never mutates the dataset file (doing so safely under
+        distributed training and parallel filesystems is not worth the
+        machinery), so datasets without ``metadata/atom_counts.npy`` must be
+        updated
+        by the user before atom-count-based sampling can be used.
+
+        :return: Atom counts for all samples, in dataset order.
+        """
+        if self._atom_counts is None:
+            raise ValueError(
+                f"'{self.zip_file_path}' has no 'metadata/atom_counts.npy' "
+                "member, which is required for atom-count-based sampling "
+                "(e.g. `max_atoms_per_batch`). Re-write the dataset with the "
+                "current DiskDatasetWriter (which always includes it), append "
+                "to it with DiskDatasetWriter(..., append=True), or add "
+                "'metadata/atom_counts.npy' (an int64 numpy array with the "
+                "atom count of each entry, in entry order) to the zip "
+                "yourself."
+            )
+        return self._atom_counts
+
+    def get_num_atoms(self, i: int) -> int:
+        """
+        Return the atom count for sample index ``i``, using the
+        ``metadata/atom_counts.npy`` file written by
+        :py:class:`DiskDatasetWriter`. Enables use with
+        :class:`~metatrain.utils.data.samplers.MaxAtomDistributedBatchSampler`.
+
+        :param i: Dataset index.
+        :return: Number of atoms in sample ``i``.
+        """
+        return int(self._require_atom_counts()[i])
+
+    def get_all_atom_counts(self) -> np.ndarray:
+        """
+        Return atom counts for all samples in one vectorized call, using the
+        ``metadata/atom_counts.npy`` file written by
+        :py:class:`DiskDatasetWriter`.
+
+        :return: Atom counts for all samples, in dataset order.
+        """
+        return self._require_atom_counts()
 
     def __getitem__(self, index: int) -> Any:
         self._open_zip_once()
@@ -760,9 +1072,8 @@ class DiskDataset(torch.utils.data.Dataset):
         system_and_targets = []
         for field_name in self._fields_to_read:
             if field_name == "system":
-                with self.zip_file.open(f"{index}/system.mta", "r") as file:
-                    system = load_system(file)
-                    system_and_targets.append(system)
+                system = load_system(self._read_member(index, field_name))
+                system_and_targets.append(system)
             elif field_name == "mtt::aux::system_index":
                 tensor_map = TensorMap(
                     keys=Labels(["_"], torch.tensor([[0]])),
@@ -781,11 +1092,10 @@ class DiskDataset(torch.utils.data.Dataset):
                 )
                 system_and_targets.append(tensor_map)
             else:
-                with self.zip_file.open(f"{index}/{field_name}.mts", "r") as file:
-                    numpy_buffer = np.load(file)
-                    tensor_buffer = torch.from_numpy(numpy_buffer)
-                    tensor_map = load_buffer(tensor_buffer)
-                    system_and_targets.append(tensor_map)
+                numpy_buffer = np.load(self._read_member(index, field_name))
+                tensor_buffer = torch.from_numpy(numpy_buffer)
+                tensor_map = load_buffer(tensor_buffer)
+                system_and_targets.append(tensor_map)
         return self._sample_class(*system_and_targets)
 
     def __iter__(self) -> Any:

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -759,7 +759,7 @@ def _scan_members(zip_file: SmartZip, path: Union[str, Path]) -> _MemberScan:
             continue
         if info.compress_type != zipfile.ZIP_STORED:
             raise ValueError(
-                f"'{path}' is not a valid DiskDataset zip: member "
+                f"'{path}' is not a valid DiskDataset zip: file "
                 f"'{name}' is compressed. DiskDataset zips must be "
                 "uncompressed (STORED); re-create the zip without "
                 "compression, e.g. `zip -rX -Z store <dataset>.zip .` "
@@ -789,13 +789,13 @@ def _validate_format(scan: _MemberScan, path: Union[str, Path]) -> int:
     """
     if "system" not in scan.field_id_by_name:
         message = (
-            "Could not find any `<N>/system.mta` member in the zip file. "
+            "Could not find any `<N>/system.mta` file in the zip. "
             "The dataset format might be wrong, or the dataset might be "
             "empty. Empty disk datasets are not supported."
         )
         if scan.ignored_names:
             message += (
-                " The zip does contain members that are not part of the "
+                " The zip does contain files that are not part of the "
                 f"format: {_format_member_names(scan.ignored_names)}."
             )
             first_component = scan.ignored_names[0].split("/", 1)[0]
@@ -836,8 +836,8 @@ def _validate_format(scan: _MemberScan, path: Union[str, Path]) -> int:
         field_name = list(scan.field_id_by_name)[field_id]
         raise ValueError(
             f"This DiskDataset zip is not homogeneous: entry {entry} has no "
-            f"'{field_name}' member while other entries do "
-            f"({len(missing)} missing members in total). Every entry must "
+            f"'{field_name}' file while other entries do "
+            f"({len(missing)} missing files in total). Every entry must "
             "contain the same fields; re-write the dataset."
         )
     # With no member missing, a valid zip has exactly one member per
@@ -846,8 +846,8 @@ def _validate_format(scan: _MemberScan, path: Union[str, Path]) -> int:
     n_valid_members = int((scan.field_ids >= 0).sum())
     if n_valid_members != present.shape[0] * present.shape[1]:
         raise ValueError(
-            "This DiskDataset zip contains duplicated members or field "
-            "members for entries that have no `system.mta` (e.g. "
+            "This DiskDataset zip contains duplicated files or field "
+            "files for entries that have no `system.mta` (e.g. "
             "`7/energy.mts` without `7/system.mta`); re-write the dataset."
         )
     return n_samples
@@ -1004,7 +1004,7 @@ class DiskDataset(torch.utils.data.Dataset):
         if self._atom_counts is None:
             raise ValueError(
                 f"'{self.zip_file_path}' has no 'metadata/atom_counts.npy' "
-                "member, which is required for atom-count-based sampling "
+                "file, which is required for atom-count-based sampling "
                 "(e.g. `max_atoms_per_batch`). Re-write the dataset with the "
                 "current DiskDatasetWriter (which always includes it), append "
                 "to it with DiskDatasetWriter(..., append=True), or add "

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -36,6 +36,7 @@ from metatrain.utils.data.readers.metatensor import (
     _check_tensor_map_metadata,
     _empty_tensor_map_like,
 )
+from metatrain.utils.data.smart_zip import SmartZip
 from metatrain.utils.data.target_info import (
     TargetInfo,
     get_energy_target_info,
@@ -74,23 +75,6 @@ def _parse_disk_dataset_member_name(name: str) -> Optional[Tuple[int, str]]:
     if tail.endswith(".mts") and len(tail) > len(".mts"):
         return int(head), tail[: -len(".mts")]
     return None
-
-
-class _LazyZipFile(zipfile.ZipFile):
-    """Read-mode ``ZipFile`` that skips central-directory parsing.
-
-    Parsing the central directory materializes one ``ZipInfo`` object per
-    member, which does not scale to zips with millions of members (about
-    10 GB of RAM and 80 s for 13 million members), repeated in every
-    dataloader worker. :py:class:`DiskDataset` instead indexes the member
-    locations once, at construction, and opens members here by passing
-    reconstructed ``ZipInfo`` objects to ``open()`` (public API). The
-    inherited ``open()`` still validates the local header signature,
-    cross-checks the member name, and verifies CRC-32 while reading.
-    """
-
-    def _RealGetContents(self) -> None:
-        self.start_dir = 0
 
 
 def _format_member_names(names: List[str], limit: int = 10) -> str:
@@ -764,12 +748,11 @@ class DiskDataset(torch.utils.data.Dataset):
             fields = {options.get("key", key): key for key, options in fields.items()}
 
         self._field_names = ["system"]
-        # Parse the zip's central directory once, into compact numpy arrays
-        # of member locations. Opening a zipfile.ZipFile per process instead
-        # does not scale: it materializes one Python object per member (about
-        # 10 GB of RAM and 80 s for a zip with 13 million members), repeated
-        # in every dataloader worker. __getitem__ reads members directly at
-        # these offsets instead.
+        # SmartZip parses the zip's central directory once, into compact
+        # numpy arrays of member locations, and reads members from those
+        # (opening a zipfile.ZipFile per dataloader worker instead does not
+        # scale to zips with millions of members). The loop below only
+        # validates the DiskDataset format on top of it.
         #
         # The entry members `<N>/system.mta` and `<N>/<field>.mts` must be
         # STORED (uncompressed) and are validated strictly; any other file is
@@ -777,105 +760,89 @@ class DiskDataset(torch.utils.data.Dataset):
         # with standard tools (from inside the folder, without compression)
         # therefore works like DiskDatasetWriter output. Directory entries
         # are skipped silently.
-        with zipfile.ZipFile(path, "r") as zip_file:
-            infos = zip_file.infolist()
-            n_members = len(infos)
-            member_entries = np.full(n_members, -1, dtype=np.int64)
-            member_offsets = np.empty(n_members, dtype=np.int64)
-            member_sizes = np.empty(n_members, dtype=np.int64)
-            member_crcs = np.empty(n_members, dtype=np.int64)
-            member_field_ids = np.full(n_members, -1, dtype=np.int64)
-            field_ids: Dict[str, int] = {}
-            ignored_names: List[str] = []
-            has_atom_counts = False
-            for i, info in enumerate(infos):
-                name = info.filename
-                if name == ATOM_COUNTS_MEMBER:
-                    has_atom_counts = True
-                    continue
-                if info.is_dir():
-                    continue
-                parsed = _parse_disk_dataset_member_name(name)
-                if parsed is None:
-                    ignored_names.append(name)
-                    continue
-                if info.compress_type != zipfile.ZIP_STORED:
-                    raise ValueError(
-                        f"'{path}' is not a valid DiskDataset zip: member "
-                        f"'{name}' is compressed. DiskDataset zips must be "
-                        "uncompressed (STORED); re-create the zip without "
-                        "compression, e.g. `zip -rX -Z store <dataset>.zip .` "
-                        "from inside the dataset folder."
-                    )
-                if info.flag_bits & 0x1:
-                    raise ValueError(
-                        f"'{path}' is not a valid DiskDataset zip: member "
-                        f"'{name}' is encrypted."
-                    )
-                entry, field = parsed
-                member_entries[i] = entry
-                member_offsets[i] = info.header_offset
-                member_sizes[i] = info.file_size
-                member_crcs[i] = info.CRC
-                member_field_ids[i] = field_ids.setdefault(field, len(field_ids))
-            self._field_names += [f for f in field_ids if f != "system"]
-
-            if "system" not in field_ids:
-                message = (
-                    "Could not find any `<N>/system.mta` member in the zip file. "
-                    "The dataset format might be wrong, or the dataset might be "
-                    "empty. Empty disk datasets are not supported."
-                )
-                if ignored_names:
-                    message += (
-                        " The zip does contain members that are not part of the "
-                        f"format: {_format_member_names(ignored_names)}."
-                    )
-                    first_component = ignored_names[0].split("/", 1)[0]
-                    if all(n.startswith(f"{first_component}/") for n in ignored_names):
-                        message += (
-                            " They all share the prefix "
-                            f"'{first_component}/'; if you zipped a dataset "
-                            "folder from outside, re-create the zip from inside "
-                            f"it: `cd {first_component} && zip -rX -Z store "
-                            "../<dataset>.zip .`"
-                        )
-                raise ValueError(message)
-            entry_numbers = member_entries[member_field_ids == field_ids["system"]]
-            # Entries are read positionally as "0/", "1/", ...: require exactly
-            # the dense range, and fail loudly on duplicated entry names (e.g.
-            # produced by appending with an older, buggy DiskDatasetWriter that
-            # restarted indexing at 0 -- reading those would silently return
-            # the last-written copy) or on gaps.
-            if not np.array_equal(
-                np.sort(entry_numbers), np.arange(len(entry_numbers))
-            ):
+        self._zip = SmartZip(path)
+        n_members = len(self._zip)
+        member_entries = np.full(n_members, -1, dtype=np.int64)
+        member_field_ids = np.full(n_members, -1, dtype=np.int64)
+        field_ids: Dict[str, int] = {}
+        ignored_names: List[str] = []
+        has_atom_counts = False
+        for i, info in enumerate(self._zip.infoiter()):
+            name = info.filename
+            if name == ATOM_COUNTS_MEMBER:
+                has_atom_counts = True
+                continue
+            parsed = _parse_disk_dataset_member_name(name)
+            if parsed is None:
+                ignored_names.append(name)
+                continue
+            if info.compress_type != zipfile.ZIP_STORED:
                 raise ValueError(
-                    "This DiskDataset zip file does not contain a dense range of "
-                    "entries `0/`, `1/`, ...: it has gaps or duplicated entry "
-                    "numbers and cannot be read reliably; re-write the dataset."
+                    f"'{path}' is not a valid DiskDataset zip: member "
+                    f"'{name}' is compressed. DiskDataset zips must be "
+                    "uncompressed (STORED); re-create the zip without "
+                    "compression, e.g. `zip -rX -Z store <dataset>.zip .` "
+                    "from inside the dataset folder."
                 )
-            self._len = len(entry_numbers)
+            entry, field = parsed
+            member_entries[i] = entry
+            member_field_ids[i] = field_ids.setdefault(field, len(field_ids))
+        self._field_names += [f for f in field_ids if f != "system"]
 
-            # Optional atom-count file (written by DiskDatasetWriter), keyed by
-            # sample index. Lets get_num_atoms()/get_all_atom_counts() below answer
-            # without opening/deserializing every system, which is what makes this
-            # dataset usable with MaxAtomDistributedBatchSampler.
-            self._atom_counts: Optional[np.ndarray] = None
-            if has_atom_counts:
-                with zip_file.open(ATOM_COUNTS_MEMBER, "r") as f:
-                    atom_counts = np.load(f)
-                if len(atom_counts) >= self._len:
-                    self._atom_counts = atom_counts[: self._len].astype(
-                        np.int64, copy=False
+        if "system" not in field_ids:
+            message = (
+                "Could not find any `<N>/system.mta` member in the zip file. "
+                "The dataset format might be wrong, or the dataset might be "
+                "empty. Empty disk datasets are not supported."
+            )
+            if ignored_names:
+                message += (
+                    " The zip does contain members that are not part of the "
+                    f"format: {_format_member_names(ignored_names)}."
+                )
+                first_component = ignored_names[0].split("/", 1)[0]
+                if all(n.startswith(f"{first_component}/") for n in ignored_names):
+                    message += (
+                        " They all share the prefix "
+                        f"'{first_component}/'; if you zipped a dataset "
+                        "folder from outside, re-create the zip from inside "
+                        f"it: `cd {first_component} && zip -rX -Z store "
+                        "../<dataset>.zip .`"
                     )
-                else:
-                    warnings.warn(
-                        f"Ignoring '{ATOM_COUNTS_MEMBER}' in this DiskDataset: "
-                        f"it has {len(atom_counts)} entries, fewer than the "
-                        f"{self._len} samples found. It is likely stale.",
-                        stacklevel=2,
-                    )
+            raise ValueError(message)
+        entry_numbers = member_entries[member_field_ids == field_ids["system"]]
+        # Entries are read positionally as "0/", "1/", ...: require exactly
+        # the dense range, and fail loudly on duplicated entry names (e.g.
+        # produced by appending with an older, buggy DiskDatasetWriter that
+        # restarted indexing at 0 -- reading those would silently return
+        # the last-written copy) or on gaps.
+        if not np.array_equal(np.sort(entry_numbers), np.arange(len(entry_numbers))):
+            raise ValueError(
+                "This DiskDataset zip file does not contain a dense range of "
+                "entries `0/`, `1/`, ...: it has gaps or duplicated entry "
+                "numbers and cannot be read reliably; re-write the dataset."
+            )
+        self._len = len(entry_numbers)
+
+        # Optional atom-count file (written by DiskDatasetWriter), keyed by
+        # sample index. Lets get_num_atoms()/get_all_atom_counts() below answer
+        # without opening/deserializing every system, which is what makes this
+        # dataset usable with MaxAtomDistributedBatchSampler.
+        self._atom_counts: Optional[np.ndarray] = None
+        if has_atom_counts:
+            with self._zip.open(ATOM_COUNTS_MEMBER) as f:
+                atom_counts = np.load(f)
+            if len(atom_counts) >= self._len:
+                self._atom_counts = atom_counts[: self._len].astype(
+                    np.int64, copy=False
+                )
+            else:
+                warnings.warn(
+                    f"Ignoring '{ATOM_COUNTS_MEMBER}' in this DiskDataset: "
+                    f"it has {len(atom_counts)} entries, fewer than the "
+                    f"{self._len} samples found. It is likely stale.",
+                    stacklevel=2,
+                )
 
         # Determine which fields are going to be read
         if fields is None:
@@ -899,29 +866,17 @@ class DiskDataset(torch.utils.data.Dataset):
             "Sample", [fields_map.get(field, field) for field in self._fields_to_read]
         )
 
-        # Per-(entry, field) member locations, over ALL fields present in the
-        # zip: (header_offset, file_size, crc32). This is the only zip metadata
-        # workers need to read samples.
-        self._member_cols: Dict[str, int] = {
-            f: c for c, f in enumerate(self._field_names)
-        }
-        locs = np.full((self._len, len(self._field_names), 3), -1, dtype=np.int64)
-        for field_name, col in self._member_cols.items():
+        # Every entry must carry the same fields ("homogeneous" format): a
+        # missing member would otherwise only surface as a failure whenever
+        # that particular sample happens to be read.
+        present = np.zeros((self._len, len(self._field_names)), dtype=bool)
+        for col, field_name in enumerate(self._field_names):
             # entries are the dense range 0..N-1, so they index rows directly
             mask = (member_field_ids == field_ids[field_name]) & (
                 member_entries < self._len
             )
-            rows = member_entries[mask]
-            sel = np.flatnonzero(mask)
-            locs[rows, col, 0] = member_offsets[sel]
-            locs[rows, col, 1] = member_sizes[sel]
-            locs[rows, col, 2] = member_crcs[sel]
-        self._member_locs = locs
-
-        # Every entry must carry the same fields ("homogeneous" format): a
-        # missing member would otherwise only surface as a failure whenever
-        # that particular sample happens to be read.
-        missing = np.argwhere(locs[:, :, 0] < 0)
+            present[member_entries[mask], col] = True
+        missing = np.argwhere(~present)
         if len(missing):
             entry, col = (int(v) for v in missing[0])
             raise ValueError(
@@ -934,7 +889,7 @@ class DiskDataset(torch.utils.data.Dataset):
         # (entry, field) cell. A surplus means field members for entries
         # without a system, or duplicated names; both are out of spec.
         n_valid_members = int((member_field_ids >= 0).sum())
-        if n_valid_members != locs.shape[0] * locs.shape[1]:
+        if n_valid_members != present.shape[0] * present.shape[1]:
             raise ValueError(
                 "This DiskDataset zip contains duplicated members or field "
                 "members for entries that have no `system.mta` (e.g. "
@@ -951,31 +906,15 @@ class DiskDataset(torch.utils.data.Dataset):
                 stacklevel=2,
             )
 
-        # Do not open file in the main process and start sub-processes with None
-        self.zip_file: Optional[_LazyZipFile] = None
-        self._zip_file_pid: Optional[int] = None
-
-    def _open_zip_once(self) -> None:
-        pid = os.getpid()
-        if self._zip_file_pid != pid:
-            if self.zip_file is not None:
-                self.zip_file.close()
-            # _LazyZipFile skips the central-directory parse: members are
-            # read via the offsets indexed at construction, so per-process
-            # opens are O(1) in memory and time.
-            self.zip_file = _LazyZipFile(self.zip_file_path, "r")
-            self._zip_file_pid = pid
-
     def _read_member(self, index: int, field_name: str) -> io.BytesIO:
-        """Read one zip member by its indexed offset, bypassing the central
-        directory.
+        """Read one zip member of the sample at ``index``.
 
-        The member's ``ZipInfo`` is reconstructed from the locations indexed
-        at construction (member names are deterministic in the DiskDataset
-        format) and passed to ``ZipFile.open()``, which validates the local
-        header and verifies the CRC-32 from the central directory.
+        Member names are deterministic in the DiskDataset format, so the
+        name is rebuilt from the index and field and read from the
+        :py:class:`SmartZip`, which validates the local header and verifies
+        the CRC-32 from the central directory.
 
-        :param index: Positional dataset index (row in the member index).
+        :param index: Positional dataset index.
         :param field_name: Field to read ("system" or a target/extra field).
         :return: The member contents.
         """
@@ -984,22 +923,12 @@ class DiskDataset(torch.utils.data.Dataset):
                 f"index {index} is out of range for a DiskDataset with "
                 f"{self._len} samples"
             )
-        offset, size, crc = (
-            int(v) for v in self._member_locs[index, self._member_cols[field_name]]
-        )
         name = (
             f"{index}/system.mta"
             if field_name == "system"
             else f"{index}/{field_name}.mts"
         )
-        zinfo = zipfile.ZipInfo(name)
-        zinfo.header_offset = offset
-        zinfo.compress_type = zipfile.ZIP_STORED  # validated at construction
-        zinfo.compress_size = size
-        zinfo.file_size = size
-        zinfo.CRC = crc
-        assert self.zip_file is not None
-        with self.zip_file.open(zinfo) as member:
+        with self._zip.open(name) as member:
             return io.BytesIO(member.read())
 
     def __len__(self) -> int:
@@ -1052,9 +981,6 @@ class DiskDataset(torch.utils.data.Dataset):
         return self._require_atom_counts()
 
     def __getitem__(self, index: int) -> Any:
-        self._open_zip_once()
-        assert self.zip_file is not None
-
         system_and_targets = []
         for field_name in self._fields_to_read:
             if field_name == "system":
@@ -1141,10 +1067,6 @@ class DiskDataset(torch.utils.data.Dataset):
                 },
             )
         return target_info_dict
-
-    def __del__(self) -> None:
-        if hasattr(self, "zip_file") and self.zip_file is not None:
-            self.zip_file.close()
 
 
 def _is_disk_dataset(dataset: Any) -> bool:

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -5,7 +5,7 @@ import os
 import warnings
 import zipfile
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Tuple, Union
 
 import numpy as np
 import torch
@@ -714,6 +714,171 @@ def load_indices(indices_spec: Union[List[int], str]) -> List[int]:
     return indices
 
 
+class _MemberScan(NamedTuple):
+    """Classification of a DiskDataset zip's members, one row per member."""
+
+    entries: np.ndarray
+    """Entry number of each member, ``-1`` for non-format members."""
+    field_ids: np.ndarray
+    """Field id of each member, ``-1`` for non-format members."""
+    field_id_by_name: Dict[str, int]
+    """Field name to field id, in order of first appearance."""
+    ignored_names: List[str]
+    """Members that are not part of the DiskDataset format."""
+    has_atom_counts: bool
+    """Whether the zip contains the ``metadata/atom_counts.npy`` member."""
+
+
+def _scan_members(zip_file: SmartZip, path: Union[str, Path]) -> _MemberScan:
+    """Classify every member of a DiskDataset zip into ``(entry, field)``.
+
+    The entry members ``<N>/system.mta`` and ``<N>/<field>.mts`` must be
+    STORED (uncompressed); any other file is collected as ignored, for
+    :py:func:`_validate_format` to report. A zip of a dataset folder made
+    with standard tools (from inside the folder, without compression)
+    therefore classifies like DiskDatasetWriter output.
+
+    :param zip_file: The indexed zip.
+    :param path: The zip's path, for error messages.
+    :return: The classification.
+    """
+    n_members = len(zip_file)
+    entries = np.full(n_members, -1, dtype=np.int64)
+    field_ids = np.full(n_members, -1, dtype=np.int64)
+    field_id_by_name: Dict[str, int] = {}
+    ignored_names: List[str] = []
+    has_atom_counts = False
+    for i, info in enumerate(zip_file.infoiter()):
+        name = info.filename
+        if name == ATOM_COUNTS_MEMBER:
+            has_atom_counts = True
+            continue
+        parsed = _parse_disk_dataset_member_name(name)
+        if parsed is None:
+            ignored_names.append(name)
+            continue
+        if info.compress_type != zipfile.ZIP_STORED:
+            raise ValueError(
+                f"'{path}' is not a valid DiskDataset zip: member "
+                f"'{name}' is compressed. DiskDataset zips must be "
+                "uncompressed (STORED); re-create the zip without "
+                "compression, e.g. `zip -rX -Z store <dataset>.zip .` "
+                "from inside the dataset folder."
+            )
+        entry, field = parsed
+        entries[i] = entry
+        field_ids[i] = field_id_by_name.setdefault(field, len(field_id_by_name))
+    return _MemberScan(
+        entries, field_ids, field_id_by_name, ignored_names, has_atom_counts
+    )
+
+
+def _validate_format(scan: _MemberScan, path: Union[str, Path]) -> int:
+    """Reject zips that cannot be read reliably, with actionable messages.
+
+    Checks, in order: at least one system member; a dense ``0..N-1`` entry
+    range (duplicated or missing entry numbers would be read positionally
+    and silently alias other samples); the same fields in every entry (a
+    missing member would otherwise only surface when that sample happens to
+    be read); no duplicated or orphaned members. A zip can violate several
+    at once: the first failing check is the one reported.
+
+    :param scan: The member classification from :py:func:`_scan_members`.
+    :param path: The zip's path, for error messages.
+    :return: The number of samples in the dataset.
+    """
+    if "system" not in scan.field_id_by_name:
+        message = (
+            "Could not find any `<N>/system.mta` member in the zip file. "
+            "The dataset format might be wrong, or the dataset might be "
+            "empty. Empty disk datasets are not supported."
+        )
+        if scan.ignored_names:
+            message += (
+                " The zip does contain members that are not part of the "
+                f"format: {_format_member_names(scan.ignored_names)}."
+            )
+            first_component = scan.ignored_names[0].split("/", 1)[0]
+            if all(n.startswith(f"{first_component}/") for n in scan.ignored_names):
+                message += (
+                    " They all share the prefix "
+                    f"'{first_component}/'; if you zipped a dataset "
+                    "folder from outside, re-create the zip from inside "
+                    f"it: `cd {first_component} && zip -rX -Z store "
+                    "../<dataset>.zip .`"
+                )
+        raise ValueError(message)
+
+    # Entries are read positionally as "0/", "1/", ...: require exactly
+    # the dense range, and fail loudly on duplicated entry names (e.g.
+    # produced by appending with an older, buggy DiskDatasetWriter that
+    # restarted indexing at 0 -- reading those would silently return
+    # the last-written copy) or on gaps.
+    system_id = scan.field_id_by_name["system"]
+    entry_numbers = scan.entries[scan.field_ids == system_id]
+    if not np.array_equal(np.sort(entry_numbers), np.arange(len(entry_numbers))):
+        raise ValueError(
+            "This DiskDataset zip file does not contain a dense range of "
+            "entries `0/`, `1/`, ...: it has gaps or duplicated entry "
+            "numbers and cannot be read reliably; re-write the dataset."
+        )
+    n_samples = len(entry_numbers)
+
+    # Every entry must carry the same fields ("homogeneous" format).
+    present = np.zeros((n_samples, len(scan.field_id_by_name)), dtype=bool)
+    for field_id in scan.field_id_by_name.values():
+        # entries are the dense range 0..N-1, so they index rows directly
+        mask = (scan.field_ids == field_id) & (scan.entries < n_samples)
+        present[scan.entries[mask], field_id] = True
+    missing = np.argwhere(~present)
+    if len(missing):
+        entry, field_id = (int(v) for v in missing[0])
+        field_name = list(scan.field_id_by_name)[field_id]
+        raise ValueError(
+            f"This DiskDataset zip is not homogeneous: entry {entry} has no "
+            f"'{field_name}' member while other entries do "
+            f"({len(missing)} missing members in total). Every entry must "
+            "contain the same fields; re-write the dataset."
+        )
+    # With no member missing, a valid zip has exactly one member per
+    # (entry, field) cell. A surplus means field members for entries
+    # without a system, or duplicated names; both are out of spec.
+    n_valid_members = int((scan.field_ids >= 0).sum())
+    if n_valid_members != present.shape[0] * present.shape[1]:
+        raise ValueError(
+            "This DiskDataset zip contains duplicated members or field "
+            "members for entries that have no `system.mta` (e.g. "
+            "`7/energy.mts` without `7/system.mta`); re-write the dataset."
+        )
+    return n_samples
+
+
+def _load_atom_counts(zip_file: SmartZip, n_samples: int) -> Optional[np.ndarray]:
+    """Load the per-sample atom counts written by DiskDatasetWriter.
+
+    Lets ``get_num_atoms()``/``get_all_atom_counts()`` answer without
+    opening and deserializing every system, which is what makes DiskDataset
+    usable with
+    :class:`~metatrain.utils.data.samplers.MaxAtomDistributedBatchSampler`.
+
+    :param zip_file: The indexed zip; must contain ``metadata/atom_counts.npy``.
+    :param n_samples: The number of samples in the dataset.
+    :return: Atom counts for all samples, or ``None`` (with a warning) when
+        the stored counts are stale.
+    """
+    with zip_file.open(ATOM_COUNTS_MEMBER) as f:
+        atom_counts = np.load(f)
+    if len(atom_counts) >= n_samples:
+        return atom_counts[:n_samples].astype(np.int64, copy=False)
+    warnings.warn(
+        f"Ignoring '{ATOM_COUNTS_MEMBER}' in this DiskDataset: "
+        f"it has {len(atom_counts)} entries, fewer than the "
+        f"{n_samples} samples found. It is likely stale.",
+        stacklevel=2,
+    )
+    return None
+
+
 class DiskDataset(torch.utils.data.Dataset):
     """
     A class representing a dataset stored on disk.
@@ -747,102 +912,20 @@ class DiskDataset(torch.utils.data.Dataset):
         if isinstance(fields, dict):
             fields = {options.get("key", key): key for key, options in fields.items()}
 
-        self._field_names = ["system"]
         # SmartZip parses the zip's central directory once, into compact
         # numpy arrays of member locations, and reads members from those
         # (opening a zipfile.ZipFile per dataloader worker instead does not
-        # scale to zips with millions of members). The loop below only
-        # validates the DiskDataset format on top of it.
-        #
-        # The entry members `<N>/system.mta` and `<N>/<field>.mts` must be
-        # STORED (uncompressed) and are validated strictly; any other file is
-        # ignored with a single warning below. A zip of a dataset folder made
-        # with standard tools (from inside the folder, without compression)
-        # therefore works like DiskDatasetWriter output. Directory entries
-        # are skipped silently.
+        # scale to zips with millions of members). The scan and validation
+        # only check the DiskDataset format on top of it.
         self._zip = SmartZip(path)
-        n_members = len(self._zip)
-        member_entries = np.full(n_members, -1, dtype=np.int64)
-        member_field_ids = np.full(n_members, -1, dtype=np.int64)
-        field_ids: Dict[str, int] = {}
-        ignored_names: List[str] = []
-        has_atom_counts = False
-        for i, info in enumerate(self._zip.infoiter()):
-            name = info.filename
-            if name == ATOM_COUNTS_MEMBER:
-                has_atom_counts = True
-                continue
-            parsed = _parse_disk_dataset_member_name(name)
-            if parsed is None:
-                ignored_names.append(name)
-                continue
-            if info.compress_type != zipfile.ZIP_STORED:
-                raise ValueError(
-                    f"'{path}' is not a valid DiskDataset zip: member "
-                    f"'{name}' is compressed. DiskDataset zips must be "
-                    "uncompressed (STORED); re-create the zip without "
-                    "compression, e.g. `zip -rX -Z store <dataset>.zip .` "
-                    "from inside the dataset folder."
-                )
-            entry, field = parsed
-            member_entries[i] = entry
-            member_field_ids[i] = field_ids.setdefault(field, len(field_ids))
-        self._field_names += [f for f in field_ids if f != "system"]
-
-        if "system" not in field_ids:
-            message = (
-                "Could not find any `<N>/system.mta` member in the zip file. "
-                "The dataset format might be wrong, or the dataset might be "
-                "empty. Empty disk datasets are not supported."
-            )
-            if ignored_names:
-                message += (
-                    " The zip does contain members that are not part of the "
-                    f"format: {_format_member_names(ignored_names)}."
-                )
-                first_component = ignored_names[0].split("/", 1)[0]
-                if all(n.startswith(f"{first_component}/") for n in ignored_names):
-                    message += (
-                        " They all share the prefix "
-                        f"'{first_component}/'; if you zipped a dataset "
-                        "folder from outside, re-create the zip from inside "
-                        f"it: `cd {first_component} && zip -rX -Z store "
-                        "../<dataset>.zip .`"
-                    )
-            raise ValueError(message)
-        entry_numbers = member_entries[member_field_ids == field_ids["system"]]
-        # Entries are read positionally as "0/", "1/", ...: require exactly
-        # the dense range, and fail loudly on duplicated entry names (e.g.
-        # produced by appending with an older, buggy DiskDatasetWriter that
-        # restarted indexing at 0 -- reading those would silently return
-        # the last-written copy) or on gaps.
-        if not np.array_equal(np.sort(entry_numbers), np.arange(len(entry_numbers))):
-            raise ValueError(
-                "This DiskDataset zip file does not contain a dense range of "
-                "entries `0/`, `1/`, ...: it has gaps or duplicated entry "
-                "numbers and cannot be read reliably; re-write the dataset."
-            )
-        self._len = len(entry_numbers)
-
-        # Optional atom-count file (written by DiskDatasetWriter), keyed by
-        # sample index. Lets get_num_atoms()/get_all_atom_counts() below answer
-        # without opening/deserializing every system, which is what makes this
-        # dataset usable with MaxAtomDistributedBatchSampler.
-        self._atom_counts: Optional[np.ndarray] = None
-        if has_atom_counts:
-            with self._zip.open(ATOM_COUNTS_MEMBER) as f:
-                atom_counts = np.load(f)
-            if len(atom_counts) >= self._len:
-                self._atom_counts = atom_counts[: self._len].astype(
-                    np.int64, copy=False
-                )
-            else:
-                warnings.warn(
-                    f"Ignoring '{ATOM_COUNTS_MEMBER}' in this DiskDataset: "
-                    f"it has {len(atom_counts)} entries, fewer than the "
-                    f"{self._len} samples found. It is likely stale.",
-                    stacklevel=2,
-                )
+        scan = _scan_members(self._zip, path)
+        self._len = _validate_format(scan, path)
+        self._field_names = ["system"] + [
+            f for f in scan.field_id_by_name if f != "system"
+        ]
+        self._atom_counts: Optional[np.ndarray] = (
+            _load_atom_counts(self._zip, self._len) if scan.has_atom_counts else None
+        )
 
         # Determine which fields are going to be read
         if fields is None:
@@ -866,43 +949,13 @@ class DiskDataset(torch.utils.data.Dataset):
             "Sample", [fields_map.get(field, field) for field in self._fields_to_read]
         )
 
-        # Every entry must carry the same fields ("homogeneous" format): a
-        # missing member would otherwise only surface as a failure whenever
-        # that particular sample happens to be read.
-        present = np.zeros((self._len, len(self._field_names)), dtype=bool)
-        for col, field_name in enumerate(self._field_names):
-            # entries are the dense range 0..N-1, so they index rows directly
-            mask = (member_field_ids == field_ids[field_name]) & (
-                member_entries < self._len
-            )
-            present[member_entries[mask], col] = True
-        missing = np.argwhere(~present)
-        if len(missing):
-            entry, col = (int(v) for v in missing[0])
-            raise ValueError(
-                f"This DiskDataset zip is not homogeneous: entry {entry} has no "
-                f"'{self._field_names[col]}' member while other entries do "
-                f"({len(missing)} missing members in total). Every entry must "
-                "contain the same fields; re-write the dataset."
-            )
-        # With no member missing, a valid zip has exactly one member per
-        # (entry, field) cell. A surplus means field members for entries
-        # without a system, or duplicated names; both are out of spec.
-        n_valid_members = int((member_field_ids >= 0).sum())
-        if n_valid_members != present.shape[0] * present.shape[1]:
-            raise ValueError(
-                "This DiskDataset zip contains duplicated members or field "
-                "members for entries that have no `system.mta` (e.g. "
-                "`7/energy.mts` without `7/system.mta`); re-write the dataset."
-            )
-
         # The dataset is valid: report ignored members, once.
         # DiskDatasetWriter output never triggers this.
-        if ignored_names:
+        if scan.ignored_names:
             warnings.warn(
-                f"Ignoring {len(ignored_names)} zip member(s) of "
+                f"Ignoring {len(scan.ignored_names)} zip member(s) of "
                 f"'{path}' that are not part of the DiskDataset format: "
-                f"{_format_member_names(ignored_names)}.",
+                f"{_format_member_names(scan.ignored_names)}.",
                 stacklevel=2,
             )
 

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -949,13 +949,16 @@ class DiskDataset(torch.utils.data.Dataset):
             "Sample", [fields_map.get(field, field) for field in self._fields_to_read]
         )
 
-        # The dataset is valid: report ignored members, once.
+        # The dataset is valid: report skipped files, once.
         # DiskDatasetWriter output never triggers this.
         if scan.ignored_names:
             warnings.warn(
-                f"Ignoring {len(scan.ignored_names)} zip member(s) of "
-                f"'{path}' that are not part of the DiskDataset format: "
-                f"{_format_member_names(scan.ignored_names)}.",
+                f"Skipping {len(scan.ignored_names)} file(s) in '{path}' "
+                "that are not part of the DiskDataset format: "
+                f"{_format_member_names(scan.ignored_names)}. This is fine "
+                "if they are extra files stored alongside the dataset; if "
+                "they were meant to be read as data, name them "
+                "`<N>/system.mta` or `<N>/<target>.mts`.",
                 stacklevel=2,
             )
 

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -4,9 +4,8 @@ import multiprocessing
 import os
 import warnings
 import zipfile
-import zlib
 from pathlib import Path
-from typing import IO, Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import torch
@@ -77,31 +76,21 @@ def _parse_disk_dataset_member_name(name: str) -> Optional[Tuple[int, str]]:
     return None
 
 
-if hasattr(os, "pread"):
+class _LazyZipFile(zipfile.ZipFile):
+    """Read-mode ``ZipFile`` that skips central-directory parsing.
 
-    def _read_at(handle: IO[bytes], n: int, offset: int) -> bytes:
-        """Read ``n`` bytes at ``offset`` without moving the shared position,
-        so concurrent reads from one process cannot interleave.
+    Parsing the central directory materializes one ``ZipInfo`` object per
+    member, which does not scale to zips with millions of members (about
+    10 GB of RAM and 80 s for 13 million members), repeated in every
+    dataloader worker. :py:class:`DiskDataset` instead indexes the member
+    locations once, at construction, and opens members here by passing
+    reconstructed ``ZipInfo`` objects to ``open()`` (public API). The
+    inherited ``open()`` still validates the local header signature,
+    cross-checks the member name, and verifies CRC-32 while reading.
+    """
 
-        :param handle: Open binary file handle.
-        :param n: Number of bytes to read.
-        :param offset: Absolute offset to read at.
-        :return: The bytes read.
-        """
-        return os.pread(handle.fileno(), n, offset)
-
-else:  # pragma: no cover (Windows: os.pread is Unix-only)
-
-    def _read_at(handle: IO[bytes], n: int, offset: int) -> bytes:
-        """Windows fallback (no ``os.pread``): plain seek and read.
-
-        :param handle: Open binary file handle.
-        :param n: Number of bytes to read.
-        :param offset: Absolute offset to read at.
-        :return: The bytes read.
-        """
-        handle.seek(offset)
-        return handle.read(n)
+    def _RealGetContents(self) -> None:
+        self.start_dir = 0
 
 
 def _format_member_names(names: List[str], limit: int = 10) -> str:
@@ -963,7 +952,7 @@ class DiskDataset(torch.utils.data.Dataset):
             )
 
         # Do not open file in the main process and start sub-processes with None
-        self.zip_file: Optional[IO[bytes]] = None
+        self.zip_file: Optional[_LazyZipFile] = None
         self._zip_file_pid: Optional[int] = None
 
     def _open_zip_once(self) -> None:
@@ -971,21 +960,20 @@ class DiskDataset(torch.utils.data.Dataset):
         if self._zip_file_pid != pid:
             if self.zip_file is not None:
                 self.zip_file.close()
-            # A plain handle, not a zipfile.ZipFile: members are read via
-            # the offsets indexed at construction, so per-process opens are
-            # O(1) in memory and time.
-            self.zip_file = open(self.zip_file_path, "rb")
+            # _LazyZipFile skips the central-directory parse: members are
+            # read via the offsets indexed at construction, so per-process
+            # opens are O(1) in memory and time.
+            self.zip_file = _LazyZipFile(self.zip_file_path, "r")
             self._zip_file_pid = pid
 
     def _read_member(self, index: int, field_name: str) -> io.BytesIO:
         """Read one zip member by its indexed offset, bypassing the central
         directory.
 
-        Members are STORED (validated at construction), so the bytes are
-        read directly at the indexed offset and verified against the member's
-        CRC-32 from the central directory. :func:`_read_at` does not touch
-        the handle's shared position, so concurrent reads from one process
-        are safe.
+        The member's ``ZipInfo`` is reconstructed from the locations indexed
+        at construction (member names are deterministic in the DiskDataset
+        format) and passed to ``ZipFile.open()``, which validates the local
+        header and verifies the CRC-32 from the central directory.
 
         :param index: Positional dataset index (row in the member index).
         :param field_name: Field to read ("system" or a target/extra field).
@@ -999,22 +987,20 @@ class DiskDataset(torch.utils.data.Dataset):
         offset, size, crc = (
             int(v) for v in self._member_locs[index, self._member_cols[field_name]]
         )
+        name = (
+            f"{index}/system.mta"
+            if field_name == "system"
+            else f"{index}/{field_name}.mts"
+        )
+        zinfo = zipfile.ZipInfo(name)
+        zinfo.header_offset = offset
+        zinfo.compress_type = zipfile.ZIP_STORED  # validated at construction
+        zinfo.compress_size = size
+        zinfo.file_size = size
+        zinfo.CRC = crc
         assert self.zip_file is not None
-        header = _read_at(self.zip_file, 30, offset)
-        if len(header) != 30 or header[:4] != b"PK\x03\x04":
-            raise zipfile.BadZipFile(
-                f"Bad local file header at offset {offset} in "
-                f"'{self.zip_file_path}': the file is corrupted"
-            )
-        name_len = int.from_bytes(header[26:28], "little")
-        extra_len = int.from_bytes(header[28:30], "little")
-        data = _read_at(self.zip_file, size, offset + 30 + name_len + extra_len)
-        if len(data) != size or zlib.crc32(data) != crc:
-            raise zipfile.BadZipFile(
-                f"Bad CRC-32 for member '{index}/{field_name}' in "
-                f"'{self.zip_file_path}': the file is corrupted"
-            )
-        return io.BytesIO(data)
+        with self.zip_file.open(zinfo) as member:
+            return io.BytesIO(member.read())
 
     def __len__(self) -> int:
         return self._len

--- a/src/metatrain/utils/data/samplers.py
+++ b/src/metatrain/utils/data/samplers.py
@@ -34,8 +34,8 @@ def _get_num_atoms(dataset: torch.utils.data.Dataset, i: int) -> int:
         return dataset.get_num_atoms(i)
     raise TypeError(
         f"Dataset of type {type(dataset).__name__} does not support "
-        "get_num_atoms(). Only MemmapDataset (and Subsets thereof) is "
-        "currently supported with max_atoms_per_batch."
+        "get_num_atoms(). Only MemmapDataset and DiskDataset (and Subsets "
+        "thereof) are currently supported with max_atoms_per_batch."
     )
 
 
@@ -110,7 +110,8 @@ class MaxAtomDistributedBatchSampler(torch.utils.data.Sampler):
     ``MaxAtomDistributedBatchSampler`` design.
 
     :param dataset: The dataset to sample from. Must support ``get_num_atoms(i)``
-        (currently only ``MemmapDataset`` and ``Subset`` wrappers thereof).
+        (currently ``MemmapDataset``, ``DiskDataset`` with a
+        ``metadata/atom_counts.npy`` file, and ``Subset`` wrappers thereof).
     :param max_atoms: Maximum total number of atoms across all structures in a batch.
     :param num_replicas: Number of distributed processes (world size).
     :param rank: Rank of the current process.

--- a/src/metatrain/utils/data/smart_zip.py
+++ b/src/metatrain/utils/data/smart_zip.py
@@ -1,0 +1,200 @@
+"""A read-only zip reader that scales to zips with millions of members."""
+
+import os
+import zipfile
+from pathlib import Path
+from typing import IO, Any, Dict, Iterator, Optional, Union
+
+import numpy as np
+
+
+class _LazyZipFile(zipfile.ZipFile):
+    """Read-mode ``ZipFile`` that skips central-directory parsing.
+
+    Only used internally by :py:class:`SmartZip`, which indexes the member
+    locations itself and opens members by passing reconstructed ``ZipInfo``
+    objects to ``open()`` (public API). The inherited ``open()`` still
+    validates the local header signature, cross-checks the member name, and
+    verifies CRC-32 while reading.
+    """
+
+    def _RealGetContents(self) -> None:
+        self.start_dir = 0
+
+
+class SmartZip:
+    """Read-only zip reader that scales to zips with millions of members.
+
+    Implements the subset of the ``zipfile.ZipFile`` reading API that
+    metatrain uses (``open``, ``namelist``, ``infoiter``, ``len``, context
+    manager), with one structural difference: the central directory is
+    parsed exactly once, at construction, into flat numpy arrays instead of
+    one ``ZipInfo`` Python object per member. Compared to keeping a parsed
+    ``ZipFile`` around, the index is
+
+    - small: tens of bytes per member instead of ~650 (a 13M-member
+      ``ZipFile`` costs ~10 GB of RAM and ~80 s to construct);
+    - picklable: instances can be sent to ``spawn``/``forkserver``
+      dataloader workers (the per-process file handle is dropped on pickling
+      and reopened lazily);
+    - fork-friendly: numpy data pages contain no Python object headers, so
+      reads never write to them and they stay shared under copy-on-write,
+      while ``ZipInfo`` objects are unshared page by page by refcount and
+      garbage-collector writes.
+
+    Reads go through ``ZipFile.open()`` with a ``ZipInfo`` rebuilt from the
+    index, so local-header validation, member-name cross-checking, CRC-32
+    verification and decompression are all standard-library behavior; in
+    particular, compressed members are supported. ``open()`` transparently
+    opens one file handle per process, so a single instance can be shared
+    with dataloader workers.
+
+    Known API divergences from ``ZipFile``: ``namelist()``/``infoiter()``
+    are generators (a list of millions of names would defeat the purpose)
+    and yield in sorted-name order rather than archive order; directory
+    entries are skipped; encrypted members are rejected at construction.
+    Like ``ZipFile``, ``open()`` on a duplicated member name reads the last
+    copy in archive order.
+
+    :param path: Path to the zip file.
+    """
+
+    # index columns, per member
+    _OFFSET, _SIZE, _CRC, _COMPRESS_TYPE, _COMPRESS_SIZE = range(5)
+
+    def __init__(self, path: Union[str, Path]):
+        self.path = path
+
+        names = []
+        locs = []
+        with zipfile.ZipFile(path, "r") as zip_file:
+            for info in zip_file.infolist():
+                if info.is_dir():
+                    continue
+                if info.flag_bits & 0x1:
+                    raise ValueError(
+                        f"cannot read '{path}': member '{info.filename}' is encrypted"
+                    )
+                names.append(info.filename.encode("utf-8"))
+                locs.append(
+                    (
+                        info.header_offset,
+                        info.file_size,
+                        info.CRC,
+                        info.compress_type,
+                        info.compress_size,
+                    )
+                )
+
+        self._names = np.array(names) if names else np.empty(0, dtype="S1")
+        self._locs = (
+            np.array(locs, dtype=np.int64) if locs else np.empty((0, 5), dtype=np.int64)
+        )
+        # sort by name for O(log n) lookups; stable, so duplicated names
+        # keep their archive order
+        order = np.argsort(self._names, kind="stable")
+        self._names = self._names[order]
+        self._locs = self._locs[order]
+
+        self._fp: Optional[_LazyZipFile] = None
+        self._fp_pid: Optional[int] = None
+
+    def __len__(self) -> int:
+        return len(self._names)
+
+    def namelist(self) -> Iterator[str]:
+        """Yield the name of every member (directory entries excluded).
+
+        :return: Iterator over member names, in sorted order.
+        """
+        for name in self._names:
+            yield name.decode("utf-8")
+
+    def infoiter(self) -> Iterator[zipfile.ZipInfo]:
+        """Yield a reconstructed ``ZipInfo`` for every member.
+
+        The objects are rebuilt from the index one at a time (holding a list
+        of all of them is what this class exists to avoid) and carry the
+        fields the index stores: ``filename``, ``header_offset``,
+        ``file_size``, ``CRC``, ``compress_type`` and ``compress_size``.
+
+        :return: Iterator over member infos, in sorted-name order.
+        """
+        for row in range(len(self._names)):
+            yield self._make_zipinfo(row)
+
+    def _make_zipinfo(self, row: int) -> zipfile.ZipInfo:
+        zinfo = zipfile.ZipInfo(self._names[row].decode("utf-8"))
+        (
+            zinfo.header_offset,
+            zinfo.file_size,
+            zinfo.CRC,
+            zinfo.compress_type,
+            zinfo.compress_size,
+        ) = (int(value) for value in self._locs[row])
+        return zinfo
+
+    def _ensure_fp(self) -> _LazyZipFile:
+        """The zip handle for the current process, opened on first use.
+
+        A handle cannot be shared across processes (the underlying file
+        offset would be shared too, and concurrent seeks would interleave),
+        so each process — e.g. each dataloader worker — lazily opens its
+        own. ``_LazyZipFile`` skips the central-directory parse, so this is
+        O(1) in time and memory.
+
+        :return: The per-process zip handle.
+        """
+        pid = os.getpid()
+        if self._fp_pid != pid:
+            if self._fp is not None:
+                self._fp.close()
+            self._fp = _LazyZipFile(self.path, "r")
+            self._fp_pid = pid
+        return self._fp
+
+    def open(self, name: str, mode: str = "r") -> IO[bytes]:
+        """Open the member ``name`` for reading, like ``ZipFile.open``.
+
+        :param name: The member name.
+        :param mode: Only ``"r"`` is supported (``ZipFile`` also writes).
+        :return: A file-like object with the member's (decompressed)
+            contents.
+        """
+        if mode != "r":
+            raise ValueError("SmartZip only supports opening members with mode='r'")
+        key = name.encode("utf-8")
+        # rightmost match: with the stable name sort, duplicated names keep
+        # their archive order, so this reads the last-written copy exactly
+        # like ZipFile does (e.g. a re-written `metadata/atom_counts.npy`
+        # appended by DiskDatasetWriter shadows the stale one)
+        row = int(np.searchsorted(self._names, key, side="right")) - 1
+        if row < 0 or self._names[row] != key:
+            raise KeyError(f"There is no item named {name!r} in the archive")
+        return self._ensure_fp().open(self._make_zipinfo(row))
+
+    def close(self) -> None:
+        """Close the per-process file handle, if this process opened one."""
+        if self._fp is not None:
+            self._fp.close()
+            self._fp = None
+            self._fp_pid = None
+
+    def __enter__(self) -> "SmartZip":
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        if getattr(self, "_fp", None) is not None:
+            self._fp.close()
+
+    def __getstate__(self) -> Dict[str, Any]:
+        # the open handle is process-local and unpicklable; drop it and let
+        # the unpickling process (e.g. a "spawn" dataloader worker) reopen
+        # lazily
+        state = self.__dict__.copy()
+        state["_fp"] = None
+        state["_fp_pid"] = None
+        return state

--- a/src/metatrain/utils/data/smart_zip.py
+++ b/src/metatrain/utils/data/smart_zip.py
@@ -105,7 +105,8 @@ class SmartZip:
     def namelist(self) -> Iterator[str]:
         """Yield the name of every member (directory entries excluded).
 
-        :return: Iterator over member names, in sorted order.
+        :yield: Member names, in sorted order.
+        :ytype: str
         """
         for name in self._names:
             yield name.decode("utf-8")
@@ -118,7 +119,8 @@ class SmartZip:
         fields the index stores: ``filename``, ``header_offset``,
         ``file_size``, ``CRC``, ``compress_type`` and ``compress_size``.
 
-        :return: Iterator over member infos, in sorted-name order.
+        :yield: Member infos, in sorted-name order.
+        :ytype: zipfile.ZipInfo
         """
         for row in range(len(self._names)):
             yield self._make_zipinfo(row)
@@ -146,12 +148,14 @@ class SmartZip:
         :return: The per-process zip handle.
         """
         pid = os.getpid()
-        if self._fp_pid != pid:
-            if self._fp is not None:
-                self._fp.close()
-            self._fp = _LazyZipFile(self.path, "r")
+        fp = self._fp
+        if fp is None or self._fp_pid != pid:
+            if fp is not None:
+                fp.close()
+            fp = _LazyZipFile(self.path, "r")
+            self._fp = fp
             self._fp_pid = pid
-        return self._fp
+        return fp
 
     def open(self, name: str, mode: str = "r") -> IO[bytes]:
         """Open the member ``name`` for reading, like ``ZipFile.open``.
@@ -187,8 +191,9 @@ class SmartZip:
         self.close()
 
     def __del__(self) -> None:
-        if getattr(self, "_fp", None) is not None:
-            self._fp.close()
+        fp = getattr(self, "_fp", None)
+        if fp is not None:
+            fp.close()
 
     def __getstate__(self) -> Dict[str, Any]:
         # the open handle is process-local and unpicklable; drop it and let

--- a/src/metatrain/utils/data/writers/diskdataset.py
+++ b/src/metatrain/utils/data/writers/diskdataset.py
@@ -1,3 +1,5 @@
+import os
+import warnings
 import zipfile
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, Union
@@ -6,16 +8,60 @@ import metatensor.torch as mts
 import metatomic.torch as mta
 import numpy as np
 import torch
-from metatensor.torch import TensorMap
-from metatomic.torch import ModelCapabilities, System
+from metatensor.torch import Labels, TensorBlock, TensorMap
+from metatomic.torch import ModelCapabilities, System, load_system
 
+from ..dataset import ATOM_COUNTS_MEMBER, _parse_disk_dataset_member_name
 from .writers import Writer, _split_tensormaps
+
+
+def _stamp_system_label(tensor_map: TensorMap, system_index: int) -> TensorMap:
+    """Set the ``"system"`` sample column of every block to ``system_index``.
+
+    Values, components, properties and gradients are preserved.
+
+    :param tensor_map: A single-system TensorMap.
+    :param system_index: The value to write into the ``"system"`` column.
+    :return: The relabeled TensorMap.
+    """
+    blocks = []
+    for block in tensor_map.blocks():
+        samples = block.samples
+        if "system" not in samples.names:
+            raise ValueError(
+                "DiskDatasetWriter targets must have a 'system' sample "
+                f"dimension, got {samples.names}"
+            )
+        column = samples.names.index("system")
+        values = samples.values.clone()
+        if len(values) > 0 and len(torch.unique(values[:, column])) > 1:
+            raise ValueError(
+                "write() was called with a single system but a TensorMap "
+                "containing multiple system ids "
+                f"({torch.unique(values[:, column]).tolist()})"
+            )
+        values[:, column] = system_index
+        new_block = TensorBlock(
+            values=block.values,
+            samples=Labels(samples.names, values),
+            components=block.components,
+            properties=block.properties,
+        )
+        for parameter in block.gradients_list():
+            new_block.add_gradient(parameter, block.gradient(parameter).copy())
+        blocks.append(new_block)
+    return TensorMap(tensor_map.keys, blocks)
 
 
 class DiskDatasetWriter(Writer):
     """
     Write systems and predictions to a zip file, each system in a separate folder inside
     the zip.
+
+    Every finished zip carries a complete ``metadata/atom_counts.npy`` member
+    (the atom count of each entry, in entry order), which is what makes the
+    dataset usable with atom-count-based sampling. The ``metadata/`` folder is
+    reserved for such dataset-level informative files.
 
     :param path: Path to the output zip file.
     :param capabilities: Model capabilities.
@@ -31,23 +77,134 @@ class DiskDatasetWriter(Writer):
         append: Optional[bool] = False,  # if True, open zip in append mode
     ):
         super().__init__(filename=path, capabilities=capabilities, append=append)
+        self._finished = False
+        self._atom_counts_prefix = np.empty(0, dtype=np.int64)
+        self.index = 0
+
+        if append and os.path.exists(path) and os.path.getsize(path) > 0:
+            # Continue indexing after the existing entries, instead of
+            # overwriting them at "0/", "1/", ..., and reconstruct the
+            # atom-count prefix so finish() always leaves a complete
+            # `metadata/atom_counts.npy`. A corrupt existing zip raises
+            # BadZipFile here: appending to it would silently orphan every
+            # existing entry, because mode "a" appends after the corrupt
+            # bytes and writes a fresh central directory that lists only the
+            # new members.
+            with zipfile.ZipFile(path, "r") as existing:
+                self.index, self._atom_counts_prefix = self._scan_existing(
+                    path, existing
+                )
+
         mode: Literal["w", "a"] = "a" if append else "w"
         self.zip_file = zipfile.ZipFile(path, mode)
-        self.index = 0
+        self._atom_counts: List[int] = []
+
+    @staticmethod
+    def _scan_existing(
+        path: Union[str, Path], existing: zipfile.ZipFile
+    ) -> tuple[int, np.ndarray]:
+        """Validate an existing dataset zip and gather its append state.
+
+        :param path: The zip file path (for error messages).
+        :param existing: The zip, opened for reading.
+        :return: The next free entry index and the existing entries' atom
+            counts.
+        """
+        entry_numbers = []
+        counts: Optional[np.ndarray] = None
+        for info in existing.infolist():
+            name = info.filename
+            if name == ATOM_COUNTS_MEMBER:
+                with existing.open(name, "r") as f:
+                    counts = np.load(f)
+                continue
+            # Members that are not part of the format are left alone here;
+            # DiskDataset warns about them when the dataset is read.
+            parsed = _parse_disk_dataset_member_name(name)
+            if parsed is not None and parsed[1] == "system":
+                entry_numbers.append(parsed[0])
+        if not entry_numbers and counts is None:
+            # A non-empty file with no recognizable dataset content: likely a
+            # corrupt zip, or not a DiskDataset at all. Truncated zips can
+            # still parse, exposing an embedded archive's members (system.mta
+            # files are zips themselves). Appending would orphan the content.
+            raise ValueError(
+                f"Cannot append to '{path}': the existing file contains no "
+                "DiskDataset entries; it is corrupted or not a DiskDataset."
+            )
+
+        num_existing = 0
+        if entry_numbers:
+            # Appended entries continue the dense range 0..N-1 that DiskDataset
+            # requires; fail now, while the existing file is still intact,
+            # rather than producing a zip the reader is guaranteed to reject.
+            if not np.array_equal(
+                np.sort(entry_numbers), np.arange(len(entry_numbers))
+            ):
+                raise ValueError(
+                    f"Cannot append to '{path}': its entries are not the dense "
+                    "range `0/`, `1/`, ... (gaps or duplicated entry numbers); "
+                    "re-write the dataset."
+                )
+            num_existing = len(entry_numbers)
+
+        if counts is not None and len(counts) >= num_existing:
+            prefix = counts[:num_existing].astype(np.int64, copy=False)
+        elif num_existing > 0:
+            # The dataset has no usable atom-count file: compute the missing
+            # prefix now (one read per existing system) so the finished zip
+            # is complete.
+            prefix = np.empty(num_existing, dtype=np.int64)
+            for entry in range(num_existing):
+                with existing.open(f"{entry}/system.mta", "r") as f:
+                    prefix[entry] = len(load_system(f))
+        else:
+            prefix = np.empty(0, dtype=np.int64)
+        return num_existing, prefix
 
     def write(self, systems: List[System], predictions: Dict[str, TensorMap]) -> None:
         """
         Write a single (system, predictions) into the zip under
         a new folder "<index>/".
 
+        The stored TensorMaps' ``"system"`` sample labels always hold the
+        entry number, whether the systems arrive batched or one at a time.
+        Distinct labels are required to read the dataset back for training
+        (per-sample maps are joined at collation).
+
         :param systems: List of systems to write.
         :param predictions: Dictionary of TensorMaps with predictions for the systems.
         """
 
         if len(systems) == 1:
-            # Avoid reindexing samples
-            split_predictions = [predictions]
+            # A batch of one carries a single system id already; stamping the
+            # entry number over it (instead of splitting) also supports maps
+            # whose id is not 0, e.g. carrying the sample id of a source
+            # dataset.
+            split_predictions = [
+                {
+                    name: _stamp_system_label(tensor_map, self.index)
+                    for name, tensor_map in predictions.items()
+                }
+            ]
         else:
+            # _split_tensormaps selects samples by batch-local system ids;
+            # any other labeling would silently produce empty members.
+            for name, tensor_map in predictions.items():
+                ids = torch.unique(
+                    torch.cat(
+                        [
+                            block.samples.column("system")
+                            for block in tensor_map.blocks()
+                        ]
+                    )
+                )
+                if ids.tolist() != list(range(len(systems))):
+                    raise ValueError(
+                        f"batched write() requires the '{name}' TensorMap to "
+                        f"label its {len(systems)} systems 0..{len(systems) - 1}, "
+                        f"got system ids {ids.tolist()}"
+                    )
             split_predictions = _split_tensormaps(
                 systems, predictions, istart_system=self.index
             )
@@ -56,6 +213,7 @@ class DiskDatasetWriter(Writer):
             # system
             with self.zip_file.open(f"{self.index}/system.mta", "w") as f:
                 mta.save(f, system.to("cpu").to(torch.float64))
+            self._atom_counts.append(len(system))
 
             # each target
             for target_name, tensor_map in preds.items():
@@ -70,6 +228,22 @@ class DiskDatasetWriter(Writer):
 
     def finish(self) -> None:
         """
-        Close the zip file.
+        Write the complete per-structure atom-count file
+        (``metadata/atom_counts.npy``) and close the zip file. Calling it
+        again is a no-op.
         """
+        if self._finished:
+            return
+        full_counts = np.concatenate(
+            [self._atom_counts_prefix, np.asarray(self._atom_counts, dtype=np.int64)]
+        )
+        # Zip files don't support in-place replacement of an entry: on
+        # append, this adds a second "metadata/atom_counts.npy" rather than
+        # overwriting the first. That is harmless, since reading a duplicated
+        # name returns the last copy written.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Duplicate name")
+            with self.zip_file.open(ATOM_COUNTS_MEMBER, "w") as f:
+                np.save(f, full_counts)
         self.zip_file.close()
+        self._finished = True

--- a/tests/utils/data/test_smart_zip.py
+++ b/tests/utils/data/test_smart_zip.py
@@ -18,7 +18,7 @@ def _make_zip(path, compression=zipfile.ZIP_STORED):
     with zipfile.ZipFile(path, "w", compression) as zf:
         for name, data in PAYLOADS.items():
             zf.writestr(name, data)
-        zf.mkdir("empty_dir")
+        zf.writestr("empty_dir/", b"")  # ZipFile.mkdir needs Python >= 3.11
     return path
 
 

--- a/tests/utils/data/test_smart_zip.py
+++ b/tests/utils/data/test_smart_zip.py
@@ -1,0 +1,151 @@
+import pickle
+import struct
+import zipfile
+
+import pytest
+
+from metatrain.utils.data.smart_zip import SmartZip
+
+
+PAYLOADS = {
+    "0/system.mta": b"alpha" * 100,
+    "1/system.mta": b"bravo" * 200,
+    "readme.txt": b"hello",
+}
+
+
+def _make_zip(path, compression=zipfile.ZIP_STORED):
+    with zipfile.ZipFile(path, "w", compression) as zf:
+        for name, data in PAYLOADS.items():
+            zf.writestr(name, data)
+        zf.mkdir("empty_dir")
+    return path
+
+
+def test_open_reads_members_back(tmp_path):
+    """SmartZip must return exactly the bytes that were written, for any
+    member, in any access order — it replaces ZipFile as the read path of
+    DiskDataset."""
+    smart_zip = SmartZip(_make_zip(tmp_path / "data.zip"))
+    for name in reversed(list(PAYLOADS)):
+        with smart_zip.open(name) as f:
+            assert f.read() == PAYLOADS[name]
+
+
+def test_supports_compressed_members(tmp_path):
+    """Decompression is delegated to ZipExtFile, so compressed zips must read
+    back identically: this is what lets DiskDataset (or future users) support
+    compressed datasets without a different code path."""
+    smart_zip = SmartZip(_make_zip(tmp_path / "data.zip", zipfile.ZIP_DEFLATED))
+    for name in PAYLOADS:
+        with smart_zip.open(name) as f:
+            assert f.read() == PAYLOADS[name]
+
+
+def test_namelist_and_len_skip_directories(tmp_path):
+    """Directory entries are not readable members; listing them would make
+    every consumer re-filter (and DiskDataset would warn about them as
+    unknown members)."""
+    smart_zip = SmartZip(_make_zip(tmp_path / "data.zip"))
+    assert sorted(PAYLOADS) == list(smart_zip.namelist())
+    assert len(smart_zip) == len(PAYLOADS)
+    assert [i.filename for i in smart_zip.infoiter()] == sorted(PAYLOADS)
+
+
+def test_missing_member_is_keyerror(tmp_path):
+    """Same exception type and message as ZipFile.open, so SmartZip can be
+    swapped for ZipFile without changing callers' error handling."""
+    smart_zip = SmartZip(_make_zip(tmp_path / "data.zip"))
+    with pytest.raises(KeyError, match="There is no item named '2/system.mta'"):
+        smart_zip.open("2/system.mta")
+
+
+def test_write_mode_is_rejected(tmp_path):
+    """SmartZip is read-only: a caller expecting ZipFile's mode='w' must fail
+    loudly instead of silently corrupting the archive."""
+    smart_zip = SmartZip(_make_zip(tmp_path / "data.zip"))
+    with pytest.raises(ValueError, match="mode='r'"):
+        smart_zip.open("0/system.mta", mode="w")
+
+
+def test_corrupted_member_is_detected(tmp_path):
+    """Reads verify the member's CRC-32 from the central directory: bit rot
+    must raise instead of returning corrupted bytes."""
+    path = _make_zip(tmp_path / "data.zip")
+    smart_zip = SmartZip(path)
+    with zipfile.ZipFile(path) as zf:
+        offset = zf.getinfo("1/system.mta").header_offset
+    with open(path, "r+b") as f:
+        f.seek(offset + 60)  # inside the member's data
+        byte = f.read(1)
+        f.seek(offset + 60)
+        f.write(bytes([byte[0] ^ 0xFF]))
+
+    with pytest.raises(zipfile.BadZipFile, match="Bad CRC-32"):
+        with smart_zip.open("1/system.mta") as f:
+            f.read()
+
+
+def test_encrypted_members_are_rejected(tmp_path):
+    """SmartZip cannot decrypt members (it rebuilds ZipInfo objects with no
+    flag bits), so encrypted archives must fail at construction, not with a
+    CRC error at some later read."""
+    path = _make_zip(tmp_path / "data.zip")
+    # the stdlib cannot write encrypted zips: flip the encryption flag bit of
+    # the first central-directory entry (2 bytes at offset 8 from the
+    # signature) by hand
+    data = bytearray(path.read_bytes())
+    entry = data.index(b"PK\x01\x02")
+    flags = struct.unpack_from("<H", data, entry + 8)[0]
+    struct.pack_into("<H", data, entry + 8, flags | 0x1)
+    path.write_bytes(bytes(data))
+
+    with pytest.raises(ValueError, match="is encrypted"):
+        SmartZip(path)
+
+
+def test_reads_do_not_construct_zipfile(tmp_path, monkeypatch):
+    """After construction, reads must never re-open zipfile.ZipFile: parsing
+    the central directory materializes one ZipInfo per member, which is what
+    made dataloader workers OOM on large datasets (~10 GB RSS per open for a
+    13M-member zip)."""
+    smart_zip = SmartZip(_make_zip(tmp_path / "data.zip"))
+
+    def _no_zipfile(*args, **kwargs):
+        raise AssertionError("reads must not construct zipfile.ZipFile")
+
+    monkeypatch.setattr(zipfile, "ZipFile", _no_zipfile)
+    with smart_zip.open("0/system.mta") as f:
+        assert f.read() == PAYLOADS["0/system.mta"]
+
+
+def test_duplicated_names_read_last_copy(tmp_path):
+    """ZipFile reads the last copy of a duplicated member name; SmartZip must
+    do the same — DiskDatasetWriter's append mode relies on it, since it
+    appends a fresh `metadata/atom_counts.npy` that shadows the stale one."""
+    path = tmp_path / "data.zip"
+    with warnings_as_duplicate_is_expected():
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("metadata/atom_counts.npy", b"stale")
+            zf.writestr("metadata/atom_counts.npy", b"fresh")
+
+    smart_zip = SmartZip(path)
+    with smart_zip.open("metadata/atom_counts.npy") as f:
+        assert f.read() == b"fresh"
+
+
+def warnings_as_duplicate_is_expected():
+    return pytest.warns(UserWarning, match="Duplicate name")
+
+
+def test_picklable_and_readable_after_unpickling(tmp_path):
+    """Datasets are pickled to dataloader workers under the spawn/forkserver
+    start methods; the process-local file handle must be dropped and lazily
+    reopened, not break pickling (as an open ZipFile would)."""
+    smart_zip = SmartZip(_make_zip(tmp_path / "data.zip"))
+    with smart_zip.open("0/system.mta") as f:  # open a handle to be dropped
+        f.read()
+
+    clone = pickle.loads(pickle.dumps(smart_zip))
+    with clone.open("1/system.mta") as f:
+        assert f.read() == PAYLOADS["1/system.mta"]

--- a/tests/utils/data/test_writers.py
+++ b/tests/utils/data/test_writers.py
@@ -950,7 +950,8 @@ def test_disk_dataset_detects_corrupted_members(monkeypatch, tmp_path):
     writer.finish()
 
     dataset = DiskDataset("test_crc.zip", fields=[])
-    offset = int(dataset._member_locs[0, dataset._member_cols["system"], 0])
+    with zipfile.ZipFile("test_crc.zip") as zf:
+        offset = zf.getinfo("0/system.mta").header_offset
     with open("test_crc.zip", "r+b") as f:
         f.seek(offset + 200)  # inside the member's data
         byte = f.read(1)

--- a/tests/utils/data/test_writers.py
+++ b/tests/utils/data/test_writers.py
@@ -815,7 +815,7 @@ def test_disk_dataset_warns_once_about_ignored_members(monkeypatch, tmp_path):
         zf.writestr("0/notes.txt", "hello")
         zf.writestr("0/sub/system.mta", "x")  # nested: not an entry member
 
-    with pytest.warns(UserWarning, match=r"Ignoring 3 zip member.*readme\.txt"):
+    with pytest.warns(UserWarning, match=r"Skipping 3 file.*readme\.txt"):
         dataset = DiskDataset("test_junk.zip", fields=[])
     assert len(dataset) == 1
     assert len(dataset[0].system) == 2
@@ -825,7 +825,7 @@ def test_disk_dataset_warns_once_about_ignored_members(monkeypatch, tmp_path):
     writer = DiskDatasetWriter("test_junk.zip", append=True)
     writer.write([_make_system(3)], {})
     writer.finish()
-    with pytest.warns(UserWarning, match="Ignoring 3 zip member"):
+    with pytest.warns(UserWarning, match="Skipping 3 file"):
         dataset = DiskDataset("test_junk.zip", fields=[])
     assert dataset.get_all_atom_counts().tolist() == [2, 3]
 
@@ -866,7 +866,7 @@ def test_disk_dataset_tolerates_macos_junk(monkeypatch, tmp_path):
         zf.writestr(".DS_Store", "junk")
         zf.writestr("0/.DS_Store", "junk")
 
-    with pytest.warns(UserWarning, match="Ignoring 3 zip member"):
+    with pytest.warns(UserWarning, match="Skipping 3 file"):
         dataset = DiskDataset("test_macos.zip", fields=[])
     assert len(dataset) == 1
     assert len(dataset[0].system) == 2
@@ -875,7 +875,7 @@ def test_disk_dataset_tolerates_macos_junk(monkeypatch, tmp_path):
     writer = DiskDatasetWriter("test_macos.zip", append=True)
     writer.write([_make_system(3)], {})
     writer.finish()
-    with pytest.warns(UserWarning, match="Ignoring 3 zip member"):
+    with pytest.warns(UserWarning, match="Skipping 3 file"):
         dataset = DiskDataset("test_macos.zip", fields=[])
     assert dataset.get_all_atom_counts().tolist() == [2, 3]
 
@@ -1117,7 +1117,7 @@ def test_disk_dataset_metadata_folder(monkeypatch, tmp_path):
             mta.save(f, _make_system(3))
         with zf.open("_atom_counts.npy", "w") as f:
             np.save(f, np.array([3], dtype=np.int64))
-    with pytest.warns(UserWarning, match=r"Ignoring 1 zip member.*_atom_counts"):
+    with pytest.warns(UserWarning, match=r"Skipping 1 file.*_atom_counts"):
         dataset = DiskDataset("test_toplevel.zip", fields=[])
     with pytest.raises(ValueError, match="has no 'metadata/atom_counts.npy'"):
         dataset.get_all_atom_counts()

--- a/tests/utils/data/test_writers.py
+++ b/tests/utils/data/test_writers.py
@@ -1083,7 +1083,7 @@ def test_disk_dataset_rejects_orphan_and_duplicate_members(monkeypatch, tmp_path
                 np.save(f, energy_buffer)
         with zf.open("7/energy.mts", "w") as f:  # no 7/system.mta
             np.save(f, energy_buffer)
-    with pytest.raises(ValueError, match="duplicated members or field members"):
+    with pytest.raises(ValueError, match="duplicated files or field files"):
         DiskDataset("test_orphan.zip", fields=[])
 
     with zipfile.ZipFile("test_dup_field.zip", "w") as zf:
@@ -1094,7 +1094,7 @@ def test_disk_dataset_rejects_orphan_and_duplicate_members(monkeypatch, tmp_path
             for _ in range(2):
                 with zf.open("0/energy.mts", "w") as f:
                     np.save(f, energy_buffer)
-    with pytest.raises(ValueError, match="duplicated members or field members"):
+    with pytest.raises(ValueError, match="duplicated files or field files"):
         DiskDataset("test_dup_field.zip", fields=[])
 
 

--- a/tests/utils/data/test_writers.py
+++ b/tests/utils/data/test_writers.py
@@ -1,14 +1,17 @@
+import warnings
+import zipfile
 from pathlib import Path
 from typing import Dict, List, Tuple
 
 import metatensor.torch as mts
+import metatomic.torch as mta
 import numpy as np
 import pytest
 import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
 from metatomic.torch import ModelCapabilities, ModelOutput, System
 
-from metatrain.utils.data.dataset import MemmapDataset
+from metatrain.utils.data.dataset import DiskDataset, MemmapDataset
 from metatrain.utils.data.readers.ase import read
 from metatrain.utils.data.writers import (
     ASEWriter,
@@ -17,6 +20,15 @@ from metatrain.utils.data.writers import (
     MetatensorWriter,
     get_writer,
 )
+
+
+def _make_system(n_atoms: int) -> System:
+    return System(
+        positions=torch.zeros((n_atoms, 3), dtype=torch.float64),
+        types=torch.ones(n_atoms, dtype=torch.int32),
+        cell=torch.zeros((3, 3), dtype=torch.float64),
+        pbc=torch.zeros(3, dtype=torch.bool),
+    )
 
 
 def systems_capabilities_predictions(
@@ -579,3 +591,608 @@ def test_memmap_writer_stress_sign_left_handed_cell(monkeypatch, tmp_path):
             atol=1e-4,
             rtol=1e-4,
         )
+
+
+def test_disk_dataset_writer_append_continues_indices(monkeypatch, tmp_path):
+    """append=True must continue indexing after the existing entries.
+
+    Regression test: the writer used to always start at index 0 regardless of
+    ``append``, so a second session silently overwrote ("0/", "1/", ...) the
+    first session's entries instead of adding new ones.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    writer = DiskDatasetWriter("test_append.zip")
+    writer.write([_make_system(2)], {})
+    writer.write([_make_system(5)], {})
+    writer.write([_make_system(3)], {})
+    writer.finish()
+
+    writer = DiskDatasetWriter("test_append.zip", append=True)
+    writer.write([_make_system(8)], {})
+    writer.write([_make_system(4)], {})
+    writer.finish()
+
+    with zipfile.ZipFile("test_append.zip", "r") as zf:
+        names = zf.namelist()
+    for i in range(5):
+        assert f"{i}/system.mta" in names, f"missing entry {i}, index did not continue"
+
+    dataset = DiskDataset("test_append.zip", fields=[])
+    assert len(dataset) == 5
+    # original entries must be untouched, not overwritten by the append session
+    assert len(dataset[0].system) == 2
+    assert len(dataset[1].system) == 5
+    assert len(dataset[2].system) == 3
+    assert len(dataset[3].system) == 8
+    assert len(dataset[4].system) == 4
+
+
+def test_disk_dataset_writer_append_extends_atom_counts(monkeypatch, tmp_path):
+    """The atom-count file must stay complete and correct across appends."""
+    monkeypatch.chdir(tmp_path)
+
+    writer = DiskDatasetWriter("test_append_atom_counts.zip")
+    writer.write([_make_system(2)], {})
+    writer.write([_make_system(5)], {})
+    writer.finish()
+
+    writer = DiskDatasetWriter("test_append_atom_counts.zip", append=True)
+    writer.write([_make_system(8)], {})
+    writer.finish()
+
+    dataset = DiskDataset("test_append_atom_counts.zip", fields=[])
+    # The repo's pytest config turns warnings into errors; if the file were
+    # incomplete this would raise via the "no atom-counts file, backfilling"
+    # warning instead of just returning the (wrong) answer.
+    counts = dataset.get_all_atom_counts()
+    assert counts.tolist() == [2, 5, 8]
+
+
+def test_disk_dataset_writer_append_chain_extends_atom_counts_repeatedly(
+    monkeypatch, tmp_path
+):
+    """Three chained append sessions must each extend the atom counts correctly.
+
+    Also checks that the (expected) duplicate ``metadata/atom_counts.npy`` entries
+    this produces resolve to the last (complete) one on read.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    writer = DiskDatasetWriter("test_append_chain.zip")
+    writer.write([_make_system(1)], {})
+    writer.write([_make_system(2)], {})
+    writer.finish()
+
+    writer = DiskDatasetWriter("test_append_chain.zip", append=True)
+    writer.write([_make_system(3)], {})
+    writer.finish()
+
+    writer = DiskDatasetWriter("test_append_chain.zip", append=True)
+    writer.write([_make_system(4)], {})
+    writer.write([_make_system(5)], {})
+    writer.finish()
+
+    with zipfile.ZipFile("test_append_chain.zip", "r") as zf:
+        n_atom_counts_entries = zf.namelist().count("metadata/atom_counts.npy")
+    assert n_atom_counts_entries == 3
+
+    dataset = DiskDataset("test_append_chain.zip", fields=[])
+    assert len(dataset) == 5
+    assert dataset.get_all_atom_counts().tolist() == [1, 2, 3, 4, 5]
+
+
+def test_disk_dataset_writer_append_without_prior_atom_counts(monkeypatch, tmp_path):
+    """Appending onto a dataset with no atom-count file must reconstruct it.
+
+    A complete `metadata/atom_counts.npy` is a writer-guaranteed invariant (the reader
+    never mutates the dataset, it only errors when the file is missing), so
+    the append session must compute the counts of the entries it didn't write
+    by reading their systems once.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    with zipfile.ZipFile("test_append_no_atom_counts.zip", "w") as zf:
+        for i, n in enumerate([6, 7]):
+            with zf.open(f"{i}/system.mta", "w") as f:
+                mta.save(f, _make_system(n))
+
+    writer = DiskDatasetWriter("test_append_no_atom_counts.zip", append=True)
+    writer.write([_make_system(9)], {})
+    writer.finish()
+
+    with zipfile.ZipFile("test_append_no_atom_counts.zip", "r") as zf:
+        names = zf.namelist()
+    assert "2/system.mta" in names, "index did not continue past the pre-existing 2"
+    dataset = DiskDataset("test_append_no_atom_counts.zip", fields=[])
+    assert len(dataset) == 3
+    assert dataset.get_all_atom_counts().tolist() == [6, 7, 9]
+
+
+def test_disk_dataset_rejects_non_dense_entries(monkeypatch, tmp_path):
+    """Zips with duplicated or missing entry numbers must be rejected loudly:
+    the reader is positional, so reading them would silently return the
+    last-written copy (duplicates) or crash mid-epoch (gaps)."""
+    monkeypatch.chdir(tmp_path)
+
+    # writing the duplicated entry itself warns; that's the very situation
+    # this guard exists for
+    with pytest.warns(UserWarning, match="Duplicate name"):
+        with zipfile.ZipFile("test_duplicates.zip", "w") as zf:
+            for i, n in zip([0, 1, 0], [2, 3, 5], strict=True):
+                with zf.open(f"{i}/system.mta", "w") as f:
+                    mta.save(f, _make_system(n))
+    with pytest.raises(ValueError, match="dense range"):
+        DiskDataset("test_duplicates.zip", fields=[])
+
+    with zipfile.ZipFile("test_gaps.zip", "w") as zf:
+        for i, n in zip([0, 2], [2, 3], strict=True):
+            with zf.open(f"{i}/system.mta", "w") as f:
+                mta.save(f, _make_system(n))
+    with pytest.raises(ValueError, match="dense range"):
+        DiskDataset("test_gaps.zip", fields=[])
+
+
+def test_disk_dataset_reads_bypass_central_directory(monkeypatch, tmp_path):
+    """After construction, reading samples must never re-open zipfile.ZipFile.
+
+    DiskDataset indexes member offsets once at construction; __getitem__ reads
+    by direct seek. Re-parsing the central directory per process is what made
+    dataloader workers OOM on large datasets (~10 GB RSS per open for a
+    13M-member zip), so a read path that silently falls back to zipfile would
+    reintroduce that.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    writer = DiskDatasetWriter("test_no_cd.zip")
+    writer.write([_make_system(2)], {})
+    writer.write([_make_system(4)], {})
+    writer.finish()
+
+    dataset = DiskDataset("test_no_cd.zip", fields=[])
+
+    def _no_zipfile(*args, **kwargs):
+        raise AssertionError("sample reads must not construct zipfile.ZipFile")
+
+    monkeypatch.setattr(zipfile, "ZipFile", _no_zipfile)
+    assert len(dataset[0].system) == 2
+    assert len(dataset[1].system) == 4
+
+
+def test_disk_dataset_rejects_compressed_members(monkeypatch, tmp_path):
+    """DiskDataset zips are STORED-only: users re-zipping a dataset by hand
+    must not compress it, and a compressed member is rejected at construction
+    with a re-zipping hint (not read wrongly or slowly later)."""
+    monkeypatch.chdir(tmp_path)
+
+    writer = DiskDatasetWriter("test_stored.zip")
+    writer.write([_make_system(3)], {})
+    writer.finish()
+
+    with (
+        zipfile.ZipFile("test_stored.zip", "r") as src,
+        zipfile.ZipFile("test_deflated.zip", "w", zipfile.ZIP_DEFLATED) as dst,
+    ):
+        for info in src.infolist():
+            dst.writestr(info.filename, src.read(info.filename))
+
+    with pytest.raises(ValueError, match="must be uncompressed"):
+        DiskDataset("test_deflated.zip", fields=[])
+
+
+def test_disk_dataset_missing_atom_counts_is_a_clean_error(monkeypatch, tmp_path):
+    """The reader never mutates the dataset zip (no locks, no write-back —
+    in-place mutation under distributed training and parallel filesystems is
+    a corruption hazard): a dataset without `metadata/atom_counts.npy` must produce a
+    clear error telling the user how to update it, from both accessors."""
+    monkeypatch.chdir(tmp_path)
+
+    with zipfile.ZipFile("test_no_counts.zip", "w") as zf:
+        for i, n in zip([0, 1], [2, 3], strict=True):
+            with zf.open(f"{i}/system.mta", "w") as f:
+                mta.save(f, _make_system(n))
+
+    dataset = DiskDataset("test_no_counts.zip", fields=[])
+    with pytest.raises(ValueError, match="has no 'metadata/atom_counts.npy'"):
+        dataset.get_all_atom_counts()
+    with pytest.raises(ValueError, match="has no 'metadata/atom_counts.npy'"):
+        dataset.get_num_atoms(0)
+    # normal reading is unaffected
+    assert len(dataset[1].system) == 3
+
+
+def test_disk_dataset_warns_once_about_ignored_members(monkeypatch, tmp_path):
+    """Members that are not part of the format (`<N>/system.mta`,
+    `<N>/<field>.mts`, `metadata/atom_counts.npy`) are tolerated, but a
+    single warning at construction lists them: they are harmless to read,
+    yet a clean DiskDatasetWriter output would contain none of them."""
+    monkeypatch.chdir(tmp_path)
+
+    with zipfile.ZipFile("test_junk.zip", "w") as zf:
+        with zf.open("0/system.mta", "w") as f:
+            mta.save(f, _make_system(2))
+        zf.writestr("readme.txt", "hello")
+        zf.writestr("0/notes.txt", "hello")
+        zf.writestr("0/sub/system.mta", "x")  # nested: not an entry member
+
+    with pytest.warns(UserWarning, match=r"Ignoring 3 zip member.*readme\.txt"):
+        dataset = DiskDataset("test_junk.zip", fields=[])
+    assert len(dataset) == 1
+    assert len(dataset[0].system) == 2
+
+    # the append writer tolerates them too (silently: the reader is where
+    # the diagnosis matters) and leaves them in place
+    writer = DiskDatasetWriter("test_junk.zip", append=True)
+    writer.write([_make_system(3)], {})
+    writer.finish()
+    with pytest.warns(UserWarning, match="Ignoring 3 zip member"):
+        dataset = DiskDataset("test_junk.zip", fields=[])
+    assert dataset.get_all_atom_counts().tolist() == [2, 3]
+
+    # zero-padded entry numbers are not entry members: with no valid entry
+    # left, construction fails (and the ignored files give the clue)
+    with zipfile.ZipFile("test_padded.zip", "w") as zf:
+        with zf.open("00/system.mta", "w") as f:
+            mta.save(f, _make_system(2))
+    with pytest.raises(ValueError, match=r"Could not find any.*00/system\.mta"):
+        DiskDataset("test_padded.zip", fields=[])
+
+
+def test_disk_dataset_no_entries_error_carries_hints(monkeypatch, tmp_path):
+    """The classic hand-zipping mistake — zipping the dataset folder from
+    outside — leaves no valid entries at all; the error lists the ignored
+    members and names the exact command to fix it."""
+    monkeypatch.chdir(tmp_path)
+
+    with zipfile.ZipFile("test_prefixed.zip", "w") as zf:
+        with zf.open("data/0/system.mta", "w") as f:
+            mta.save(f, _make_system(2))
+    with pytest.raises(ValueError, match="cd data"):
+        DiskDataset("test_prefixed.zip", fields=[])
+
+
+def test_disk_dataset_tolerates_macos_junk(monkeypatch, tmp_path):
+    """Zipping on a Mac sprinkles `__MACOSX/` resource forks and `.DS_Store`
+    files into the archive; they are inert, so plain unzip/re-zip on macOS
+    must remain a valid way to produce a DiskDataset — read (with the
+    ignored-members warning) and appended to alike."""
+    monkeypatch.chdir(tmp_path)
+
+    writer = DiskDatasetWriter("test_macos.zip")
+    writer.write([_make_system(2)], {})
+    writer.finish()
+    with zipfile.ZipFile("test_macos.zip", "a") as zf:
+        zf.writestr("__MACOSX/0/._system.mta", "junk")
+        zf.writestr(".DS_Store", "junk")
+        zf.writestr("0/.DS_Store", "junk")
+
+    with pytest.warns(UserWarning, match="Ignoring 3 zip member"):
+        dataset = DiskDataset("test_macos.zip", fields=[])
+    assert len(dataset) == 1
+    assert len(dataset[0].system) == 2
+    assert dataset.get_all_atom_counts().tolist() == [2]
+
+    writer = DiskDatasetWriter("test_macos.zip", append=True)
+    writer.write([_make_system(3)], {})
+    writer.finish()
+    with pytest.warns(UserWarning, match="Ignoring 3 zip member"):
+        dataset = DiskDataset("test_macos.zip", fields=[])
+    assert dataset.get_all_atom_counts().tolist() == [2, 3]
+
+
+def test_disk_dataset_unzip_rezip_roundtrip(monkeypatch, tmp_path):
+    """Unzipping a writer-produced dataset and re-zipping it with standard
+    tools (STORED, from inside the folder) must read back identically —
+    including the directory entries such tools materialize."""
+    monkeypatch.chdir(tmp_path)
+
+    writer = DiskDatasetWriter("original.zip")
+    writer.write([_make_system(2)], {})
+    writer.write([_make_system(5)], {})
+    writer.finish()
+
+    # simulate `cd folder && zip -rX -Z store ../rezipped.zip .`
+    with (
+        zipfile.ZipFile("original.zip", "r") as src,
+        zipfile.ZipFile("rezipped.zip", "w", zipfile.ZIP_STORED) as dst,
+    ):
+        dst.writestr("0/", b"")  # directory entries
+        dst.writestr("1/", b"")
+        for info in src.infolist():
+            dst.writestr(info.filename, src.read(info.filename))
+
+    original = DiskDataset("original.zip", fields=[])
+    rezipped = DiskDataset("rezipped.zip", fields=[])
+    assert len(rezipped) == len(original) == 2
+    assert rezipped.get_all_atom_counts().tolist() == [2, 5]
+    for i in range(2):
+        torch.testing.assert_close(
+            rezipped[i].system.positions, original[i].system.positions
+        )
+
+
+def test_disk_dataset_rejects_heterogeneous_entries(monkeypatch, tmp_path):
+    """Every entry must carry the same fields: a member missing from some
+    entries fails at construction with the entry and field named, instead of
+    crashing whenever that sample happens to be read."""
+    monkeypatch.chdir(tmp_path)
+
+    energy = TensorMap(
+        keys=Labels.single(),
+        blocks=[
+            TensorBlock(
+                values=torch.tensor([[1.0]], dtype=torch.float64),
+                samples=Labels(["system"], torch.tensor([[0]])),
+                components=[],
+                properties=Labels(["energy"], torch.tensor([[0]])),
+            )
+        ],
+    )
+    with zipfile.ZipFile("test_hetero.zip", "w") as zf:
+        for i in range(2):
+            with zf.open(f"{i}/system.mta", "w") as f:
+                mta.save(f, _make_system(2))
+        with zf.open("1/energy.mts", "w") as f:
+            np.save(f, energy.save_buffer().numpy())
+
+    with pytest.raises(ValueError, match="entry 0 has no 'energy'"):
+        DiskDataset("test_hetero.zip", fields=[])
+
+
+def test_disk_dataset_detects_corrupted_members(monkeypatch, tmp_path):
+    """Reads verify the member's CRC-32 from the central directory: bit rot or
+    a truncated copy must raise instead of feeding corrupted bytes (systems,
+    coefficients) into training."""
+    monkeypatch.chdir(tmp_path)
+
+    writer = DiskDatasetWriter("test_crc.zip")
+    writer.write([_make_system(4)], {})
+    writer.finish()
+
+    dataset = DiskDataset("test_crc.zip", fields=[])
+    offset = int(dataset._member_locs[0, dataset._member_cols["system"], 0])
+    with open("test_crc.zip", "r+b") as f:
+        f.seek(offset + 200)  # inside the member's data
+        byte = f.read(1)
+        f.seek(offset + 200)
+        f.write(bytes([byte[0] ^ 0xFF]))
+
+    with pytest.raises(zipfile.BadZipFile, match="Bad CRC-32|corrupted"):
+        dataset[0]
+
+
+def test_disk_dataset_rejects_out_of_range_indices(monkeypatch, tmp_path):
+    """Negative indices must not silently wrap to another sample (numpy
+    semantics) — the returned system_index would then lie about which
+    structure the data belongs to."""
+    monkeypatch.chdir(tmp_path)
+
+    writer = DiskDatasetWriter("test_range.zip")
+    writer.write([_make_system(2)], {})
+    writer.write([_make_system(3)], {})
+    writer.finish()
+
+    dataset = DiskDataset("test_range.zip", fields=[])
+    with pytest.raises(IndexError, match="out of range"):
+        dataset[-1]
+    with pytest.raises(IndexError, match="out of range"):
+        dataset[2]
+
+
+def test_disk_dataset_writer_append_rejects_corrupt_zip(monkeypatch, tmp_path):
+    """Appending to a corrupt zip must fail loudly, with the file untouched:
+    zipfile mode 'a' would append blindly after the corrupt bytes and write a
+    central directory listing only the new members, silently discarding every
+    prior entry."""
+    monkeypatch.chdir(tmp_path)
+
+    writer = DiskDatasetWriter("test_corrupt.zip")
+    writer.write([_make_system(2)], {})
+    writer.write([_make_system(3)], {})
+    writer.finish()
+
+    # Truncation can leave the trailing bytes of an *embedded* archive
+    # (system.mta members are zips themselves), whose end-of-directory record
+    # zipfile then finds: depending on where the cut lands, the probe raises
+    # BadZipFile directly or our format validation rejects the bogus member
+    # names. Either way it must raise before anything is written.
+    size = Path("test_corrupt.zip").stat().st_size
+    before = Path("test_corrupt.zip").read_bytes()[: size // 2]
+    with open("test_corrupt.zip", "r+b") as f:
+        f.truncate(size // 2)
+
+    with pytest.raises((zipfile.BadZipFile, ValueError)):
+        DiskDatasetWriter("test_corrupt.zip", append=True)
+    assert Path("test_corrupt.zip").read_bytes() == before, "file was modified"
+
+
+def test_disk_dataset_writer_append_rejects_non_dense_zip(monkeypatch, tmp_path):
+    """Appending to a gapped zip must fail while the file is still intact:
+    the reader is guaranteed to reject the result, so appending hours of
+    writes to it would produce an unreadable dataset."""
+    monkeypatch.chdir(tmp_path)
+
+    with zipfile.ZipFile("test_gapped.zip", "w") as zf:
+        for i in [0, 2]:
+            with zf.open(f"{i}/system.mta", "w") as f:
+                mta.save(f, _make_system(2))
+
+    with pytest.raises(ValueError, match="dense range"):
+        DiskDatasetWriter("test_gapped.zip", append=True)
+
+
+def test_disk_dataset_writer_append_fresh_file_writes_counts(monkeypatch, tmp_path):
+    """append=True on a nonexistent (or empty) path is a fresh write: the
+    counts file must be written like in write mode, not silently omitted."""
+    monkeypatch.chdir(tmp_path)
+
+    writer = DiskDatasetWriter("fresh.zip", append=True)
+    writer.write([_make_system(4)], {})
+    writer.finish()
+
+    dataset = DiskDataset("fresh.zip", fields=[])
+    assert dataset.get_all_atom_counts().tolist() == [4]
+
+    Path("empty.zip").touch()
+    writer = DiskDatasetWriter("empty.zip", append=True)
+    writer.write([_make_system(6)], {})
+    writer.finish()
+    assert DiskDataset("empty.zip", fields=[]).get_all_atom_counts().tolist() == [6]
+
+
+def test_disk_dataset_writer_finish_is_idempotent(monkeypatch, tmp_path):
+    """finish() in a finally block is a natural idiom; a second call must be
+    a no-op, not an 'archive already closed' crash."""
+    monkeypatch.chdir(tmp_path)
+
+    writer = DiskDatasetWriter("test_finish.zip")
+    writer.write([_make_system(2)], {})
+    writer.finish()
+    writer.finish()
+
+    assert DiskDataset("test_finish.zip", fields=[]).get_all_atom_counts().tolist() == [
+        2
+    ]
+
+
+def test_disk_dataset_rejects_orphan_and_duplicate_members(monkeypatch, tmp_path):
+    """Field members for entries without a system, and duplicated member
+    names, are out of spec: both must fail at construction instead of being
+    silently dropped or silently last-wins."""
+    monkeypatch.chdir(tmp_path)
+
+    energy = TensorMap(
+        keys=Labels.single(),
+        blocks=[
+            TensorBlock(
+                values=torch.tensor([[1.0]], dtype=torch.float64),
+                samples=Labels(["system"], torch.tensor([[0]])),
+                components=[],
+                properties=Labels(["energy"], torch.tensor([[0]])),
+            )
+        ],
+    )
+    energy_buffer = energy.save_buffer().numpy()
+
+    with zipfile.ZipFile("test_orphan.zip", "w") as zf:
+        for i in range(2):
+            with zf.open(f"{i}/system.mta", "w") as f:
+                mta.save(f, _make_system(2))
+            with zf.open(f"{i}/energy.mts", "w") as f:
+                np.save(f, energy_buffer)
+        with zf.open("7/energy.mts", "w") as f:  # no 7/system.mta
+            np.save(f, energy_buffer)
+    with pytest.raises(ValueError, match="duplicated members or field members"):
+        DiskDataset("test_orphan.zip", fields=[])
+
+    with zipfile.ZipFile("test_dup_field.zip", "w") as zf:
+        with zf.open("0/system.mta", "w") as f:
+            mta.save(f, _make_system(2))
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Duplicate name")
+            for _ in range(2):
+                with zf.open("0/energy.mts", "w") as f:
+                    np.save(f, energy_buffer)
+    with pytest.raises(ValueError, match="duplicated members or field members"):
+        DiskDataset("test_dup_field.zip", fields=[])
+
+
+def test_disk_dataset_metadata_folder(monkeypatch, tmp_path):
+    """The atom counts can ONLY come from `metadata/atom_counts.npy`: other
+    files (even a plausible-looking top-level `_atom_counts.npy`) are
+    ignored-with-warning, never read as counts."""
+    monkeypatch.chdir(tmp_path)
+
+    writer = DiskDatasetWriter("test_meta.zip")
+    writer.write([_make_system(2)], {})
+    writer.finish()
+    with zipfile.ZipFile("test_meta.zip", "r") as zf:
+        assert "metadata/atom_counts.npy" in zf.namelist()
+    dataset = DiskDataset("test_meta.zip", fields=[])
+    assert dataset.get_all_atom_counts().tolist() == [2]
+
+    with zipfile.ZipFile("test_toplevel.zip", "w") as zf:
+        with zf.open("0/system.mta", "w") as f:
+            mta.save(f, _make_system(3))
+        with zf.open("_atom_counts.npy", "w") as f:
+            np.save(f, np.array([3], dtype=np.int64))
+    with pytest.warns(UserWarning, match=r"Ignoring 1 zip member.*_atom_counts"):
+        dataset = DiskDataset("test_toplevel.zip", fields=[])
+    with pytest.raises(ValueError, match="has no 'metadata/atom_counts.npy'"):
+        dataset.get_all_atom_counts()
+
+
+def test_disk_dataset_writer_single_and_batched_writes_match(monkeypatch, tmp_path):
+    """Writing systems one at a time or in one batched call must produce
+    identical datasets: the stored "system" sample labels always hold the
+    entry number. Without this, `mtt eval` with batch_size=1 (the default)
+    produced zips whose targets all carried system=0, which crash at
+    collation when training on them."""
+    monkeypatch.chdir(tmp_path)
+
+    def energy_map(values, system_ids):
+        return TensorMap(
+            Labels.single(),
+            [
+                TensorBlock(
+                    values=torch.tensor(values, dtype=torch.float64),
+                    samples=Labels(["system"], torch.tensor(system_ids).reshape(-1, 1)),
+                    components=[],
+                    properties=Labels(["energy"], torch.tensor([[0]])),
+                )
+            ],
+        )
+
+    systems = [_make_system(n) for n in (2, 5, 3)]
+
+    writer = DiskDatasetWriter("batched.zip")
+    writer.write(systems, {"energy": energy_map([[1.0], [2.0], [3.0]], [0, 1, 2])})
+    writer.finish()
+
+    # one at a time, every map carrying system=0 (an eval batch of one), and
+    # the last carrying an unrelated source id (a dumped-dataset scenario)
+    writer = DiskDatasetWriter("singles.zip")
+    writer.write(systems[:1], {"energy": energy_map([[1.0]], [0])})
+    writer.write(systems[1:2], {"energy": energy_map([[2.0]], [0])})
+    writer.write(systems[2:], {"energy": energy_map([[3.0]], [77])})
+    writer.finish()
+
+    batched = DiskDataset("batched.zip", fields=["energy"])
+    singles = DiskDataset("singles.zip", fields=["energy"])
+    assert len(batched) == len(singles) == 3
+    for i in range(3):
+        block_b = batched[i].energy.block()
+        block_s = singles[i].energy.block()
+        assert block_b.samples == block_s.samples
+        assert block_s.samples.values[0, 0] == i, "label must be the entry number"
+        torch.testing.assert_close(block_b.values, block_s.values)
+
+    # a "single system" write with a genuinely multi-system map is an error
+    writer = DiskDatasetWriter("bad.zip")
+    with pytest.raises(ValueError, match="multiple system ids"):
+        writer.write(systems[:1], {"energy": energy_map([[1.0], [2.0]], [0, 1])})
+    writer.finish()
+
+
+def test_disk_dataset_writer_batched_write_rejects_foreign_ids(monkeypatch, tmp_path):
+    """Batched writes split samples by batch-local system ids (0..B-1); maps
+    labeled with anything else used to produce silently EMPTY target members.
+    They must be rejected loudly instead."""
+    monkeypatch.chdir(tmp_path)
+
+    systems = [_make_system(2), _make_system(3)]
+    energy = TensorMap(
+        Labels.single(),
+        [
+            TensorBlock(
+                values=torch.tensor([[1.0], [2.0]], dtype=torch.float64),
+                samples=Labels(["system"], torch.tensor([[5], [2]])),
+                components=[],
+                properties=Labels(["energy"], torch.tensor([[0]])),
+            )
+        ],
+    )
+    writer = DiskDatasetWriter("test_foreign.zip")
+    with pytest.raises(ValueError, match=r"label its 2 systems 0\.\.1"):
+        writer.write(systems, {"energy": energy})
+    writer.finish()


### PR DESCRIPTION
This PR makes `max_atoms_per_batch` work with `DiskDatset` and reworks DiskDataset reading so it scales to large datasets.

DiskDatasetWriter now always writes a `metadata` folder containing (for now, can be extended with more info in the future) an `atom_counts.npy` file with an array containing the number of atoms in every system. This file can be quickly read by the max atoms sampler without the need for opening every folder in the zip file. 
The job crashes with a clear error if `max_atoms_per_batch` is requested but the file is missing. 

Other improvements:
- DiskDataset used to open a `zipfile.ZipFile` per dataloader worker, risking overfilling the RAM and taking time for very larget datasets (~100GB or more, as it's the case for densities in big datasets): now it's opened once at construction and some numpy arrays storing relevant information are stored in memory for later use
- DiskDataset has a stricter format, failing with clear error when e.g. the folders are not "dense" (i.e., not `0..N-1`, with `N` the number of systems in the dataset, or when it's a compressed zip file. The error message suggests solution (e.g. the zip command to avoid compression, or to use DiskDatasetWriter)
- Fixed DiskDatasetWriter in append mode

Possible mild conflict with #1142 but I think it's manageable (we'll have to decide how to handle the case when the atom counts file is not present but `get_num_atoms` is implemeted by that PR)

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - ~~[ ] Issue referenced (for PRs that solve an issue)?~~

# Maintainer/Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?
 - [x] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1205.org.readthedocs.build/en/1205/

<!-- readthedocs-preview metatrain end -->