### PR TITLE
Add possibility to build docs without running examples

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -13,6 +13,7 @@ os.environ["METATENSOR_IMPORT_FOR_SPHINX"] = "1"
 os.environ["METATOMIC_IMPORT_FOR_SPHINX"] = "1"
 os.environ["PYTORCH_JIT"] = "0"
 os.environ["METATENSOR_DEBUG_EXTENSIONS_LOADING"] = "1"
+RUN_EXAMPLES = os.environ.get("MTT_DOCS_EXAMPLES", "1") != "0"
 
 import metatrain  # noqa: E402
 
@@ -88,7 +89,8 @@ def generate_examples():
 
 def setup(app):
     copy_readme()
-    generate_examples()
+    if RUN_EXAMPLES:
+        generate_examples()
     setup_architectures_docs()
 
 
@@ -104,9 +106,11 @@ extensions = [
     "sphinxcontrib.bibtex",
     "sphinx_copybutton",
     "sphinx_toggleprompt",
-    "sphinx_gallery.gen_gallery",
     "chemiscope.sphinx",
 ]
+
+if RUN_EXAMPLES:
+    extensions.append("sphinx_gallery.gen_gallery")
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/tox.ini
+++ b/tox.ini
@@ -278,7 +278,7 @@ extras = # these architectures are used in the documentation
     mace
 commands =
     # Run all .sh files in the example folder (including subfolders)
-    bash -c "set -e && for f in $(find examples -name '*.sh'); do cd $(dirname $f); bash $(basename $f); cd -; done"
+    bash -c 'if [ "${MTT_DOCS_EXAMPLES}" != "0" ]; then set -e && for f in $(find examples -name '*.sh'); do cd $(dirname $f); bash $(basename $f); cd -; done; fi'
     sphinx-build \
         {posargs:-E} \
         --builder html \


### PR DESCRIPTION
For modifying documentation and see how it looks like, it is super annoying that you have to run the examples every time.

This PR introduces an environment variable to avoid running the examples. I was doing this modification every time, so now people won't need to modify anything to get fast documentation builds. By doing:

```
MTT_DOCS_EXAMPLES=0 tox -e docs
```

docs are fasttttttttttttttttttt

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1224.org.readthedocs.build/en/1224/

<!-- readthedocs-preview metatrain end -->