### PR TITLE
SPACE: Make sure that the radial basis hypers are shown in docs

### DIFF
--- a/src/metatrain/experimental/space/documentation.py
+++ b/src/metatrain/experimental/space/documentation.py
@@ -57,6 +57,15 @@ of importance) for the SPACE architecture:
 
   .. autoattribute:: {{model_hypers_path}}.force_rectangular
       :no-index:
+
+{{SECTION_MODEL_HYPERS}}
+
+with the radial basis hyperparameters being:
+
+.. autoclass:: {{architecture_path}}.documentation.RadialBasisHypers
+    :members:
+    :undoc-members:
+
 """
 
 from typing import Literal, Optional


### PR DESCRIPTION
The radial basis hypers are very important but they were not shown in detail in the docs, now they are.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1223.org.readthedocs.build/en/1223/

<!-- readthedocs-preview metatrain end -->