### PR TITLE
Add explicit gradients to the LLPR energy ensemble

### DIFF
--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -53,6 +53,9 @@ Added
   being refitted from the training data.
 - Rotational augmentation now supports atomic-basis targets and Cartesian targets of
   rank > 2.
+- LLPR energy ensembles can now return explicit ``positions`` and ``strain`` gradients,
+  giving per-member forces and virials, and hence their uncertainty, straight from the
+  exported model.
 
 Changed
 #######

--- a/src/metatrain/llpr/model.py
+++ b/src/metatrain/llpr/model.py
@@ -10,6 +10,7 @@ from metatomic.torch import (
     ModelMetadata,
     ModelOutput,
     System,
+    register_autograd_neighbors,
 )
 from torch.utils.data import DataLoader
 
@@ -41,6 +42,8 @@ from .documentation import ModelHypers
 
 class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
     __checkpoint_version__ = 4
+
+    ensemble_gradient_outputs: List[str]
 
     # all torch devices and dtypes are supported, if they are supported by the wrapped
     # the check is performed in the trainer
@@ -191,6 +194,10 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
 
         # register buffers for ensemble weights and ensemble outputs
         ensemble_outputs = {}
+        # ensemble outputs `forward` is able to attach explicit gradients to, resolved
+        # here from the wrapped model's outputs so that `forward` does not have to
+        # re-derive it (and cannot disagree with the advertised capabilities)
+        self.ensemble_gradient_outputs: List[str] = []
         for name in self.ensemble_weight_sizes:
             if name not in self.outputs_list:
                 raise ValueError(
@@ -207,10 +214,16 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
             )
             if ensemble_output_name == "mtt::aux::energy_ensemble":
                 ensemble_output_name = "energy_ensemble"
