### PR TITLE
Use spawn for dataloader workers on CUDA

### DIFF
--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -38,6 +38,23 @@ Fixed
 - Loading a checkpoint newer than the installed architecture now raises a clear error
   asking to upgrade metatrain, instead of a confusing upgrade failure.
 
+Changed
+#######
+
+- When training on CUDA with disk-backed datasets (``DiskDataset``,
+  ``MemmapDataset``), dataloader workers are now started with the ``spawn``
+  method instead of being forked. Forking after CUDA initialization is
+  unsupported by PyTorch and made every worker gradually duplicate the memory
+  of the training process on long runs.
+
+Removed
+#######
+
+- The restriction of ``num_workers`` to 0 on platforms without fork (macOS,
+  Windows) is gone: everything a dataloader worker receives is now picklable,
+  so spawned workers work everywhere. ``validate_num_workers`` was removed
+  from ``metatrain.utils.data``.
+
 Added
 #####
 

--- a/src/metatrain/composition/trainer.py
+++ b/src/metatrain/composition/trainer.py
@@ -15,7 +15,6 @@ from metatrain.utils.data import (
     build_val_dataloaders,
     get_num_workers,
     unpack_batch,
-    validate_num_workers,
 )
 from metatrain.utils.data.atomic_basis_helpers import (
     get_prepare_atomic_basis_targets_transform,
@@ -155,7 +154,6 @@ class Trainer(TrainerInterface[TrainerHypers]):
                 )
             else:
                 num_workers = self.hypers["num_workers"]
-                validate_num_workers(num_workers)
 
             # The validation dataloader builder covers every sample exactly
             # once, without shuffling or dropping the tail batch, which is what

--- a/src/metatrain/experimental/flashmd/trainer.py
+++ b/src/metatrain/experimental/flashmd/trainer.py
@@ -20,9 +20,8 @@ from metatrain.utils.data import (
     Dataset,
     build_train_dataloaders,
     build_val_dataloaders,
-    get_num_workers,
+    resolve_dataloader_workers,
     unpack_batch,
-    validate_num_workers,
 )
 from metatrain.utils.distributed.distributed_data_parallel import (
     DistributedDataParallel,
@@ -285,15 +284,9 @@ class Trainer(TrainerInterface[TrainerHypers]):
             ],
         )
 
-        if self.hypers["num_workers"] is None:
-            num_workers = get_num_workers()
-            logging.info(
-                "Number of workers for data-loading not provided and chosen "
-                f"automatically. Using {num_workers} workers."
-            )
-        else:
-            num_workers = self.hypers["num_workers"]
-            validate_num_workers(num_workers)
+        num_workers, mp_context = resolve_dataloader_workers(
+            self.hypers["num_workers"], device, train_datasets + val_datasets
+        )
 
         max_atoms = self.hypers["max_atoms_per_batch"]
 
@@ -306,6 +299,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
             max_atoms_per_batch=max_atoms,
             min_atoms_per_batch=self.hypers["min_atoms_per_batch"],
             num_workers=num_workers,
+            multiprocessing_context=mp_context,
         )
         train_dataloader = CombinedDataLoader(train_dataloaders, shuffle=True)
 
@@ -317,6 +311,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
             batch_size=self.hypers["batch_size"],
             max_atoms_per_batch=max_atoms,
             num_workers=num_workers,
+            multiprocessing_context=mp_context,
         )
         val_dataloader = CombinedDataLoader(val_dataloaders, shuffle=False)
 

--- a/src/metatrain/experimental/flashmd_symplectic/trainer.py
+++ b/src/metatrain/experimental/flashmd_symplectic/trainer.py
@@ -20,9 +20,8 @@ from metatrain.utils.data import (
     Dataset,
     build_train_dataloaders,
     build_val_dataloaders,
-    get_num_workers,
+    resolve_dataloader_workers,
     unpack_batch,
-    validate_num_workers,
 )
 from metatrain.utils.distributed.distributed_data_parallel import (
     DistributedDataParallel,
@@ -284,15 +283,9 @@ class Trainer(TrainerInterface):
             ],
         )
 
-        if self.hypers["num_workers"] is None:
-            num_workers = get_num_workers()
-            logging.info(
-                "Number of workers for data-loading not provided and chosen "
-                f"automatically. Using {num_workers} workers."
-            )
-        else:
-            num_workers = self.hypers["num_workers"]
-            validate_num_workers(num_workers)
+        num_workers, mp_context = resolve_dataloader_workers(
+            self.hypers["num_workers"], device, train_datasets + val_datasets
+        )
 
         max_atoms = self.hypers["max_atoms_per_batch"]
 
@@ -305,6 +298,7 @@ class Trainer(TrainerInterface):
             max_atoms_per_batch=max_atoms,
             min_atoms_per_batch=self.hypers["min_atoms_per_batch"],
             num_workers=num_workers,
+            multiprocessing_context=mp_context,
         )
         train_dataloader = CombinedDataLoader(train_dataloaders, shuffle=True)
 
@@ -316,6 +310,7 @@ class Trainer(TrainerInterface):
             batch_size=self.hypers["batch_size"],
             max_atoms_per_batch=max_atoms,
             num_workers=num_workers,
+            multiprocessing_context=mp_context,
         )
         val_dataloader = CombinedDataLoader(val_dataloaders, shuffle=False)
 

--- a/src/metatrain/experimental/mace/trainer.py
+++ b/src/metatrain/experimental/mace/trainer.py
@@ -21,9 +21,8 @@ from metatrain.utils.data import (
     Dataset,
     build_train_dataloaders,
     build_val_dataloaders,
-    get_num_workers,
+    resolve_dataloader_workers,
     unpack_batch,
-    validate_num_workers,
 )
 from metatrain.utils.data.atomic_basis_helpers import (
     get_prepare_atomic_basis_targets_transform,
@@ -312,15 +311,9 @@ class Trainer(TrainerInterface):
             ],
         )
 
-        if self.hypers["num_workers"] is None:
-            num_workers = get_num_workers()
-            logging.info(
-                "Number of workers for data-loading not provided and chosen "
-                f"automatically. Using {num_workers} workers."
-            )
-        else:
-            num_workers = self.hypers["num_workers"]
-            validate_num_workers(num_workers)
+        num_workers, mp_context = resolve_dataloader_workers(
+            self.hypers["num_workers"], device, train_datasets + val_datasets
+        )
 
         max_atoms = self.hypers["max_atoms_per_batch"]
 
@@ -333,6 +326,7 @@ class Trainer(TrainerInterface):
             max_atoms_per_batch=max_atoms,
             min_atoms_per_batch=self.hypers["min_atoms_per_batch"],
             num_workers=num_workers,
+            multiprocessing_context=mp_context,
         )
         train_dataloader = CombinedDataLoader(train_dataloaders, shuffle=True)
 
@@ -344,6 +338,7 @@ class Trainer(TrainerInterface):
             batch_size=self.hypers["batch_size"],
             max_atoms_per_batch=max_atoms,
             num_workers=num_workers,
+            multiprocessing_context=mp_context,
         )
         val_dataloader = CombinedDataLoader(val_dataloaders, shuffle=False)
 

