### PR TITLE
Remove the pin on vesin version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "omegaconf >= 2.3.0",
     "python-hostlist",
     "tqdm",
-    "vesin >= 0.5.2, <0.6", # Because of https://github.com/Luthaf/vesin/pull/119,
+    "vesin >=0.6.1,<0.7",
 ]
 
 keywords = ["machine learning", "molecular modeling"]


### PR DESCRIPTION
The deadlock we saw should be fixed now.


# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Maintainer/Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1230.org.readthedocs.build/en/1230/

<!-- readthedocs-preview metatrain end -->