### PR TITLE
Fix memmap gradient property label for renamed energy targets

### DIFF
--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -1579,7 +1579,7 @@ class MemmapDataset(TorchDataset):
                                 ),
                             ),
                             components=[Labels.range("xyz", 3)],
-                            properties=Labels.range("energy", 1),
+                            properties=Labels.range(target_key.replace("mtt::", ""), 1),
                         ),
                     )
                 if target_options["stress"]:
@@ -1599,7 +1599,7 @@ class MemmapDataset(TorchDataset):
                                 Labels.range("xyz_1", 3),
                                 Labels.range("xyz_2", 3),
                             ],
-                            properties=Labels.range("energy", 1),
+                            properties=Labels.range(target_key.replace("mtt::", ""), 1),
                         ),
                     )
 

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -1555,7 +1555,8 @@ class MemmapDataset(TorchDataset):
                 samples=samples,
                 components=components,
                 properties=Labels.range(
-                    target_key.replace("mtt::", ""), target_array.shape[-1]
+                    "energy" if is_energy else target_key.replace("mtt::", ""),
+                    target_array.shape[-1],
                 ),
             )
 
@@ -1579,7 +1580,7 @@ class MemmapDataset(TorchDataset):
                                 ),
                             ),
                             components=[Labels.range("xyz", 3)],
-                            properties=Labels.range(target_key.replace("mtt::", ""), 1),
+                            properties=Labels.range("energy", 1),
                         ),
                     )
                 if target_options["stress"]:
@@ -1599,7 +1600,7 @@ class MemmapDataset(TorchDataset):
                                 Labels.range("xyz_1", 3),
                                 Labels.range("xyz_2", 3),
                             ],
-                            properties=Labels.range(target_key.replace("mtt::", ""), 1),
+                            properties=Labels.range("energy", 1),
                         ),
                     )
 


### PR DESCRIPTION
 **Summary**
 
Training from a memmap dataset crashes at dataset setup whenever an energy target (scalar, per-system, quantity: energy, with forces or stress) has a name other than `energy` — e.g. `mtt::gap_energy `or a variants name like `energy/r2scan` — with:

`invalid parameter: gradient properties must be the same as values properties`  

The ASE reader is unaffected, so the same options file trains when reading .xyz but breaks when reading the equivalent memmap directory.
  
**Root cause**
  
In `MemmapDataset.__getitem__`, the energy target's value block took its property-label name from the target name (`target_key.replace("mtt::", "")`), while the forces/stress gradient blocks — and the canonical layout from `get_energy_target_info` — use the fixed name "energy". For any name other than energy, the value label (e.g. gap_energy) no longer matched its own gradients, which metatensor rejects. An is_energy flag was already computed there ("to set the correct property label name") but never applied to the value block.

  **Fix**

 Use "energy" as the value block's property label for energy targets (keeping the target-derived name for generic targets), matching the gradient blocks and `get_energy_target_info`. This also makes the label robust to target names that aren't valid metatensor label identifiers (e.g. containing /).

  **Verification**

Reproduced with a small fake memmap dataset: mtt train on an energy target named energy/r2scan (with forces) or mtt::energy_gap previously crashed at "Setting up training set"; with the fix it completes setup and trains, reporting energy and forces metrics. The same dataset with the target renamed to energy worked before and after.
  
```
training_set:
  systems:
    read_from: train_memmap        
    length_unit: angstrom
  targets:
    mtt::energy_gap:               # <--  --> triggers the bug
      key: gap
      quantity: energy
      unit: eV
      sample_kind: system
      type: scalar
      forces:
        key: gap_forces
      stress: false
      virial: false
```

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1216.org.readthedocs.build/en/1216/

<!-- readthedocs-preview metatrain end -->