### PR TITLE
Avoid json schema making docs ugly

### DIFF
--- a/src/metatrain/utils/pydantic.py
+++ b/src/metatrain/utils/pydantic.py
@@ -518,6 +518,11 @@ def get_train_json_schema(allow_missing_hypers: bool) -> dict:
     for arch_name in find_all_architectures():
         arch_doc = preload_documentation_module(arch_name)
 
+        # We are going to modify the annotations so that the schema is correct,
+        # store the original annotations so we can restore them later.
+        old_model_annotations = arch_doc.ModelHypers.__annotations__
+        old_trainer_annotations = arch_doc.TrainerHypers.__annotations__
+
         ModelHypers = set_not_required_and_defaults(arch_doc.ModelHypers)
         TrainerHypers = set_not_required_and_defaults(arch_doc.TrainerHypers)
 
@@ -552,13 +557,22 @@ def get_train_json_schema(allow_missing_hypers: bool) -> dict:
             },
         )
 
+        # Now that the model has been created, we can restore the original annotations
+        ModelHypers.__annotations__ = old_model_annotations
+        TrainerHypers.__annotations__ = old_trainer_annotations
+
         arch_models.append(ArchModel)
 
     # Build the global model for the training options, setting the
     # architecture field to be a union of all the possible architectures.
+    old_base_annotations = BaseHypers.__annotations__
     _baseHypers = set_not_required_and_defaults(BaseHypers)
     _baseHypers.__annotations__["architecture"] = Union[tuple(arch_models)]
 
     mtttrain_model = TypeAdapter(_baseHypers)
+    json_schema = mtttrain_model.json_schema()
 
-    return mtttrain_model.json_schema()
+    # Restore the original annotations of BaseHypers to avoid side effects
+    BaseHypers.__annotations__ = old_base_annotations
+
+    return json_schema

--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -1,14 +1,19 @@
 # mypy: ignore-errors
 # Satisfying mypy in this file is hard because the fixtures
 # define different classes depending on the parametrization.
+from copy import deepcopy
+
 import pytest
 import requests
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
+from metatrain.share.base_hypers import BaseHypers
+from metatrain.utils.architectures import preload_documentation_module
 from metatrain.utils.pydantic import (
     MetatrainArchitectureValidationError,
     MetatrainValidationError,
+    get_train_json_schema,
     validate,
     validate_architecture_options,
     validate_base_options,
@@ -156,3 +161,29 @@ def test_validation_error_doc_link():
     for link in [modelhypers_link, trainerhypers_link]:
         response = requests.head(link)
         assert response.status_code == 200, f"Link {link} is not reachable"
+
+
+def test_get_train_json_schema():
+    """Test that get_train_json_schema returns a valid JSON schema.
+
+    Also check that the hypers classes have not gotten their annotations
+    modified by the schema generation process.
+    """
+    pet_docs = preload_documentation_module("pet")
+    pet_model_hypers = pet_docs.ModelHypers
+    pet_trainer_hypers = pet_docs.TrainerHypers
+    old_model_annotations = deepcopy(pet_model_hypers.__annotations__)
+    pet_trainer_annotations = deepcopy(pet_trainer_hypers.__annotations__)
+    base_old_annotations = deepcopy(BaseHypers.__annotations__)
+
+    schema = get_train_json_schema(allow_missing_hypers=True)
+
+    assert isinstance(schema, dict)
+    assert "properties" in schema
+    assert "architecture" in schema["properties"]
+
+    # Check that the hypers classes have not gotten their annotations
+    # modified by the schema generation process.
+    assert pet_model_hypers.__annotations__ == old_model_annotations
+    assert pet_trainer_hypers.__annotations__ == pet_trainer_annotations
+    assert BaseHypers.__annotations__ == base_old_annotations


### PR DESCRIPTION
I hadn't realised that since we introduced the json schema in the docs, the documentation for the architecture hyperparameters became extra ugly:

<img width="853" height="175" alt="Screenshot from 2026-07-27 15-38-30" src="https://github.com/user-attachments/assets/383d1caa-4d78-4d8a-a96c-f33103283c4d" />

this is because the function that generates the json schemas was modifying the annotations inplace. In this PR I make sure they are not modified, and I add a test to check that.


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1222.org.readthedocs.build/en/1222/

<!-- readthedocs-preview metatrain end -->