### PR TITLE
frostedoyster is retiring as a maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,14 +2,14 @@
 # that they get asked for a review whenever the code for this architecture
 # is modified.
 
-**/composition           @ppegolo
-**/soap_bpnn            @frostedoyster
-**/pet                  @abmazitov @frostedoyster @sofiia-chorna
-**/gap                  @DavideTisi
-**/space                @frostedoyster
-**/llpr                 @frostedoyster @SanggyuChong
-**/flashmd              @johannes-spies @frostedoyster
-**/flashmd_symplectic   @frostedoyster @johannes-spies
-**/classifier           @frostedoyster
-**/mace                 @pfebrer @jwa7
+**/classifier           @sofiia-chorna
+**/composition          @ppegolo
 **/dpa3                 @HaoZeke
+**/flashmd              @johannes-spies @zyxwwxyz
+**/flashmd_symplectic   @johannes-spies @zyxwwxyz
+**/gap                  @DavideTisi
+**/llpr                 @ppegolo @SanggyuChong
+**/mace                 @pfebrer @jwa7
+**/pet                  @abmazitov @sofiia-chorna
+**/soap_bpnn            @ppegolo
+**/space                @frostedoyster

--- a/README.md
+++ b/README.md
@@ -161,7 +161,10 @@ Thanks goes to all people who make metatrain possible:
 
 [![Contributors](https://contrib.rocks/image?repo=metatensor/metatrain)](https://github.com/metatensor/metatrain/graphs/contributors)
 
-The overall metatrain project is [maintained](https://github.com/lab-cosmo/.github/blob/main/Maintainers.md) by @frostedoyster, @pfebrer, and @PicoCentauri who will reply to issues and pull requests opened on this repository as soon as possible. You can mention them directly if you did not receive an answer after a couple of days. Additionally, different architectures are maintained by separate maintainers, you can find their names in the corresponding [documentation](https://docs.metatensor.org/metatrain/latest/architectures/)
+The overall metatrain project is [maintained](https://github.com/lab-cosmo/.github/blob/main/Maintainers.md) by @pfebrer and @PicoCentauri who will reply to issues and pull requests opened on this repository as soon as possible. You can mention them directly if you did not receive an answer after a couple of days.
+It was previously maintained by @frostedoyster (2023 to 2026), many thanks to them for their work making metatrain awesome!
+
+Additionally, different architectures are maintained by separate maintainers, you can find their names in the corresponding [documentation](https://docs.metatensor.org/metatrain/latest/architectures/)
 
 <!-- marker-cite -->
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,6 +206,8 @@ filterwarnings = [
     "ignore:`compute_requested_neighbors_from_options` is deprecated and will be removed in a future version:UserWarning",
     # Code from ASE using deprecated NumPy features
     "ignore:Setting the shape on a NumPy array has been deprecated in NumPy 2.5:DeprecationWarning",
+    # new state_dict format in metatensor-learn
+    "ignore:module does not have '_mts_buffer_names'; falling back to processing all attributes:UserWarning",
 ]
 addopts = ["-p", "mtt_plugin"]
 pythonpath = "src/metatrain/utils/testing"


### PR DESCRIPTION
@frostedoyster wants to (mostly) retire as a maintainer, and only keep the SPACE architecture. Many thanks for bringing the project to where it is now, this was awesome work!

Could this PR get approval from one of the remaining core maintainer (@pfebrer and @PicoCentauri) and @frostedoyster?

We will need to find a secondary maintainer for many architectures, but this can be done later.

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [x] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Maintainer/Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1226.org.readthedocs.build/en/1226/

<!-- readthedocs-preview metatrain end -->