+            explicit_gradients = _ensemble_explicit_gradients(
+                old_capabilities.outputs[name]
+            )
+            if len(explicit_gradients) > 0:
+                self.ensemble_gradient_outputs.append(ensemble_output_name)
             ensemble_outputs[ensemble_output_name] = ModelOutput(
                 quantity=old_capabilities.outputs[name].quantity,
                 unit=old_capabilities.outputs[name].unit,
                 sample_kind=old_capabilities.outputs[name].sample_kind,
+                explicit_gradients=explicit_gradients,
                 description=f"ensemble of '{name}'",
             )
         self.capabilities = ModelCapabilities(
@@ -388,6 +401,27 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
                 continue
             outputs_for_model[name] = output
 
+        # Explicit gradients of an energy ensemble require grad-enabled positions/cell
+        # and autograd-registered neighbor lists *before* the wrapped model runs.
+        # Engines generally hand over systems without any of this set up, so rebuild
+        # them here if needed.
+        for name, output in outputs.items():
+            if (
+                name in self.ensemble_gradient_outputs
+                and len(output.explicit_gradients) > 0
+            ):
+                if selected_atoms is not None:
+                    # the gradient samples built by `_add_energy_ensemble_gradients`
+                    # assume one value sample per system, in order, and cover every
+                    # atom of every system. A selection can drop systems from the
+                    # value block, which leaves the two out of sync.
+                    raise ValueError(
+                        f"explicit gradients of '{name}' are not supported together "
+                        "with 'selected_atoms'"
+                    )
+                systems = self._systems_with_grad(systems)
+                break
+
         return_dict = self.model(systems, outputs_for_model, selected_atoms)
 
         requested_uncertainties: List[str] = []
@@ -564,19 +598,57 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
             # for the num_ens dimension
             old_prop_val = return_dict[original_name].block().properties.values
             num_samples = old_prop_val.shape[0]
-            exp_prop_val = old_prop_val.repeat(num_ens, 1)
             ens_idxs = torch.arange(
                 num_ens,
                 device=old_prop_val.device,
                 dtype=old_prop_val.dtype,
             )
             ens_idxs = ens_idxs.repeat_interleave(num_samples).unsqueeze(1)
-            new_prop_val = torch.cat([ens_idxs, exp_prop_val], dim=-1)
-            ens_prop = Labels(
-                names=["ensemble_member"]
-                + return_dict[original_name].block().properties.names,
-                values=new_prop_val,
+            if ens_name == "energy_ensemble":
+                # "energy_ensemble" quantity requires a single "energy"
+                # property column holding the ensemble member index
+                ens_prop = Labels(names=["energy"], values=ens_idxs)
+            else:
+                exp_prop_val = old_prop_val.repeat(num_ens, 1)
+                new_prop_val = torch.cat([ens_idxs, exp_prop_val], dim=-1)
+                ens_prop = Labels(
+                    names=["ensemble_member"]
+                    + return_dict[original_name].block().properties.names,
+                    values=new_prop_val,
+                )
+
+            ensemble_block = TensorBlock(
+                values=ensemble_values,
+                samples=ll_features.block().samples,
+                components=return_dict[original_name].block().components,
+                properties=ens_prop,
             )
+
+            if ens_name in self.ensemble_gradient_outputs:
+                requested_gradients = outputs[ens_name].explicit_gradients
+                want_positions = "positions" in requested_gradients
+                want_strain = "strain" in requested_gradients
+                if want_positions or want_strain:
+                    if outputs[ens_name].sample_kind != "system":
+                        # `_add_energy_ensemble_gradients` assumes one sample per
+                        # system. For a per-atom energy it would silently return the
+                        # gradient of the summed energy, labelled as if it were
+                        # per-sample, so refuse rather than produce wrong numbers.
+                        raise ValueError(
+                            f"explicit gradients of '{ens_name}' are only "
+                            "supported for a per-system energy, but this output was "
+                            f"requested with sample_kind "
+                            f"'{outputs[ens_name].sample_kind}'"
+                        )
+                    self._add_energy_ensemble_gradients(
+                        ensemble_block,
+                        systems,
+                        ensemble_values,
+                        ens_prop,
+                        num_ens,
+                        want_positions,
+                        want_strain,
+                    )
 
             ensemble = TensorMap(
                 keys=Labels(
@@ -585,14 +657,7 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
                         [[0]], device=ll_features.block().values.device
                     ),
                 ),
-                blocks=[
-                    TensorBlock(
-                        values=ensemble_values,
-                        samples=ll_features.block().samples,
-                        components=return_dict[original_name].block().components,
-                        properties=ens_prop,
-                    ),
-                ],
+                blocks=[ensemble_block],
             )
 
             return_dict[ens_name] = ensemble
@@ -605,6 +670,186 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
                 return_dict.pop(key)
 
         return return_dict
+
+    def _systems_with_grad(self, systems: List[System]) -> List[System]:
+        """Rebuild ``systems`` so that positions and cell require grad and neighbor
+        lists are registered with autograd, as needed by
+        ``_add_energy_ensemble_gradients``.
+
+        Systems whose positions and cell already require grad (e.g. because the
+        engine is doing its own autograd on top of this call) are passed through
+        untouched, keeping the caller's graph intact. Everything else is replaced by
+        a copy built on grad-enabled positions/cell tensors, with neighbor lists
+        re-registered against them.
+
+        A tensor that already requires grad is *reused as is* rather than detached,
+        even when only one of positions/cell does. Detaching it would silently cut
+        the caller out of the graph: an engine that grad-enables positions only (as
+        one doing forces but not stress does) would then get "one of the
+        differentiated Tensors appears to not have been used in the graph" from its
+        own backward pass.
+
+        :param systems: systems to rebuild.
+        :return: list with one system per input system, either the original object
+            (already grad-enabled) or its grad-enabled copy.
+        """
+        new_systems: List[System] = []
+        for system in systems:
+            if system.positions.requires_grad and system.cell.requires_grad:
+                new_systems.append(system)
+                continue
+            positions = system.positions
+            if not positions.requires_grad:
+                positions = positions.detach().requires_grad_(True)
+            cell = system.cell
+            if not cell.requires_grad:
+                cell = cell.detach().requires_grad_(True)
+            new_system = System(system.types, positions, cell, system.pbc)
+            for nl_options in system.known_neighbor_lists():
+                neighbors = mts.detach_block(system.get_neighbor_list(nl_options))
+                register_autograd_neighbors(new_system, neighbors, False)
+                new_system.add_neighbor_list(nl_options, neighbors)
+            for data_name in system.known_data():
+                new_system.add_data(data_name, system.get_data(data_name))
+            new_systems.append(new_system)
+        return new_systems
+
+    def _add_energy_ensemble_gradients(
+        self,
+        ensemble_block: TensorBlock,
+        systems: List[System],
+        ensemble_values: torch.Tensor,
+        ens_prop: Labels,
+        num_ens: int,
+        want_positions: bool,
+        want_strain: bool,
+    ) -> None:
+        """Attach "positions"/"strain" gradients to an "energy_ensemble" block.
+
+        Positions and cell are differentiated directly (no strain-trick deformation
+        needed): since the "strain" gradient is evaluated at strain = identity, the
+        virial can be recovered from the positions/cell gradients alone as
+        ``positions^T @ d(output)/d(positions) + cell^T @ d(output)/d(cell)``, which is
+        numerically equivalent to differentiating w.r.t. an explicit strain parameter.
+        This avoids needing a dedicated strain tensor.
+
+        :param ensemble_block: the "energy_ensemble" value block gradients are
+            attached to, in place, via ``add_gradient``.
+        :param systems: the systems this batch was computed for; ``positions`` and
+            ``cell`` must already require grad (ensured by ``_systems_with_grad`` in
+            ``forward``, or set up by the caller) for any of this to produce
+            non-trivial gradients.
+        :param ensemble_values: the (already recentered) ensemble values, with shape
+            ``(num_samples, num_ens)`` (one row per system, one column per ensemble
+            member). This is only valid for the "energy" quantity, which has no
+            components and a single property.
+        :param ens_prop: properties of ``ensemble_block``, reused verbatim for the
+            gradient blocks, as required by metatensor.
+        :param num_ens: number of ensemble members.
+        :param want_positions: whether to attach a "positions" gradient.
+        :param want_strain: whether to attach a "strain" gradient.
+        """
+        # one column per ensemble member, i.e. a single property and no components:
+        # anything else interleaves the properties with the members, and the
+        # member-by-member differentiation below would pick the wrong columns
+        if len(ensemble_values.shape) != 2 or ensemble_values.shape[1] != num_ens:
+            raise ValueError(
+                "explicit gradients of an energy ensemble are only supported for a "
+                "single-property energy without components"
+            )
+
+        n_systems = len(systems)
+        all_positions = [system.positions for system in systems]
+        all_cells = [system.cell for system in systems]
+        n_atoms_per_system = [p.shape[0] for p in all_positions]
+        # cells are only differentiated when the strain gradient is actually wanted:
+        # asking autograd for them otherwise costs a gradient per system per member
+        # that is then discarded
+        grad_inputs = all_positions + all_cells if want_strain else all_positions
+
+        dtype = ensemble_values.dtype
+        device = ensemble_values.device
+        n_atoms_total = sum(n_atoms_per_system)
+
+        positions_grad_values = torch.zeros(
+            (n_atoms_total, 3, num_ens), dtype=dtype, device=device
+        )
+        strain_grad_values = torch.zeros(
+            (n_systems, 3, 3, num_ens) if want_strain else (0, 3, 3, num_ens),
+            dtype=dtype,
+            device=device,
+        )
+
+        for member in range(num_ens):
+            grads = torch.autograd.grad(
+                [ensemble_values[:, member].sum()],
+                grad_inputs,
+                # never False: the graph may be the caller's (see `_systems_with_grad`,
+                # which passes already-grad-enabled systems straight through), and
+                # freeing it here would break the caller's own backward pass with
+                # "trying to backward through the graph a second time". The graph is
+                # released normally once the last reference to it goes away.
+                retain_graph=True,
+                create_graph=False,
+            )
+
+            atom_offset = 0
+            for s in range(n_systems):
+                pos_grad = grads[s]
+                assert pos_grad is not None
+
+                n_atoms_s = n_atoms_per_system[s]
+                # store dE/dr directly (not the force -dE/dr)
+                positions_grad_values[
+                    atom_offset : atom_offset + n_atoms_s, :, member
+                ] = pos_grad
+                if want_strain:
+                    cell_grad = grads[n_systems + s]
+                    assert cell_grad is not None
+                    strain_grad_values[s, :, :, member] = (
+                        all_positions[s].detach().t() @ pos_grad
+                        + all_cells[s].detach().t() @ cell_grad
+                    )
+                atom_offset += n_atoms_s
+
+        xyz = torch.tensor([[0], [1], [2]], device=device)
+
+        if want_positions:
+            sample_col = torch.repeat_interleave(
+                torch.arange(n_systems, device=device),
+                torch.tensor(n_atoms_per_system, device=device),
+            )
+            atom_col = torch.cat(
+                [torch.arange(n, device=device) for n in n_atoms_per_system]
+            )
+            ensemble_block.add_gradient(
+                "positions",
+                TensorBlock(
+                    values=positions_grad_values,
+                    samples=Labels(
+                        names=["sample", "system", "atom"],
+                        values=torch.stack([sample_col, sample_col, atom_col], dim=1),
+                    ),
+                    components=[Labels(["xyz"], xyz)],
+                    properties=ens_prop,
+                ),
+            )
+
+        if want_strain:
+            # build the "sample" Labels with the plain constructor, not
+            # `Labels.range(...)` as the latter breaks TorchScript compatibility
+            ensemble_block.add_gradient(
+                "strain",
+                TensorBlock(
+                    values=strain_grad_values,
+                    samples=Labels(
+                        names=["sample"],
+                        values=torch.arange(n_systems, device=device).reshape(-1, 1),
+                    ),
+                    components=[Labels(["xyz_1"], xyz), Labels(["xyz_2"], xyz)],
+                    properties=ens_prop,
+                ),
+            )
 
     def compute_covariance(
         self,
@@ -902,6 +1147,7 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
                 quantity=old_outputs[name].quantity,
                 unit=old_outputs[name].unit,
                 sample_kind=old_outputs[name].sample_kind,
+                explicit_gradients=_ensemble_explicit_gradients(old_outputs[name]),
                 description=f"ensemble of {name}",
             )
         self.capabilities = ModelCapabilities(
@@ -1065,6 +1311,30 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
 
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.capabilities.outputs
+
+
+def _ensemble_explicit_gradients(output: ModelOutput) -> List[str]:
+    """Explicit gradients the ensemble of ``output`` is able to produce.
+
+    ``_add_energy_ensemble_gradients`` differentiates one per-system scalar per
+    ensemble member, so what matters is that the output *is* a per-system energy,
+    not what it is called: an energy target may carry any name (``mtt::my_energy``)
+    and any variant (``energy/pbesol``). Selecting on the quantity rather than on the
+    name keeps all of those working.
+
+    Other quantities get nothing: positions/strain gradients of them are not what
+    this computes.
+
+    Note that ``sample_kind`` is deliberately *not* consulted here. In capabilities
+    it describes what the wrapped model is able to produce (PET reports ``"atom"``
+    for its energy even when the target is per-system), not what a given call asks
+    for. Whether the *requested* sample kind is supported is checked in ``forward``,
+    where the request is actually known.
+
+    :param output: the wrapped model's output the ensemble is built from.
+    :return: gradient names for the corresponding ensemble output.
+    """
+    return ["positions", "strain"] if output.quantity == "energy" else []
 
 
 def _get_uncertainty_name(name: str) -> str:

--- a/src/metatrain/llpr/tests/test_energy_ensemble_gradients.py
+++ b/src/metatrain/llpr/tests/test_energy_ensemble_gradients.py
@@ -1,0 +1,419 @@
+import copy
+
+import metatensor.torch as mts
+import pytest
+import torch
+from metatensor.torch import Labels
+from metatomic.torch import (
+    ModelEvaluationOptions,
+    ModelOutput,
+    System,
+    load_atomistic_model,
+)
+from omegaconf import OmegaConf
+
+from metatrain.llpr import LLPRUncertaintyModel
+from metatrain.llpr import Trainer as LLPRTrainer
+from metatrain.llpr.model import _get_uncertainty_name
+from metatrain.pet import PET
+from metatrain.pet import Trainer as PETTrainer
+from metatrain.utils.data import DatasetInfo, get_atomic_types, get_dataset
+from metatrain.utils.data.readers import read_systems
+from metatrain.utils.data.target_info import get_generic_target_info
+from metatrain.utils.hypers import init_with_defaults
+from metatrain.utils.loss import LossSpecification
+from metatrain.utils.neighbor_lists import (
+    get_requested_neighbor_lists,
+    get_system_with_neighbor_lists,
+)
+
+from . import DATASET_WITH_FORCES_PATH, DEFAULT_HYPERS_LLPR, DEFAULT_HYPERS_PET
+
+
+DTYPE = torch.float64
+GRADIENTS = ["positions", "strain"]
+ENSEMBLE = "energy_ensemble"
+
+# gradients are computed once per member, so runtime scales with this
+NUM_ENSEMBLE_MEMBERS = 8
+
+# two runs of the same model should differ by numerical noise only
+SAME_MODEL = {"atol": 1e-10, "rtol": 1e-8}
+
+SMALL_PET = {
+    "d_pet": 16,
+    "d_head": 16,
+    "d_node": 16,
+    "d_feedforward": 16,
+    "num_heads": 2,
+    "num_attention_layers": 1,
+    "num_gnn_layers": 1,
+}
+
+
+@pytest.fixture(scope="module")
+def wrapped_pet(tmp_path_factory):
+    """A one-epoch PET, as the checkpoint and the arguments needed to wrap it."""
+    torch.manual_seed(0)
+
+    targets = {
+        "energy": {
+            "quantity": "energy",
+            "read_from": DATASET_WITH_FORCES_PATH,
+            "reader": "ase",
+            "key": "energy",
+            "unit": "eV",
+            "type": "scalar",
+            "sample_kind": "system",
+            "num_subtargets": 1,
+            "forces": False,
+            "stress": False,
+            "virial": False,
+        }
+    }
+    dataset, targets_info, _ = get_dataset(
+        {
+            "systems": {"read_from": DATASET_WITH_FORCES_PATH, "reader": "ase"},
+            "targets": targets,
+        }
+    )
+    dataset_info = DatasetInfo(
+        length_unit="Angstrom",
+        atomic_types=get_atomic_types(dataset),
+        targets=targets_info,
+    )
+
+    pet_hypers = copy.deepcopy(DEFAULT_HYPERS_PET)
+    pet_hypers["model"].update(SMALL_PET)
+    pet_hypers["training"]["num_epochs"] = 1
+    pet_hypers["training"]["loss"] = OmegaConf.to_container(
+        OmegaConf.create({"energy": init_with_defaults(LossSpecification)}),
+        resolve=True,
+    )
+
+    train_kwargs = {
+        "dtype": DTYPE,
+        "devices": [torch.device("cpu")],
+        "train_datasets": [dataset],
+        "val_datasets": [dataset],
+        "checkpoint_dir": "",
+    }
+    pet_model = PET(pet_hypers["model"], dataset_info)
+    pet_trainer = PETTrainer(pet_hypers["training"])
+    pet_trainer.train(pet_model, **train_kwargs)
+
+    checkpoint_path = str(tmp_path_factory.mktemp("llpr") / "pet.ckpt")
+    pet_trainer.save_checkpoint(pet_model, checkpoint_path)
+
+    return checkpoint_path, dataset_info, train_kwargs
+
+
+def wrap_in_llpr(wrapped_pet, num_ensemble_members) -> LLPRUncertaintyModel:
+    """The trained LLPR wrapper around ``wrapped_pet``, with those ensemble sizes."""
+    checkpoint_path, dataset_info, train_kwargs = wrapped_pet
+
+    llpr_hypers = copy.deepcopy(DEFAULT_HYPERS_LLPR)
+    llpr_hypers["model"]["num_ensemble_members"] = num_ensemble_members
+    llpr_hypers["training"].update(model_checkpoint=checkpoint_path, batch_size=4)
+    model = LLPRUncertaintyModel(llpr_hypers["model"], dataset_info)
+    LLPRTrainer(llpr_hypers["training"]).train(model, **train_kwargs)
+
+    return model
+
+
+@pytest.fixture(scope="module")
+def llpr_model(wrapped_pet) -> LLPRUncertaintyModel:
+    """A one-epoch PET wrapped in LLPR, with an ensemble over the energy."""
+    return wrap_in_llpr(wrapped_pet, {"energy": NUM_ENSEMBLE_MEMBERS})
+
+
+def ensemble_output(gradients=GRADIENTS, sample_kind="system", name=ENSEMBLE):
+    """The ``outputs`` argument requesting the ensemble ``name`` with ``gradients``."""
+    return {
+        name: ModelOutput(sample_kind=sample_kind, explicit_gradients=list(gradients))
+    }
+
+
+def make_systems(model, n=2, *, requires_grad=False, device="cpu"):
+    """``n`` systems from the carbon dataset, with neighbor lists attached.
+
+    ``requires_grad`` selects how a caller hands systems over: ``True`` for an engine
+    running its own autograd, ``False`` for one that does not and so relies on
+    ``_systems_with_grad``. It also accepts ``("positions",)``, as sent by an engine
+    computing forces but not stress.
+    """
+    if isinstance(requires_grad, bool):
+        requires_grad = ("positions", "cell") if requires_grad else ()
+
+    requested_neighbor_lists = get_requested_neighbor_lists(model)
+    systems = []
+    for system in read_systems(DATASET_WITH_FORCES_PATH)[:n]:
+        system = system.to(dtype=DTYPE)
+        system = System(
+            system.types,
+            system.positions.detach().requires_grad_("positions" in requires_grad),
+            system.cell.detach().requires_grad_("cell" in requires_grad),
+            system.pbc,
+        )
+        get_system_with_neighbor_lists(system, requested_neighbor_lists)
+        systems.append(system if device == "cpu" else system.to(device=device))
+    return systems
+
+
+def ensemble_block(model, systems, gradients=GRADIENTS, name=ENSEMBLE):
+    return model(systems, ensemble_output(gradients, name=name))[name].block()
+
+
+def deterministic_energy_gradients(model, systems):
+    """``dE/dr`` and ``dE/dstrain`` of the plain ``energy`` output.
+
+    Differentiates that output directly, independently of
+    ``_add_energy_ensemble_gradients``, so it can serve as its reference. The strain
+    gradient uses the identity the implementation relies on: at strain = identity,
+    ``dE/dstrain == positions^T @ dE/dpositions + cell^T @ dE/dcell``.
+    """
+    energy = model(systems, {"energy": ModelOutput(sample_kind="system")})
+    gradients = torch.autograd.grad(
+        energy["energy"].block().values.sum(),
+        [s.positions for s in systems] + [s.cell for s in systems],
+    )
+    positions_grad, cell_grad = gradients[: len(systems)], gradients[len(systems) :]
+    return {
+        "positions": torch.cat(positions_grad, dim=0),
+        "strain": torch.stack(
+            [
+                system.positions.detach().t() @ positions_grad[i]
+                + system.cell.detach().t() @ cell_grad[i]
+                for i, system in enumerate(systems)
+            ]
+        ),
+    }
+
+
+@pytest.mark.parametrize("gradient", GRADIENTS)
+def test_gradients_average_to_the_deterministic_energy(llpr_model, gradient):
+    """The ensemble is recentered on the model's own prediction, so the mean over
+    members must reproduce the gradient of the deterministic ``energy`` output.
+    """
+    systems = make_systems(llpr_model, requires_grad=True)
+    reference = deterministic_energy_gradients(llpr_model, systems)[gradient]
+
+    block = ensemble_block(llpr_model, make_systems(llpr_model, requires_grad=True))
+    torch.testing.assert_close(
+        block.gradient(gradient).values.mean(dim=-1), reference, atol=1e-5, rtol=1e-5
+    )
+
+
+@pytest.mark.parametrize("requested", [[], ["positions"], ["strain"]])
+def test_only_requested_gradients_are_attached(llpr_model, requested):
+    """Asking for both is what every other test does, so only the partial requests
+    are worth spelling out here: each skips work the other one does."""
+    block = ensemble_block(llpr_model, make_systems(llpr_model, n=1), requested)
+    assert block.gradients_list() == requested
+
+
+@pytest.mark.parametrize("gradient", GRADIENTS)
+def test_batching_does_not_mix_systems(llpr_model, gradient):
+    """Guards the atom-offset bookkeeping: the first system's gradients must not
+    change when a second, independent system is batched alongside it."""
+    single = ensemble_block(llpr_model, make_systems(llpr_model, n=1))
+    batched = ensemble_block(llpr_model, make_systems(llpr_model, n=2))
+
+    expected = single.gradient(gradient).values
+    torch.testing.assert_close(
+        batched.gradient(gradient).values[: expected.shape[0]], expected, **SAME_MODEL
+    )
+
+
+def test_gradients_do_not_depend_on_the_callers_grad_setup(llpr_model):
+    """Systems handed over without grad enabled are rebuilt by ``_systems_with_grad``
+    and must give what caller-prepared ones give, so that an engine can request
+    ensemble gradients without any autograd setup of its own."""
+    mts.allclose_block_raise(
+        ensemble_block(llpr_model, make_systems(llpr_model)),
+        ensemble_block(llpr_model, make_systems(llpr_model, requires_grad=True)),
+        **SAME_MODEL,
+    )
+
+
+def test_exported_model_gives_the_same_gradients(llpr_model, tmp_path):
+    """The gradient path must survive ``torch.jit.script`` at export, which is how
+    engines actually load the model."""
+    path = str(tmp_path / "llpr_ensemble.pt")
+    llpr_model.export().save(path)
+
+    options = ModelEvaluationOptions(
+        length_unit="angstrom", outputs=ensemble_output(), selected_atoms=None
+    )
+    exported = load_atomistic_model(path)(
+        make_systems(llpr_model), options, check_consistency=True
+    )
+
+    mts.allclose_block_raise(
+        exported[ENSEMBLE].block(),
+        ensemble_block(llpr_model, make_systems(llpr_model, requires_grad=True)),
+        **SAME_MODEL,
+    )
+
+
+def test_model_without_any_ensemble_can_be_exported(wrapped_pet, tmp_path):
+    """Requesting no ensembles at all leaves ``ensemble_gradient_outputs`` empty, and
+    an empty list gives ``torch.jit.script`` no element type to infer at export. Every
+    other test here configures an ensemble, so this is the only one that covers the
+    plain uncertainty-only model, which is what the LLPR example trains."""
+    model = wrap_in_llpr(wrapped_pet, {})
+    assert model.ensemble_gradient_outputs == []
+
+    model.export().save(str(tmp_path / "llpr_without_ensemble.pt"))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a CUDA device")
+def test_gradients_on_cuda_match_cpu(llpr_model):
+    """The gradient blocks must be assembled on the device the values live on: their
+    Labels were built on the CPU, which metatensor rejects."""
+    cuda_model = copy.deepcopy(llpr_model).to(device="cuda", dtype=DTYPE)
+    block = ensemble_block(cuda_model, make_systems(cuda_model, device="cuda"))
+
+    for name in GRADIENTS:
+        gradient = block.gradient(name)
+        assert gradient.values.device.type == "cuda"
+        assert gradient.samples.device.type == "cuda"
+        assert gradient.properties.device.type == "cuda"
+        assert all(c.device.type == "cuda" for c in gradient.components)
+
+    mts.allclose_block_raise(
+        block.to(device="cpu"),
+        ensemble_block(llpr_model, make_systems(llpr_model, requires_grad=True)),
+        **SAME_MODEL,
+    )
+
+
+@pytest.mark.parametrize(
+    "requires_grad",
+    [("positions", "cell"), ("positions",)],
+    ids=["positions+cell", "positions-only"],
+)
+def test_caller_keeps_its_own_autograd_graph(llpr_model, requires_grad):
+    """Requesting ensemble gradients must leave the caller's graph usable, so that an
+    engine differentiating the energy itself can still run its own backward pass.
+    """
+    system = make_systems(llpr_model, n=1, requires_grad=requires_grad)[0]
+
+    outputs = llpr_model(
+        [system],
+        {"energy": ModelOutput(sample_kind="system"), **ensemble_output()},
+    )
+    (caller_gradient,) = torch.autograd.grad(
+        outputs["energy"].block().values.sum(), [system.positions]
+    )
+
+    # the ensemble is recentered on the energy, so the two must agree
+    ensemble_gradient = (
+        outputs[ENSEMBLE].block().gradient("positions").values.mean(dim=-1)
+    )
+    torch.testing.assert_close(caller_gradient, ensemble_gradient, atol=1e-8, rtol=1e-6)
+
+
+def test_per_atom_energy_ensemble_is_rejected(llpr_model):
+    """``_add_energy_ensemble_gradients`` assumes one sample per system; for a
+    per-atom energy it would differentiate the summed energy instead."""
+    with pytest.raises(ValueError, match="only supported for a per-system energy"):
+        llpr_model(
+            make_systems(llpr_model, n=1),
+            ensemble_output(["positions"], sample_kind="atom"),
+        )
+
+
+def test_selected_atoms_are_rejected(llpr_model):
+    """The gradient samples cover every atom of every system and index the value
+    samples by system, so a selection that drops a system from the value block leaves
+    the two pointing at different rows."""
+    selected_atoms = Labels(
+        names=["system", "atom"], values=torch.tensor([[0, 0], [0, 1]])
+    )
+    with pytest.raises(
+        ValueError, match="not supported together with 'selected_atoms'"
+    ):
+        llpr_model(
+            make_systems(llpr_model, n=2),
+            ensemble_output(["positions"]),
+            selected_atoms,
+        )
+
+
+def test_multi_property_energy_ensemble_is_rejected():
+    """The ensemble values hold one column per member *per property*, so with more
+    than one property the member-by-member differentiation would read the wrong
+    columns."""
+    model, ensemble_name = untrained_llpr_model(
+        "mtt::my_energy", "energy", num_subtargets=3
+    )
+    with pytest.raises(ValueError, match="single-property energy without components"):
+        ensemble_block(
+            model, make_systems(model, n=1), ["positions"], name=ensemble_name
+        )
+
+
+def untrained_llpr_model(target_name, quantity, num_subtargets=1):
+    """A minimal untrained LLPR model with a single target, and its ensemble name.
+
+    Training is irrelevant to which outputs may carry gradients, so this skips it and
+    seeds the covariance directly.
+    """
+    target_info = get_generic_target_info(
+        target_name,
+        {
+            "quantity": quantity,
+            "unit": "",
+            "type": "scalar",
+            "num_subtargets": num_subtargets,
+            "sample_kind": "system",
+        },
+    )
+    dataset_info = DatasetInfo(
+        length_unit="Angstrom", atomic_types=[6], targets={target_name: target_info}
+    )
+    pet_hypers = copy.deepcopy(DEFAULT_HYPERS_PET["model"])
+    pet_hypers.update(SMALL_PET)
+
+    model = LLPRUncertaintyModel(
+        {"num_ensemble_members": {target_name: 4}}, dataset_info
+    )
+    model.set_wrapped_model(PET(pet_hypers, dataset_info).to(DTYPE))
+    model = model.to(DTYPE)
+
+    uncertainty_name = _get_uncertainty_name(target_name)
+    model._get_cholesky(uncertainty_name)[:] = torch.eye(
+        model.ll_feat_size, dtype=DTYPE
+    )
+    model.generate_ensemble()
+
+    return model, uncertainty_name.replace("_uncertainty", "_ensemble")
+
+
+@pytest.mark.parametrize(
+    "target_name, quantity, expected",
+    [
+        ("energy", "energy", GRADIENTS),
+        ("mtt::my_energy", "energy", GRADIENTS),
+        ("energy/pbesol", "energy", GRADIENTS),
+        ("mtt::my_charge", "charge", []),
+    ],
+    ids=["default-name", "custom-name", "variant", "non-energy"],
+)
+def test_gradients_are_selected_by_quantity_not_by_name(
+    target_name, quantity, expected
+):
+    """Energy targets may carry any name (``mtt::my_energy``) or variant
+    (``energy/pbesol``), so the gradients follow the quantity. Keying on the name
+    dropped the feature for all but the default one, and silently: the capabilities
+    then agreed with ``forward`` that there was nothing to compute.
+    """
+    model, ensemble_name = untrained_llpr_model(target_name, quantity)
+
+    assert model.capabilities.outputs[ensemble_name].explicit_gradients == expected
+
+    block = ensemble_block(
+        model, make_systems(model, n=1), gradients=expected, name=ensemble_name
+    )
+    assert block.gradients_list() == expected


### PR DESCRIPTION
The `energy_ensemble` output can now return `positions` and `strain` gradients, so one can get per-ensemble-member forces and stresses straight from the exported model, and can use their spread as an uncertainty estimate or propagate the ensemble to other observables (e.g., phonon bands).

In other words, this feature is required to be able to easily request conservative forces and stress ensembles for a model.

To comply with metatomic, the properties of the energy ensemble TensorMap had to be changed to `energy`, with a single column enumerating members. Non-energy targets keep the previous `["ensemble_member", <target>]` format. 

The gradients have to be computed in a loop over members instead of setting `is_grads_batched=True` to compy with TorchScript.

LLPR tests tend to not use shared testing utilities, so I added a new test file. Probably it could be made to use the shared utilities more, but I think it requires modifying them enough to go outside of the scope of the current PR, so it might be delegated to a different one in the future.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Maintainer/Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?
 - [x] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1210.org.readthedocs.build/en/1210/

<!-- readthedocs-preview metatrain end -->