### PR TITLE
Improve errors when ckpt upgrading fails

### DIFF
--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -35,6 +35,8 @@ Fixed
   a side effect.
 - ``DiskDatasetWriter`` in append mode now continues the entry numbering of the
   existing zip instead of restarting from zero.
+- Loading a checkpoint newer than the installed architecture now raises a clear error
+  asking to upgrade metatrain, instead of a confusing upgrade failure.
 
 Added
 #####

--- a/src/metatrain/utils/io.py
+++ b/src/metatrain/utils/io.py
@@ -9,6 +9,7 @@ import torch
 from huggingface_hub import hf_hub_download
 from metatomic.torch import check_atomistic_model, load_atomistic_model
 
+from .. import __version__
 from .architectures import find_all_architectures, import_architecture
 
 
@@ -222,7 +223,17 @@ def model_from_checkpoint(
         model_ckpt_version = 1
         checkpoint["model_ckpt_version"] = model_ckpt_version
 
-    if model_ckpt_version != architecture.__model__.__checkpoint_version__:
+    if model_ckpt_version > architecture.__model__.__checkpoint_version__:
+        raise RuntimeError(
+            f"Unable to load the model checkpoint for the '{architecture_name}' "
+            f"architecture: the checkpoint uses checkpoint format version "
+            f"{model_ckpt_version}, but the installed '{architecture_name}' "
+            f"architecture only supports up to version "
+            f"{architecture.__model__.__checkpoint_version__}. You are using "
+            f"metatrain version {__version__}, which is too old to read this "
+            "checkpoint. Please upgrade metatrain to a newer version."
+        )
+    elif model_ckpt_version < architecture.__model__.__checkpoint_version__:
         try:
             if ckpt_before_versioning:
                 warnings.warn(

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -78,7 +78,10 @@ def test_load_model_checkpoint(load_path_ckpt):
     # currently weights of the `"export"` and the `"restart"` context are the same...
 
 
-def test_load_model_checkpoint_wrong_version(monkeypatch, tmp_path, MODEL_PATH_64_BIT):
+def test_load_model_checkpoint_newer_version(monkeypatch, tmp_path, MODEL_PATH_64_BIT):
+    """A checkpoint version newer than the installed architecture should tell the
+    user to upgrade metatrain, instead of trying (and failing) to upgrade the
+    checkpoint."""
     monkeypatch.chdir(tmp_path)
     path = MODEL_PATH_64_BIT.with_suffix(".ckpt")
     model = torch.load(path, weights_only=False, map_location="cpu")
@@ -89,7 +92,32 @@ def test_load_model_checkpoint_wrong_version(monkeypatch, tmp_path, MODEL_PATH_6
 
     message = (
         "Unable to load the model checkpoint for the 'soap_bpnn' architecture: the "
-        r"checkpoint is using version 5000000, while the current version is \d+; "
+        r"checkpoint uses checkpoint format version 5000000, but the installed "
+        r"'soap_bpnn' architecture only supports up to version \d+\. You are using "
+        r"metatrain version .*, which is too old to read this checkpoint\. Please "
+        "upgrade metatrain to a newer version."
+    )
+    with pytest.raises(RuntimeError, match=message):
+        checkpoint = torch.load(file, weights_only=False, map_location="cpu")
+        model_from_checkpoint(checkpoint, context="restart")
+
+
+def test_load_model_checkpoint_older_version_upgrade_fails(
+    monkeypatch, tmp_path, MODEL_PATH_64_BIT
+):
+    """A checkpoint version older than the installed architecture, for which the
+    upgrade path fails, should keep raising the generic upgrade-failure error."""
+    monkeypatch.chdir(tmp_path)
+    path = MODEL_PATH_64_BIT.with_suffix(".ckpt")
+    model = torch.load(path, weights_only=False, map_location="cpu")
+    model["model_ckpt_version"] = 0
+
+    file = "model-version-0.ckpt"
+    torch.save(model, file)
+
+    message = (
+        "Unable to load the model checkpoint for the 'soap_bpnn' architecture: the "
+        r"checkpoint is using version 0, while the current version is \d+; "
         "and trying to upgrade the checkpoint failed."
     )
     with pytest.raises(RuntimeError, match=message):


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Fixes #1227

When checkpoint version is newer as the supported version by the current metatrain release we inform the user that they may upgrade their local version.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - ~[ ] Documentation updated (for new features)?~
 - [x] Issue referenced (for PRs that solve an issue)?

# Maintainer/Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1228.org.readthedocs.build/en/1228/

<!-- readthedocs-preview metatrain end -->