--- a/src/metatrain/experimental/space/trainer.py
+++ b/src/metatrain/experimental/space/trainer.py
@@ -23,9 +23,8 @@ from metatrain.utils.data import (
     Dataset,
     build_train_dataloaders,
     build_val_dataloaders,
-    get_num_workers,
+    resolve_dataloader_workers,
     unpack_batch,
-    validate_num_workers,
 )
 from metatrain.utils.data.atomic_basis_helpers import (
     get_prepare_atomic_basis_targets_transform,
@@ -354,15 +353,9 @@ class Trainer(TrainerInterface[TrainerHypers]):
             ],
         )
 
-        if self.hypers["num_workers"] is None:
-            num_workers = get_num_workers()
-            logging.info(
-                "Number of workers for data-loading not provided and chosen "
-                f"automatically. Using {num_workers} workers."
-            )
-        else:
-            num_workers = self.hypers["num_workers"]
-            validate_num_workers(num_workers)
+        num_workers, mp_context = resolve_dataloader_workers(
+            self.hypers["num_workers"], device, train_datasets + val_datasets
+        )
 
         max_atoms = self.hypers["max_atoms_per_batch"]
 
@@ -375,6 +368,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
             max_atoms_per_batch=max_atoms,
             min_atoms_per_batch=self.hypers["min_atoms_per_batch"],
             num_workers=num_workers,
+            multiprocessing_context=mp_context,
         )
         train_dataloader = CombinedDataLoader(train_dataloaders, shuffle=True)
 
@@ -386,6 +380,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
             batch_size=self.hypers["batch_size"],
             max_atoms_per_batch=max_atoms,
             num_workers=num_workers,
+            multiprocessing_context=mp_context,
         )
         val_dataloader = CombinedDataLoader(val_dataloaders, shuffle=False)
 

--- a/src/metatrain/llpr/trainer.py
+++ b/src/metatrain/llpr/trainer.py
@@ -17,9 +17,8 @@ from metatrain.utils.data import (
     Dataset,
     build_train_dataloaders,
     build_val_dataloaders,
-    get_num_workers,
+    resolve_dataloader_workers,
     unpack_batch,
-    validate_num_workers,
 )
 from metatrain.utils.distributed.distributed_data_parallel import (
     DistributedDataParallel,
@@ -210,15 +209,9 @@ class Trainer(TrainerInterface[TrainerHypers]):
             ],
         )
 
-        if self.hypers["num_workers"] is None:
-            num_workers = get_num_workers()
-            logging.info(
-                "Number of workers for data-loading not provided and chosen "
-                f"automatically. Using {num_workers} workers."
-            )
-        else:
-            num_workers = self.hypers["num_workers"]
-            validate_num_workers(num_workers)
+        num_workers, mp_context = resolve_dataloader_workers(
+            self.hypers["num_workers"], device, train_datasets + val_datasets
+        )
 
         if is_distributed:
             train_samplers = [
@@ -256,6 +249,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
             max_atoms_per_batch=max_atoms,
             min_atoms_per_batch=self.hypers["min_atoms_per_batch"],
             num_workers=num_workers,
+            multiprocessing_context=mp_context,
         )
         train_dataloader = CombinedDataLoader(train_dataloaders, shuffle=True)
 
@@ -267,6 +261,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
             batch_size=self.hypers["batch_size"],
             max_atoms_per_batch=max_atoms,
             num_workers=num_workers,
+            multiprocessing_context=mp_context,
         )
         val_dataloader = CombinedDataLoader(val_dataloaders, shuffle=False)
 

--- a/src/metatrain/pet/trainer.py
+++ b/src/metatrain/pet/trainer.py
@@ -18,9 +18,8 @@ from metatrain.utils.data import (
     Dataset,
     build_train_dataloaders,
     build_val_dataloaders,
-    get_num_workers,
+    resolve_dataloader_workers,
     unpack_batch,
-    validate_num_workers,
 )
 from metatrain.utils.data.atomic_basis_helpers import (
     get_prepare_atomic_basis_targets_transform,
@@ -300,17 +299,11 @@ class Trainer(TrainerInterface[TrainerHypers]):
             ],
         )
 
-        if self.hypers["num_workers"] is None:
-            num_workers = get_num_workers()
-            logging.info(
-                "Number of workers for data-loading not provided and chosen "
-                f"automatically. Using {num_workers} workers."
-            )
-        else:
-            num_workers = self.hypers["num_workers"]
-            validate_num_workers(num_workers)
-
         # Create dataloader for the training datasets:
+        num_workers, mp_context = resolve_dataloader_workers(
+            self.hypers["num_workers"], device, train_datasets + val_datasets
+        )
+
         train_dataloaders, epoch_samplers = build_train_dataloaders(
             train_datasets=train_datasets,
             train_distributed_samplers=train_samplers,
@@ -319,6 +312,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
             max_atoms_per_batch=max_atoms,
             min_atoms_per_batch=self.hypers["min_atoms_per_batch"],
             num_workers=num_workers,
+            multiprocessing_context=mp_context,
         )
         train_dataloader = CombinedDataLoader(train_dataloaders, shuffle=True)
 
@@ -330,6 +324,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
             batch_size=self.hypers["batch_size"],
             max_atoms_per_batch=max_atoms,
             num_workers=num_workers,
+            multiprocessing_context=mp_context,
         )
         val_dataloader = CombinedDataLoader(val_dataloaders, shuffle=False)
 

--- a/src/metatrain/soap_bpnn/trainer.py
+++ b/src/metatrain/soap_bpnn/trainer.py
@@ -18,9 +18,8 @@ from metatrain.utils.data import (
     Dataset,
     build_train_dataloaders,
     build_val_dataloaders,
-    get_num_workers,
+    resolve_dataloader_workers,
     unpack_batch,
-    validate_num_workers,
 )
 from metatrain.utils.data.atomic_basis_helpers import (
     get_prepare_atomic_basis_targets_transform,
@@ -224,15 +223,9 @@ class Trainer(TrainerInterface[TrainerHypers]):
             ],
         )
 
-        if self.hypers["num_workers"] is None:
-            num_workers = get_num_workers()
-            logging.info(
-                "Number of workers for data-loading not provided and chosen "
-                f"automatically. Using {num_workers} workers."
-            )
-        else:
-            num_workers = self.hypers["num_workers"]
-            validate_num_workers(num_workers)
+        num_workers, mp_context = resolve_dataloader_workers(
+            self.hypers["num_workers"], device, train_datasets + val_datasets
+        )
 
         max_atoms = self.hypers["max_atoms_per_batch"]
 
@@ -245,6 +238,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
             max_atoms_per_batch=max_atoms,
             min_atoms_per_batch=self.hypers["min_atoms_per_batch"],
             num_workers=num_workers,
+            multiprocessing_context=mp_context,
         )
         train_dataloader = CombinedDataLoader(train_dataloaders, shuffle=True)
 
@@ -256,6 +250,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
             batch_size=self.hypers["batch_size"],
             max_atoms_per_batch=max_atoms,
             num_workers=num_workers,
+            multiprocessing_context=mp_context,
         )
         val_dataloader = CombinedDataLoader(val_dataloaders, shuffle=False)
 

--- a/src/metatrain/utils/additive/remove.py
+++ b/src/metatrain/utils/additive/remove.py
@@ -1,3 +1,4 @@
+import functools
 import warnings
 from typing import Callable, Dict, List, Tuple
 
@@ -145,6 +146,18 @@ def remove_additive(
     return targets
 
 
+def _remove_additive_transform_impl(
+    additive_models: List[torch.nn.Module],
+    target_info_dict: Dict[str, TargetInfo],
+    systems: List[System],
+    targets: Dict[str, TensorMap],
+    extra: Dict[str, TensorMap],
+) -> Tuple[List[System], Dict[str, TensorMap], Dict[str, TensorMap]]:
+    for additive_model in additive_models:
+        targets = remove_additive(systems, targets, additive_model, target_info_dict)
+    return systems, targets, extra
+
+
 def get_remove_additive_transform(
     additive_models: List[torch.nn.Module],
     target_info_dict: Dict[str, TargetInfo],
@@ -158,27 +171,6 @@ def get_remove_additive_transform(
     :return: A function that takes in systems, targets and extra data, and returns
         the systems, updated targets and extra data.
     """
-
-    def transform(
-        systems: List[System],
-        targets: Dict[str, TensorMap],
-        extra: Dict[str, TensorMap],
-    ) -> Tuple[List[System], Dict[str, TensorMap], Dict[str, TensorMap]]:
-        """
-        Transform function that removes the additive contributions from the targets.
-
-        :param systems: List of systems.
-        :param targets: Dictionary containing the targets corresponding to the systems.
-        :param extra: Dictionary containing any extra data.
-        :return: The systems, updated targets and extra data.
-        """
-        for additive_model in additive_models:
-            targets = remove_additive(
-                systems,
-                targets,
-                additive_model,
-                target_info_dict,
-            )
-        return systems, targets, extra
-
-    return transform
+    return functools.partial(
+        _remove_additive_transform_impl, additive_models, target_info_dict
+    )

--- a/src/metatrain/utils/data/__init__.py
+++ b/src/metatrain/utils/data/__init__.py
@@ -1,5 +1,9 @@
 from .combine_dataloaders import CombinedDataLoader  # noqa: F401
-from .dataloaders import build_train_dataloaders, build_val_dataloaders  # noqa: F401
+from .dataloaders import (  # noqa: F401
+    build_train_dataloaders,
+    build_val_dataloaders,
+    resolve_dataloader_workers,
+)
 from .dataset import (  # noqa: F401
     CollateFn,
     Dataset,
@@ -13,7 +17,6 @@ from .dataset import (  # noqa: F401
     get_stats,
     load_indices,
     unpack_batch,
-    validate_num_workers,
 )
 from .get_dataset import get_dataset  # noqa: F401
 from .readers import read_extra_data, read_systems, read_targets  # noqa: F401

--- a/src/metatrain/utils/data/atomic_basis_helpers.py
+++ b/src/metatrain/utils/data/atomic_basis_helpers.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Callable, Dict, List, Optional, Tuple
 
 import metatensor.torch as mts
@@ -703,6 +704,94 @@ def sparsify_atomic_basis_target(
 # ===== dataloader transforms
 
 
+def _prepare_atomic_basis_targets_impl(
+    target_info_dict: dict[str, TargetInfo],
+    extra_data_info_dict: dict[str, TargetInfo],
+    nl_options: Optional[NeighborListOptions],
+    systems: List[System],
+    targets: Dict[str, TensorMap],
+    extra: Dict[str, TensorMap],
+) -> Tuple[List[System], Dict[str, TensorMap], Dict[str, TensorMap]]:
+    for name, tensor in targets.items():
+        if name in target_info_dict and target_info_dict[name].is_atomic_basis:
+            if "mtt::aux::system_index" not in extra:
+                raise ValueError(
+                    "Atomic-basis targets require the "
+                    "'mtt::aux::system_index' extra data, which is "
+                    "currently only provided by datasets read from disk "
+                    "(DiskDataset)."
+                )
+            system_ids = (
+                extra["mtt::aux::system_index"][0].values[:, 0].to(dtype=torch.int64)
+            )
+
+            targets[name] = prepare_atomic_basis_targets(
+                systems,
+                system_ids,
+                tensor,
+                target_info_dict[name].layout,
+                nl_options,
+                fill_value=torch.nan,
+            )
+
+    for name, tensor in extra.items():
+        if name in extra_data_info_dict and extra_data_info_dict[name].is_atomic_basis:
+            if "mtt::aux::system_index" not in extra:
+                raise ValueError(
+                    "Atomic-basis targets require the "
+                    "'mtt::aux::system_index' extra data, which is "
+                    "currently only provided by datasets read from disk "
+                    "(DiskDataset)."
+                )
+            system_ids = (
+                extra["mtt::aux::system_index"][0].values[:, 0].to(dtype=torch.int64)
+            )
+
+            extra[name] = prepare_atomic_basis_targets(
+                systems,
+                system_ids,
+                tensor,
+                extra_data_info_dict[name].layout,
+                nl_options,
+                fill_value=torch.nan,
+            )
+
+    return systems, targets, extra
+
+
+def _reverse_atomic_basis_targets_impl(
+    target_info_dict: dict[str, TargetInfo],
+    extra_data_info_dict: dict[str, TargetInfo],
+    sparse_properties: dict[str, TensorMap],
+    systems: List[System],
+    targets: Dict[str, TensorMap],
+    extra: Dict[str, TensorMap],
+) -> Tuple[List[System], Dict[str, TensorMap], Dict[str, TensorMap]]:
+    for name, tensor in targets.items():
+        if name in target_info_dict and target_info_dict[name].is_atomic_basis:
+            if name in sparse_properties:
+                sparse_properties[name] = sparse_properties[name].to(tensor.device)
+            targets[name] = sparsify_atomic_basis_target(
+                systems,
+                tensor,
+                target_info_dict[name].layout,
+                sparse_properties=sparse_properties.get(name),
+            )
+
+    for name, tensor in extra.items():
+        if name in extra_data_info_dict and extra_data_info_dict[name].is_atomic_basis:
+            if name in sparse_properties:
+                sparse_properties[name] = sparse_properties[name].to(tensor.device)
+            extra[name] = sparsify_atomic_basis_target(
+                systems,
+                tensor,
+                extra_data_info_dict[name].layout,
+                sparse_properties=sparse_properties.get(name),
+            )
+
+    return systems, targets, extra
+
+
 def get_prepare_atomic_basis_targets_transform(
     target_info_dict: dict[str, TargetInfo],
     extra_data_info_dict: dict[str, TargetInfo],
@@ -722,75 +811,6 @@ def get_prepare_atomic_basis_targets_transform(
     :return: A function that takes in systems, targets and extra data, and returns the
         systems, targets and extra data with prepared atomic basis targets.
     """
-
-    def transform(
-        systems: List[System],
-        targets: Dict[str, TensorMap],
-        extra: Dict[str, TensorMap],
-    ) -> Tuple[List[System], Dict[str, TensorMap], Dict[str, TensorMap]]:
-        """
-        Transform function that prepares the atomic basis targets for batching by
-        densifying and padding, modifying in-place. Samples keep the tensor's own
-        native "system" ids throughout.
-
-        :param systems: List of systems.
-        :param targets: Dictionary containing the targets corresponding to the systems.
-        :param extra: Dictionary containing any extra data.
-        :return: The systems, targets and extra data with prepared atomic basis targets.
-        """
-        for name, tensor in targets.items():
-            if name in target_info_dict and target_info_dict[name].is_atomic_basis:
-                if "mtt::aux::system_index" not in extra:
-                    raise ValueError(
-                        "Atomic-basis targets require the "
-                        "'mtt::aux::system_index' extra data, which is "
-                        "currently only provided by datasets read from disk "
-                        "(DiskDataset)."
-                    )
-                system_ids = (
-                    extra["mtt::aux::system_index"][0]
-                    .values[:, 0]
-                    .to(dtype=torch.int64)
-                )
-
-                targets[name] = prepare_atomic_basis_targets(
-                    systems,
-                    system_ids,
-                    tensor,
-                    target_info_dict[name].layout,
-                    nl_options,
-                    fill_value=torch.nan,
-                )
-
-        for name, tensor in extra.items():
-            if (
-                name in extra_data_info_dict
-                and extra_data_info_dict[name].is_atomic_basis
-            ):
-                if "mtt::aux::system_index" not in extra:
-                    raise ValueError(
-                        "Atomic-basis targets require the "
-                        "'mtt::aux::system_index' extra data, which is "
-                        "currently only provided by datasets read from disk "
-                        "(DiskDataset)."
-                    )
-                system_ids = (
-                    extra["mtt::aux::system_index"][0]
-                    .values[:, 0]
-                    .to(dtype=torch.int64)
-                )
-
-                extra[name] = prepare_atomic_basis_targets(
-                    systems,
-                    system_ids,
-                    tensor,
-                    extra_data_info_dict[name].layout,
-                    nl_options,
-                    fill_value=torch.nan,
-                )
-
-        return systems, targets, extra
-
     # Precompute property masks for all atomic basis targets and extra data.
     # This avoids calling layout_properties.select(block.properties) every
     # time we want to sparsify a batch.
@@ -802,49 +822,20 @@ def get_prepare_atomic_basis_targets_transform(
         if info.is_atomic_basis:
             sparse_properties[name] = _compute_sparse_properties(info.layout)
 
-    def reverse_transform(
-        systems: List[System],
-        targets: Dict[str, TensorMap],
-        extra: Dict[str, TensorMap],
-    ) -> Tuple[List[System], Dict[str, TensorMap], Dict[str, TensorMap]]:
-        """
-        Reverse transform function that unpads, undensifies and reindexes the atomic
-        basis targets, modifying in-place.
-
-        :param systems: List of systems.
-        :param targets: Dictionary containing the targets corresponding to the systems.
-        :param extra: Dictionary containing any extra data.
-        :return: The systems, targets and extra data with unprepared atomic basis
-            targets.
-        """
-        for name, tensor in targets.items():
-            if name in target_info_dict and target_info_dict[name].is_atomic_basis:
-                if name in sparse_properties:
-                    sparse_properties[name] = sparse_properties[name].to(tensor.device)
-                targets[name] = sparsify_atomic_basis_target(
-                    systems,
-                    tensor,
-                    target_info_dict[name].layout,
-                    sparse_properties=sparse_properties.get(name),
-                )
-
-        for name, tensor in extra.items():
-            if (
-                name in extra_data_info_dict
-                and extra_data_info_dict[name].is_atomic_basis
-            ):
-                if name in sparse_properties:
-                    sparse_properties[name] = sparse_properties[name].to(tensor.device)
-                extra[name] = sparsify_atomic_basis_target(
-                    systems,
-                    tensor,
-                    extra_data_info_dict[name].layout,
-                    sparse_properties=sparse_properties.get(name),
-                )
-
-        return systems, targets, extra
-
-    return transform, reverse_transform
+    return (
+        functools.partial(
+            _prepare_atomic_basis_targets_impl,
+            target_info_dict,
+            extra_data_info_dict,
+            nl_options,
+        ),
+        functools.partial(
+            _reverse_atomic_basis_targets_impl,
+            target_info_dict,
+            extra_data_info_dict,
+            sparse_properties,
+        ),
+    )
 
 
 # ===== DatasetInfo manipulation utilities

--- a/src/metatrain/utils/data/dataloaders.py
+++ b/src/metatrain/utils/data/dataloaders.py
@@ -1,13 +1,97 @@
+import logging
+import multiprocessing
 from typing import Any, List, Optional, Tuple, Union
 
+import torch.multiprocessing
 import torch.utils.data
 from torch.utils.data import DataLoader, DistributedSampler
 
-from .dataset import CollateFn, Dataset
+from .dataset import (
+    CollateFn,
+    Dataset,
+    DiskDataset,
+    MemmapDataset,
+    get_num_workers,
+)
 from .samplers import MaxAtomDistributedBatchSampler
 
 
 DatasetLike = Union[Dataset, torch.utils.data.Subset]
+
+
+def resolve_dataloader_workers(
+    requested_num_workers: Optional[int],
+    device: torch.device,
+    datasets: List[DatasetLike],
+) -> Tuple[int, Optional[str]]:
+    """Resolve the dataloader worker count and start method for a trainer.
+
+    Workers are started with the ``spawn`` method when training on CUDA
+    (forking after CUDA initialization is unsupported by PyTorch), but only
+    when every dataset is disk-backed: spawned workers receive their dataset
+    by pickling, which would copy an in-memory dataset into every worker.
+
+    :param requested_num_workers: The ``num_workers`` hyperparameter, or
+        ``None`` to choose automatically.
+    :param device: The device the model is trained on.
+    :param datasets: All datasets the dataloaders will read from.
+    :return: The number of workers and the multiprocessing context to pass to
+        the dataloader builders (``"spawn"`` or ``None``).
+    """
+    if requested_num_workers is None:
+        num_workers = get_num_workers()
+        logging.info(
+            "Number of workers for data-loading not provided and chosen "
+            f"automatically. Using {num_workers} workers."
+        )
+    else:
+        num_workers = requested_num_workers
+
+    multiprocessing_context = (
+        "spawn"
+        if (
+            num_workers > 0
+            and device.type == "cuda"
+            and datasets_are_disk_backed(datasets)
+        )
+        else None
+    )
+    return num_workers, multiprocessing_context
+
+
+def datasets_are_disk_backed(datasets: List[DatasetLike]) -> bool:
+    """Whether every dataset reads its samples from disk (and therefore
+    pickles small, making it cheap to send to spawned workers).
+
+    :param datasets: The datasets the dataloaders will read from.
+    :return: True if every dataset is disk- or memmap-backed.
+    """
+    for dataset in datasets:
+        while isinstance(dataset, torch.utils.data.Subset):
+            dataset = dataset.dataset
+        if not isinstance(dataset, (DiskDataset, MemmapDataset)):
+            return False
+    return True
+
+
+def ensure_spawn_safe_sharing(multiprocessing_context: Optional[str]) -> None:
+    """Make PyTorch's tensor sharing compatible with spawned workers.
+
+    The default ``"file_descriptor"`` sharing strategy passes tensors as open
+    file descriptors, which spawned worker processes cannot inherit
+    (``ValueError: bad value(s) in fds_to_keep``), and some container setups
+    additionally restrict ``/dev/shm``, on which it relies. The
+    ``"file_system"`` strategy works in both cases.
+
+    :param multiprocessing_context: The worker start method about to be used,
+        or ``None`` for the platform default (which is also not fork on e.g.
+        macOS, Windows, and in children of ``torch.multiprocessing.spawn``).
+    """
+    effective = multiprocessing_context or multiprocessing.get_start_method(
+        allow_none=False
+    )
+    if effective != "fork":
+        torch.multiprocessing.set_sharing_strategy("file_system")
 
 
 def build_train_dataloaders(
@@ -18,6 +102,7 @@ def build_train_dataloaders(
     max_atoms_per_batch: Optional[int],
     min_atoms_per_batch: int,
     num_workers: int,
+    multiprocessing_context: Optional[str] = None,
 ) -> Tuple[List[DataLoader], List[Any]]:
     """Build one ``DataLoader`` per training dataset.
 
@@ -39,10 +124,15 @@ def build_train_dataloaders(
     :param min_atoms_per_batch: Minimum total atom count for a packed batch to be
         kept. Only used when ``max_atoms_per_batch`` is set.
     :param num_workers: Number of ``DataLoader`` workers.
+    :param multiprocessing_context: Worker start method (e.g. ``"spawn"``), or
+        ``None`` for the PyTorch default.
     :return: A tuple ``(dataloaders, epoch_samplers)``. ``epoch_samplers`` contains
         every sampler (``DistributedSampler`` or ``MaxAtomDistributedBatchSampler``)
         that must have ``set_epoch()`` called on it before each epoch.
     """
+    if num_workers > 0:
+        ensure_spawn_safe_sharing(multiprocessing_context)
+
     dataloaders: List[DataLoader] = []
     epoch_samplers: List[Any] = []
     for train_dataset, train_sampler in zip(
@@ -67,6 +157,8 @@ def build_train_dataloaders(
                     batch_sampler=batch_sampler,
                     collate_fn=collate_fn_train,
                     num_workers=num_workers,
+                    multiprocessing_context=multiprocessing_context,
+                    persistent_workers=(num_workers > 0),
                 )
             )
         else:
@@ -88,6 +180,8 @@ def build_train_dataloaders(
                     drop_last=(train_sampler is None),
                     collate_fn=collate_fn_train,
                     num_workers=num_workers,
+                    multiprocessing_context=multiprocessing_context,
+                    persistent_workers=(num_workers > 0),
                 )
             )
     return dataloaders, epoch_samplers
@@ -100,6 +194,7 @@ def build_val_dataloaders(
     batch_size: int,
     max_atoms_per_batch: Optional[int],
     num_workers: int,
+    multiprocessing_context: Optional[str] = None,
 ) -> List[DataLoader]:
     """Build one ``DataLoader`` per validation dataset.
 
@@ -120,8 +215,13 @@ def build_val_dataloaders(
     :param max_atoms_per_batch: If set, pack batches by atom count instead of by a
         fixed number of structures.
     :param num_workers: Number of ``DataLoader`` workers.
+    :param multiprocessing_context: Worker start method (e.g. ``"spawn"``), or
+        ``None`` for the PyTorch default.
     :return: One ``DataLoader`` per dataset in ``val_datasets``.
     """
+    if num_workers > 0:
+        ensure_spawn_safe_sharing(multiprocessing_context)
+
     dataloaders: List[DataLoader] = []
     for val_dataset, val_sampler in zip(
         val_datasets, val_distributed_samplers, strict=True
@@ -142,6 +242,8 @@ def build_val_dataloaders(
                     batch_sampler=batch_sampler,
                     collate_fn=collate_fn_val,
                     num_workers=num_workers,
+                    multiprocessing_context=multiprocessing_context,
+                    persistent_workers=(num_workers > 0),
                 )
             )
         else:
@@ -154,6 +256,8 @@ def build_val_dataloaders(
                     drop_last=False,
                     collate_fn=collate_fn_val,
                     num_workers=num_workers,
+                    multiprocessing_context=multiprocessing_context,
+                    persistent_workers=(num_workers > 0),
                 )
             )
     return dataloaders

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -1,3 +1,4 @@
+import functools
 import io
 import math
 import multiprocessing
@@ -10,6 +11,7 @@ from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Tuple, 
 import numpy as np
 import torch
 from metatensor.learn.data import Dataset, group_and_join
+from metatensor.learn.data._dataset import _BaseDataset
 from metatensor.learn.data._namedtuple import namedtuple
 from metatensor.torch import (
     Labels,
@@ -44,6 +46,34 @@ from metatrain.utils.data.target_info import (
 )
 from metatrain.utils.external_naming import to_external_name
 from metatrain.utils.units import get_gradient_units
+
+
+def _rebuild_base_dataset(cls: Any, state: dict) -> Any:
+    obj = cls.__new__(cls)
+    obj.__dict__.update(state)
+    obj._sample_class = namedtuple("Sample", obj._field_names)
+    return obj
+
+
+def _base_dataset_reduce(self: Any) -> tuple:
+    state = self.__dict__.copy()
+    # the dynamically created namedtuple class cannot be pickled; it is
+    # recreated from _field_names in _rebuild_base_dataset (the same treatment
+    # DiskDataset gives its own sample class below)
+    state.pop("_sample_class", None)
+    return _rebuild_base_dataset, (type(self), state)
+
+
+# metatensor-learn datasets are not picklable as-is — and dataloader workers
+# started with the "spawn" method receive their dataset by pickling. Give them
+# a __reduce__ until metatensor-learn supports pickling natively. Routing the
+# rebuild through a function in THIS module also guarantees that unpickling
+# imports it (and, transitively, metatomic.torch and metatensor.torch) before
+# reconstructing the System/TensorMap objects held by the dataset: their C++
+# TorchScript classes must be registered first, and a spawned worker unpickles
+# the dataset before anything else has imported those modules ("Tried to
+# deserialize class ... which is not known to the runtime").
+_BaseDataset.__reduce__ = _base_dataset_reduce  # type: ignore[attr-defined]
 
 
 def _set(values: List[int]) -> List[int]:
@@ -889,10 +919,8 @@ class DiskDataset(torch.utils.data.Dataset):
 
         self._fields_to_read.append("mtt::aux::system_index")
 
-        fields_map = fields if isinstance(fields, dict) else {}
-        self._sample_class = namedtuple(
-            "Sample", [fields_map.get(field, field) for field in self._fields_to_read]
-        )
+        # target-config dicts remap dataset field names to target names
+        self._fields_map: Dict[str, str] = fields if isinstance(fields, dict) else {}
 
         # The dataset is valid: report skipped files, once.
         # DiskDatasetWriter output never triggers this.
@@ -906,6 +934,21 @@ class DiskDataset(torch.utils.data.Dataset):
                 "`<N>/system.mta` or `<N>/<target>.mts`.",
                 stacklevel=2,
             )
+
+    @functools.cached_property
+    def _sample_class(self) -> Any:
+        return namedtuple(
+            "Sample",
+            [self._fields_map.get(field, field) for field in self._fields_to_read],
+        )
+
+    def __getstate__(self) -> dict:
+        # _sample_class is a cached_property stored in __dict__ after first access;
+        # drop it so workers recreate it lazily rather than unpickling a dynamic
+        # class (the SmartZip drops its own process-local file handle the same way).
+        state = self.__dict__.copy()
+        state.pop("_sample_class", None)
+        return state
 
     def _read_member(self, index: int, field_name: str) -> io.BytesIO:
         """Read one zip member of the sample at ``index``.
@@ -1148,9 +1191,6 @@ def get_num_workers() -> int:
     :return: A good number of workers for data loading.
     """
 
-    if multiprocessing.get_start_method(allow_none=False) != "fork":
-        return 0
-
     # len(os.sched_getaffinity(0)) detects thread counts set by slurm,
     # multiprocessing.cpu_count() doesn't but is more portable
     if hasattr(os, "sched_getaffinity"):
@@ -1165,23 +1205,6 @@ def get_num_workers() -> int:
     num_workers = max(0, min(num_threads - reserve, cap))
 
     return num_workers
-
-
-def validate_num_workers(num_workers: int) -> None:
-    """
-    Gets a good number of workers for data loading.
-
-    :param num_workers: The number of workers to validate.
-    :raises ValueError: If the number of workers is greater than 0 and the
-        multiprocessing start method is not "fork".
-    """
-
-    if multiprocessing.get_start_method(allow_none=False) != "fork" and num_workers > 0:
-        raise ValueError(
-            "You are using a start method for multiprocessing that is not "
-            "'fork' (this is likely because you are on macOS or Windows). "
-            "In this case, num_workers must be set to 0."
-        )
 
 
 def _make_system_contiguous(system: System) -> System:
@@ -1231,6 +1254,13 @@ class MemmapArray:
         self.dtype = np.dtype(dtype)
         self.mode = mode
         self._mm = None
+
+    def __getstate__(self) -> dict:
+        # pickling an open np.memmap materializes the whole array into the
+        # pickle; drop the handle so workers reopen the file lazily
+        state = self.__dict__.copy()
+        state["_mm"] = None
+        return state
 
     def _ensure_open(self) -> None:
         if self._mm is None:
@@ -1309,13 +1339,6 @@ class MemmapDataset(TorchDataset):
                     f"Extra data key '{key}' has type '{opts.get('type')}'; "
                     "only 'scalar' is supported for MemmapDataset extra data."
                 )
-        self.sample_class = namedtuple(
-            "Sample",
-            ["system"]
-            + list(self.target_config.keys())
-            + list(self.extra_data_config.keys()),
-        )
-
         # Information about the structures
         self.ns = np.load(path / "ns.npy")
         self.na = np.load(path / "na.npy")
@@ -1409,6 +1432,22 @@ class MemmapDataset(TorchDataset):
                 raise ValueError(
                     f"Unsupported target configuration: {single_target_options}"
                 )
+
+    @functools.cached_property
+    def sample_class(self) -> Any:
+        return namedtuple(
+            "Sample",
+            ["system"]
+            + list(self.target_config.keys())
+            + list(self.extra_data_config.keys()),
+        )
+
+    def __getstate__(self) -> dict:
+        # the dynamically created sample class cannot be pickled; drop it so
+        # workers recreate it lazily (same treatment as DiskDataset above)
+        state = self.__dict__.copy()
+        state.pop("sample_class", None)
+        return state
 
     def __len__(self) -> int:
         return self.ns

--- a/src/metatrain/utils/neighbor_lists.py
+++ b/src/metatrain/utils/neighbor_lists.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Callable, Dict, List, Tuple
 
 import ase.neighborlist
@@ -8,6 +9,19 @@ from metatensor.torch import Labels, TensorBlock
 from metatomic.torch import NeighborListOptions, System, register_autograd_neighbors
 
 from .data.system_to_ase import system_to_ase
+
+
+def _neighbor_lists_transform_impl(
+    requested_neighbor_lists: List[NeighborListOptions],
+    systems: List[System],
+    targets: Dict[str, TensorBlock],
+    extra: Dict[str, TensorBlock],
+) -> Tuple[List[System], Dict[str, TensorBlock], Dict[str, TensorBlock]]:
+    new_systems = [
+        get_system_with_neighbor_lists(system, requested_neighbor_lists)
+        for system in systems
+    ]
+    return new_systems, targets, extra
 
 
 def get_system_with_neighbor_lists_transform(
@@ -21,29 +35,7 @@ def get_system_with_neighbor_lists_transform(
     :return: A function that takes a list of `System` objects and returns a new
         list of `System` objects with the requested neighbor lists added.
     """
-
-    def transform(
-        systems: List[System],
-        targets: Dict[str, TensorBlock],
-        extra: Dict[str, TensorBlock],
-    ) -> Tuple[List[System], Dict[str, TensorBlock], Dict[str, TensorBlock]]:
-        """
-        :param systems: A list of `System` objects.
-        :param targets: A dictionary of target `TensorBlock` objects.
-        :param extra: A dictionary of extra `TensorBlock` objects.
-        :return: The systems with the requested neighbor lists added, along with
-            the original targets and extra data.
-        """
-        new_systems = []
-        for system in systems:
-            new_system = get_system_with_neighbor_lists(
-                system,
-                requested_neighbor_lists,
-            )
-            new_systems.append(new_system)
-        return new_systems, targets, extra
-
-    return transform
+    return functools.partial(_neighbor_lists_transform_impl, requested_neighbor_lists)
 
 
 def get_requested_neighbor_lists(

--- a/src/metatrain/utils/scaler/remove.py
+++ b/src/metatrain/utils/scaler/remove.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Callable, Dict, List, Tuple
 
 import torch
@@ -30,6 +31,16 @@ def remove_scale(
     )
 
 
+def _remove_scale_transform_impl(
+    scaler: Scaler,
+    systems: List[System],
+    targets: Dict[str, TensorMap],
+    extra: Dict[str, TensorMap],
+) -> Tuple[List[System], Dict[str, TensorMap], Dict[str, TensorMap]]:
+    new_targets = remove_scale(systems, targets, scaler)
+    return systems, new_targets, extra
+
+
 def get_remove_scale_transform(scaler: Scaler) -> Callable:
     """
     Remove the scaling from the targets using the provided scaler.
@@ -37,19 +48,4 @@ def get_remove_scale_transform(scaler: Scaler) -> Callable:
     :param scaler: The scaler used to scale the targets.
     :return: A function that removes the scaling from the targets.
     """
-
-    def transform(
-        systems: List[System],
-        targets: Dict[str, TensorMap],
-        extra: Dict[str, TensorMap],
-    ) -> Tuple[List[System], Dict[str, TensorMap], Dict[str, TensorMap]]:
-        """
-        :param systems: List of systems.
-        :param targets: Dictionary containing the targets corresponding to the systems.
-        :param extra: Dictionary containing any extra data.
-        :return: The systems, updated targets and extra data.
-        """
-        new_targets = remove_scale(systems, targets, scaler)
-        return systems, new_targets, extra
-
-    return transform
+    return functools.partial(_remove_scale_transform_impl, scaler)

--- a/src/metatrain/utils/system_data.py
+++ b/src/metatrain/utils/system_data.py
@@ -1,10 +1,63 @@
 """Utilities for attaching per-system data to :class:`System` objects."""
 
+import functools
 from typing import Callable, Dict, List, Tuple
 
 import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
 from metatomic.torch import System
+
+
+def _system_data_transform_impl(
+    data_keys: List[str],
+    systems: List[System],
+    targets: Dict[str, TensorMap],
+    extra: Dict[str, TensorMap],
+) -> Tuple[List[System], Dict[str, TensorMap], Dict[str, TensorMap]]:
+    for key in data_keys:
+        if key not in extra:
+            continue
+        prop_name = key.split("::")[-1]
+        block = extra[key].block()
+        if block.samples.names != ["system"]:
+            raise ValueError(
+                f"get_system_data_transform expects per-system TensorMaps "
+                f"(samples=['system']), got samples={block.samples.names} "
+                f"for key '{key}'. Per-atom extra data cannot be attached "
+                "to System objects this way."
+            )
+        # ``group_and_join`` concatenates the per-sample blocks in batch
+        # order, so row ``row_idx`` belongs to ``systems[row_idx]``. The
+        # label *values* in the "system" column are the original dataset
+        # indices and must not be used to index the batch list.
+        for row_idx in range(len(block.samples)):
+            val = block.values[row_idx : row_idx + 1]  # shape [1, n_props]
+            if torch.isnan(val).any():
+                continue
+            if key in systems[row_idx].known_data():
+                continue
+            systems[row_idx].add_data(
+                key,
+                TensorMap(
+                    keys=Labels.single(),
+                    blocks=[
+                        TensorBlock(
+                            values=val,
+                            samples=Labels(
+                                "system",
+                                torch.tensor(
+                                    [[row_idx]],
+                                    device=val.device,
+                                    dtype=torch.int32,
+                                ),
+                            ),
+                            components=[],
+                            properties=Labels.range(prop_name, val.shape[-1]),
+                        )
+                    ],
+                ),
+            )
+    return systems, targets, extra
 
 
 def get_system_data_transform(
@@ -32,55 +85,4 @@ def get_system_data_transform(
     :return: A three-argument callable
         ``(systems, targets, extra) -> (systems, targets, extra)``.
     """
-
-    def transform(
-        systems: List[System],
-        targets: Dict[str, TensorMap],
-        extra: Dict[str, TensorMap],
-    ) -> Tuple[List[System], Dict[str, TensorMap], Dict[str, TensorMap]]:
-        for key in data_keys:
-            if key not in extra:
-                continue
-            prop_name = key.split("::")[-1]
-            block = extra[key].block()
-            if block.samples.names != ["system"]:
-                raise ValueError(
-                    f"get_system_data_transform expects per-system TensorMaps "
-                    f"(samples=['system']), got samples={block.samples.names} "
-                    f"for key '{key}'. Per-atom extra data cannot be attached "
-                    "to System objects this way."
-                )
-            # ``group_and_join`` concatenates the per-sample blocks in batch
-            # order, so row ``row_idx`` belongs to ``systems[row_idx]``. The
-            # label *values* in the "system" column are the original dataset
-            # indices and must not be used to index the batch list.
-            for row_idx in range(len(block.samples)):
-                val = block.values[row_idx : row_idx + 1]  # shape [1, n_props]
-                if torch.isnan(val).any():
-                    continue
-                if key in systems[row_idx].known_data():
-                    continue
-                systems[row_idx].add_data(
-                    key,
-                    TensorMap(
-                        keys=Labels.single(),
-                        blocks=[
-                            TensorBlock(
-                                values=val,
-                                samples=Labels(
-                                    "system",
-                                    torch.tensor(
-                                        [[row_idx]],
-                                        device=val.device,
-                                        dtype=torch.int32,
-                                    ),
-                                ),
-                                components=[],
-                                properties=Labels.range(prop_name, val.shape[-1]),
-                            )
-                        ],
-                    ),
-                )
-        return systems, targets, extra
-
-    return transform
+    return functools.partial(_system_data_transform_impl, data_keys)

--- a/tests/utils/data/test_dataloaders.py
+++ b/tests/utils/data/test_dataloaders.py
@@ -1,6 +1,6 @@
 """Tests for the shared dataloader-building utilities in
 ``metatrain.utils.data.dataloaders``, covering ``max_atoms_per_batch`` packing
-end-to-end.
+end-to-end and the pickle boundary of spawned dataloader workers.
 
 Architectures each used to carry their own ``test_train_max_atoms_per_batch``
 regression test exercising this through a full model training. Since
@@ -9,15 +9,20 @@ implementation every architecture trainer calls into, one direct test here is
 enough: it removes the duplication without losing coverage.
 """
 
+import pickle
 from pathlib import Path
 
+import torch.utils.data
 from metatensor.learn.data import Dataset
+from metatomic.torch import NeighborListOptions
 from omegaconf import OmegaConf
 
 from metatrain.utils.data import build_train_dataloaders, build_val_dataloaders
-from metatrain.utils.data.dataset import CollateFn, unpack_batch
+from metatrain.utils.data.dataloaders import datasets_are_disk_backed
+from metatrain.utils.data.dataset import CollateFn, DiskDataset, unpack_batch
 from metatrain.utils.data.readers import read_systems, read_targets
 from metatrain.utils.data.samplers import MaxAtomDistributedBatchSampler
+from metatrain.utils.neighbor_lists import get_system_with_neighbor_lists_transform
 
 
 RESOURCES_PATH = Path(__file__).resolve().parents[2] / "resources"
@@ -106,3 +111,62 @@ def test_max_atoms_per_batch_end_to_end():
     for batch in val_batch_sampler.all_batches:
         atom_count = sum(len(dataset[i].system) for i in batch)
         assert atom_count <= 20
+
+
+def _collate_with_nl_transform() -> CollateFn:
+    return CollateFn(
+        target_keys=["energy"],
+        callables=[
+            get_system_with_neighbor_lists_transform(
+                [NeighborListOptions(cutoff=5.0, full_list=True, strict=True)]
+            ),
+        ],
+    )
+
+
+def test_collate_fn_with_transforms_is_picklable():
+    """Collate transforms must stay picklable: spawned workers receive the
+    collate function by pickle."""
+    dataset = _build_dataset()
+
+    reloaded = pickle.loads(pickle.dumps(_collate_with_nl_transform()))
+
+    batch = [dataset[i] for i in range(4)]
+    systems, targets, _ = unpack_batch(reloaded(batch))
+    assert "energy" in targets
+    assert all(len(s.known_neighbor_lists()) == 1 for s in systems)
+
+
+def test_dataloader_spawn_workers():
+    """A full epoch with spawn-started workers exercises everything crossing
+    the worker pickle boundary (dataset, collate function, transforms)."""
+    dataset = _build_dataset()
+
+    train_dataloaders, _ = build_train_dataloaders(
+        train_datasets=[dataset],
+        train_distributed_samplers=[None],
+        collate_fn_train=_collate_with_nl_transform(),
+        batch_size=25,
+        max_atoms_per_batch=None,
+        min_atoms_per_batch=1,
+        num_workers=2,
+        multiprocessing_context="spawn",
+    )
+
+    n_systems_seen = 0
+    for raw_batch in train_dataloaders[0]:
+        systems, targets, _ = unpack_batch(raw_batch)
+        assert "energy" in targets
+        assert all(len(s.known_neighbor_lists()) == 1 for s in systems)
+        n_systems_seen += len(systems)
+    assert n_systems_seen == len(dataset)
+
+
+def test_datasets_are_disk_backed():
+    """Only disk-backed datasets opt in to spawned workers."""
+    in_memory = _build_dataset()
+    disk = DiskDataset(RESOURCES_PATH / "spherical_disk_dataset.zip")
+    assert datasets_are_disk_backed([disk])
+    assert datasets_are_disk_backed([torch.utils.data.Subset(disk, [0])])
+    assert not datasets_are_disk_backed([in_memory])
+    assert not datasets_are_disk_backed([disk, in_memory])

--- a/tests/utils/data/test_dataset.py
+++ b/tests/utils/data/test_dataset.py
@@ -1,3 +1,4 @@
+import pickle
 from pathlib import Path
 
 import numpy as np
@@ -22,7 +23,7 @@ from metatrain.utils.data import (
     read_targets,
     unpack_batch,
 )
-from metatrain.utils.data.dataset import MemmapDataset
+from metatrain.utils.data.dataset import DiskDataset, MemmapDataset
 from metatrain.utils.data.writers import MemmapWriter
 
 
@@ -1370,3 +1371,49 @@ def test_memmap_masses_attached(tmp_path):
     # the atom label is local (0), not the global offset (1)
     assert block.samples.values.tolist() == [[1, 0]]
     assert block.values.squeeze(-1).tolist() == [12.0]
+
+
+def test_disk_dataset_is_picklable():
+    """DiskDataset must survive pickling: spawned dataloader workers receive
+    their dataset by pickle."""
+    dataset = DiskDataset(RESOURCES_PATH / "spherical_disk_dataset.zip")
+    sample = dataset[0]  # populate the cached sample class before pickling
+
+    reloaded = pickle.loads(pickle.dumps(dataset))
+    sample2 = reloaded[0]
+    assert sample2._fields == sample._fields
+    assert torch.equal(sample2.system.positions, sample.system.positions)
+
+
+def test_memmap_dataset_is_picklable(tmp_path):
+    """MemmapDataset must pickle small (paths, not array contents): spawned
+    dataloader workers receive their dataset by pickle."""
+    ns = 2
+    na = np.array([0, 2, 5], dtype=np.int64)
+    np.save(tmp_path / "ns.npy", ns)
+    np.save(tmp_path / "na.npy", na)
+    np.array(
+        [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0], [0, 0, 1]], dtype="float32"
+    ).tofile(tmp_path / "x.bin")
+    np.array([1, 1, 6, 6, 8], dtype="int32").tofile(tmp_path / "a.bin")
+    np.zeros((ns, 3, 3), dtype="float32").tofile(tmp_path / "c.bin")
+    np.arange(5, dtype="float32").reshape(5, 1).tofile(tmp_path / "charge.bin")
+
+    target_options = {
+        "atomic_charge": {
+            "key": "charge",
+            "sample_kind": "atom",
+            "num_subtargets": 1,
+            "type": "scalar",
+            "quantity": "energy",
+        }
+    }
+    dataset = MemmapDataset(tmp_path, target_options)
+    sample = dataset[1]  # opens the memmaps and creates the sample class
+
+    payload = pickle.dumps(dataset)
+    assert len(payload) < 10_000  # paths and metadata, not array contents
+
+    sample2 = pickle.loads(payload)[1]
+    assert sample2._fields == sample._fields
+    assert torch.equal(sample2.system.positions, sample.system.positions)


### PR DESCRIPTION
# Use spawn for dataloader workers on CUDA

On Linux, PyTorch creates dataloader workers by forking the training process. On GPU this causes two problems. First, PyTorch officially does not support forking after CUDA has been initialized; it can crash or deadlock. Second, forked workers gradually stop sharing memory with the training process: Python constantly writes small bookkeeping updates into every object it reads, and each write turns a shared piece of memory into a private copy inside the worker (pytorch/pytorch#13246). Over a long run, each worker ends up holding a copy of most of the training process's memory. This was OOM-killing our production trainings on CSCS Alps (GH200 nodes).

Measured on a GH200 node, with 8 workers and a training process holding 8 GiB of dataset bookkeeping:

| | memory per worker | total extra memory | batches in 240 s |
|---|---|---|---|
| fork | 11.6 GiB | 92.9 GiB | 8.8k |
| spawn | 0.4 GiB | 3.1 GiB | 149k |

The speed difference has the same cause: the fork workers spend most of their time copying memory instead of loading data.

The fix is to start workers with `spawn` instead when training on CUDA. A spawned worker is a fresh process: it receives the dataset and the collate function through pickle, and nothing else. This PR does that for every architecture that uses dataloader workers (PET, SOAP-BPNN, LLPR, MACE, SPACE, FlashMD).

Since workers now receive their inputs through pickle, everything sent to them has to be picklable. Most of the diff is the same change repeated five times: the collate transforms were functions defined inside other functions, which pickle cannot handle. Each one is now a normal top-level function, with its parameters attached using `functools.partial`. The function bodies are unchanged.

The rest:

- `resolve_dataloader_workers()` replaces the worker-count selection block that every trainer carried a copy of, and also decides between fork and spawn. Same small change in all seven trainers. Workers are kept alive between epochs when there are any, so spawned workers start once per training, not once per epoch.
- Spawn is only used when all datasets read from disk (`datasets_are_disk_backed()`). Each spawned worker gets its own copy of the dataset, which is a few kB for `DiskDataset` and `MemmapDataset`, but would be the entire dataset for in-memory ones. In-memory datasets keep the old behavior.
- `DiskDataset`, `MemmapDataset` and metatensor-learn datasets hold one attribute that pickle cannot handle (a dynamically created class). It is now dropped when pickling and recreated on first use. `MemmapDataset` also no longer serializes the full contents of any memory-mapped file it has open; workers reopen the files instead. The metatensor-learn hook is also written so that unpickling imports metatomic and metatensor before rebuilding the Systems and TensorMaps inside the dataset; without that, the worker crashes because those types are not registered yet. This part can move to metatensor-learn itself later.
- Dataloader workers are now also allowed on macOS and Windows. They were disabled there only because those platforms start workers with spawn and the collate function could not be pickled; this PR fixes the pickling, so `validate_num_workers()` and the matching check in `get_num_workers()` are removed.
- Spawn also requires PyTorch's "file_system" mode for passing tensors between processes; the dataloader builders switch to it whenever the effective start method is not fork (an explicit "spawn", but also the platform default on macOS and Windows, or inside `torch.multiprocessing.spawn` children). The default mode relies on inherited file handles, which a fresh process does not have.

Not changed here: the composition-model fit already picks its own workers and still forks them, and the scaler fit still runs without workers. Aligning both with the spawn policy is left for a follow-up.

Tests: pickle round-trips for the collate function, `DiskDataset` and `MemmapDataset`, the disk-backed check, and a full epoch with spawned workers. All pass locally and on GH200 in our production container.
