### PR TITLE
Check input model hypers when restarting trainings

### DIFF
--- a/docs/src/dev-docs/changelog.rst
+++ b/docs/src/dev-docs/changelog.rst
@@ -33,6 +33,11 @@ Added
 Changed
 #######
 
+- Models now check that the model hypers passed for restarting are the same as
+  those used for the original training. If no model hypers are specified in the
+  yaml file for restarting, that is fine, only the ones explicitly specified
+  will be checked.
+
 Removed
 #######
 

--- a/src/metatrain/cli/train.py
+++ b/src/metatrain/cli/train.py
@@ -293,6 +293,7 @@ def train_model(
     # MERGE OPTIONS ###########
     ###########################
 
+    input_options = copy.deepcopy(options)
     options = OmegaConf.merge(
         BASE_OPTIONS,
         {"architecture": get_default_hypers(architecture_name)},
@@ -634,6 +635,8 @@ def train_model(
     else:
         training_context = None
 
+    new_model_hypers = input_options.get("architecture", {}).get("model", {})
+
     try:
         if training_context == "restart" and restart_from is not None:
             logging.info(f"Restarting training from '{restart_from}'")
@@ -647,7 +650,7 @@ def train_model(
                     f"The file {restart_from} does not contain a valid checkpoint for "
                     f"the '{architecture_name}' architecture"
                 ) from e
-            model = model.restart(dataset_info)
+            model = model.restart(dataset_info, model_hypers=new_model_hypers)
             try:
                 trainer = trainer_from_checkpoint(
                     checkpoint=checkpoint,
@@ -671,7 +674,7 @@ def train_model(
                     f"The file {restart_from} does not contain a valid checkpoint for "
                     f"the '{architecture_name}' architecture"
                 ) from e
-            model = model.restart(dataset_info)
+            model = model.restart(dataset_info, model_hypers=new_model_hypers)
             trainer = Trainer(hypers["training"])
         else:
             logging.info("Starting training from scratch")

--- a/src/metatrain/cli/train.py
+++ b/src/metatrain/cli/train.py
@@ -298,6 +298,7 @@ def train_model(
     # MERGE OPTIONS ###########
     ###########################
 
+    input_options = copy.deepcopy(options)
     options = OmegaConf.merge(
         BASE_OPTIONS,
         {"architecture": get_default_hypers(architecture_name)},
@@ -631,6 +632,8 @@ def train_model(
     else:
         training_context = None
 
+    new_model_hypers = input_options.get("architecture", {}).get("model", {})
+
     try:
         if training_context == "restart" and restart_from is not None:
             logging.info(f"Restarting training from '{restart_from}'")
@@ -644,7 +647,7 @@ def train_model(
                     f"The file {restart_from} does not contain a valid checkpoint for "
                     f"the '{architecture_name}' architecture"
                 ) from e
-            model = model.restart(dataset_info)
+            model = model.restart(dataset_info, model_hypers=new_model_hypers)
             try:
                 trainer = trainer_from_checkpoint(
                     checkpoint=checkpoint,
@@ -668,7 +671,7 @@ def train_model(
                     f"The file {restart_from} does not contain a valid checkpoint for "
                     f"the '{architecture_name}' architecture"
                 ) from e
-            model = model.restart(dataset_info)
+            model = model.restart(dataset_info, model_hypers=new_model_hypers)
             trainer = Trainer(hypers["training"])
         else:
             logging.info("Starting training from scratch")

--- a/src/metatrain/composition/model.py
+++ b/src/metatrain/composition/model.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from typing import Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import metatensor.torch as mts
 import torch
@@ -22,6 +22,7 @@ from metatrain.utils.data.atomic_basis_helpers import (
     sparsify_atomic_basis_target,
 )
 from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.metadata import merge_metadata
 
 from . import checkpoints
@@ -204,7 +205,9 @@ class CompositionModel(ModelInterface[ModelHypers]):
             checkpoint_dir="",
         )
 
-    def restart(self, dataset_info: DatasetInfo) -> "CompositionModel":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "CompositionModel":
         """
         Update the model to continue training, possibly with new targets.
 
@@ -214,8 +217,13 @@ class CompositionModel(ModelInterface[ModelHypers]):
 
         :param dataset_info: Information about the new dataset, including the
             targets that will be used for training.
+        :param model_hypers: New hyperparameters for the model. They must match
+            the existing hyperparameters, otherwise an error is raised.
         :return: The updated model.
         """
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
         raw_targets = {}
         for target_name in dataset_info.targets:
             target_info = dataset_info.targets[target_name]

--- a/src/metatrain/composition/model.py
+++ b/src/metatrain/composition/model.py
@@ -219,7 +219,7 @@ class CompositionModel(ModelInterface[ModelHypers]):
         :param dataset_info: Information about the new dataset, including the
             targets that will be used for training.
         :param model_hypers: New hyperparameters for the model. They must match
-            the existing hyperparameters, otherwise an error is raised.
+            the checkpoint's hyperparameters, otherwise an error is raised.
         :return: The updated model.
         """
         if model_hypers is not None:

--- a/src/metatrain/composition/model.py
+++ b/src/metatrain/composition/model.py
@@ -15,6 +15,7 @@ from metatomic.torch import (
 )
 
 from metatrain.utils.abc import ModelInterface
+from metatrain.utils.architectures import get_default_hypers
 from metatrain.utils.data import Dataset, DatasetInfo, TargetInfo
 from metatrain.utils.data.atom_pair_helpers import check_no_atom_pair_targets
 from metatrain.utils.data.atomic_basis_helpers import (
@@ -222,7 +223,10 @@ class CompositionModel(ModelInterface[ModelHypers]):
         :return: The updated model.
         """
         if model_hypers is not None:
-            raise_if_hypers_mismatch(self.hypers, model_hypers)
+            default_hypers = get_default_hypers("composition")["model"]
+            raise_if_hypers_mismatch(
+                self.hypers, model_hypers, default_hypers=default_hypers
+            )
 
         raw_targets = {}
         for target_name in dataset_info.targets:

--- a/src/metatrain/experimental/classifier/model.py
+++ b/src/metatrain/experimental/classifier/model.py
@@ -123,7 +123,9 @@ class Classifier(ModelInterface[ModelHypers]):
         # Final classification layer
         self.linear = torch.nn.Linear(current_size, num_classes, bias=False)
 
-    def restart(self, dataset_info: DatasetInfo) -> "Classifier":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "Classifier":
         raise ValueError("Restarting from a Classifier model is not supported.")
 
     def forward(

--- a/src/metatrain/experimental/dpa3/model.py
+++ b/src/metatrain/experimental/dpa3/model.py
@@ -27,6 +27,7 @@ from metatrain.utils.data import TargetInfo
 from metatrain.utils.data.atom_pair_helpers import check_no_atom_pair_targets
 from metatrain.utils.data.dataset import DatasetInfo
 from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.metadata import merge_metadata
 from metatrain.utils.sum_over_atoms import sum_over_atoms
 
@@ -392,7 +393,13 @@ class DPA3(ModelInterface[ModelHypers]):
 
         return return_dict
 
-    def restart(self, dataset_info: DatasetInfo) -> "DPA3":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "DPA3":
+
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)
         new_atomic_types = [

--- a/src/metatrain/experimental/dpa3/model.py
+++ b/src/metatrain/experimental/dpa3/model.py
@@ -25,6 +25,7 @@ from metatrain.utils.data import TargetInfo
 from metatrain.utils.data.atom_pair_helpers import check_no_atom_pair_targets
 from metatrain.utils.data.dataset import DatasetInfo
 from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.metadata import merge_metadata
 from metatrain.utils.scaler import Scaler
 from metatrain.utils.sum_over_atoms import sum_over_atoms
@@ -391,7 +392,13 @@ class DPA3(ModelInterface[ModelHypers]):
 
         return return_dict
 
-    def restart(self, dataset_info: DatasetInfo) -> "DPA3":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "DPA3":
+
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)
         new_atomic_types = [

--- a/src/metatrain/experimental/dpa3/model.py
+++ b/src/metatrain/experimental/dpa3/model.py
@@ -398,7 +398,10 @@ class DPA3(ModelInterface[ModelHypers]):
     ) -> "DPA3":
 
         if model_hypers is not None:
-            raise_if_hypers_mismatch(self.hypers, model_hypers)
+            default_hypers = get_default_hypers("experimental.dpa3")["model"]
+            raise_if_hypers_mismatch(
+                self.hypers, model_hypers, default_hypers=default_hypers
+            )
 
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)

--- a/src/metatrain/experimental/flashmd/model.py
+++ b/src/metatrain/experimental/flashmd/model.py
@@ -30,6 +30,7 @@ from metatrain.utils.architectures import get_default_hypers
 from metatrain.utils.data import DatasetInfo, TargetInfo
 from metatrain.utils.data.atom_pair_helpers import check_no_atom_pair_targets
 from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.long_range import DummyLongRangeFeaturizer, LongRangeFeaturizer
 from metatrain.utils.metadata import merge_metadata
 from metatrain.utils.sum_over_atoms import sum_over_atoms
@@ -234,7 +235,13 @@ class FlashMD(ModelInterface[ModelHypers]):
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.outputs
 
-    def restart(self, dataset_info: DatasetInfo) -> "FlashMD":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "FlashMD":
+
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)
         new_atomic_types = [

--- a/src/metatrain/experimental/flashmd/model.py
+++ b/src/metatrain/experimental/flashmd/model.py
@@ -28,6 +28,7 @@ from metatrain.utils.abc import ModelInterface
 from metatrain.utils.data import DatasetInfo, TargetInfo
 from metatrain.utils.data.atom_pair_helpers import check_no_atom_pair_targets
 from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.long_range import DummyLongRangeFeaturizer, LongRangeFeaturizer
 from metatrain.utils.metadata import merge_metadata
 from metatrain.utils.scaler import Scaler
@@ -232,7 +233,13 @@ class FlashMD(ModelInterface[ModelHypers]):
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.outputs
 
-    def restart(self, dataset_info: DatasetInfo) -> "FlashMD":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "FlashMD":
+
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)
         new_atomic_types = [

--- a/src/metatrain/experimental/flashmd/model.py
+++ b/src/metatrain/experimental/flashmd/model.py
@@ -240,7 +240,10 @@ class FlashMD(ModelInterface[ModelHypers]):
     ) -> "FlashMD":
 
         if model_hypers is not None:
-            raise_if_hypers_mismatch(self.hypers, model_hypers)
+            default_hypers = get_default_hypers("experimental.flashmd")["model"]
+            raise_if_hypers_mismatch(
+                self.hypers, model_hypers, default_hypers=default_hypers
+            )
 
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)

--- a/src/metatrain/experimental/flashmd_symplectic/model.py
+++ b/src/metatrain/experimental/flashmd_symplectic/model.py
@@ -33,6 +33,7 @@ from metatrain.utils.data import DatasetInfo, TargetInfo
 from metatrain.utils.data.atom_pair_helpers import check_no_atom_pair_targets
 from metatrain.utils.data.target_info import get_energy_target_info
 from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.long_range import DummyLongRangeFeaturizer, LongRangeFeaturizer
 from metatrain.utils.metadata import merge_metadata
 from metatrain.utils.sum_over_atoms import sum_over_atoms
@@ -224,7 +225,13 @@ class FlashMDSymplectic(ModelInterface):
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.outputs
 
-    def restart(self, dataset_info: DatasetInfo) -> "FlashMDSymplectic":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "FlashMDSymplectic":
+
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)
         new_atomic_types = [

--- a/src/metatrain/experimental/flashmd_symplectic/model.py
+++ b/src/metatrain/experimental/flashmd_symplectic/model.py
@@ -230,7 +230,12 @@ class FlashMDSymplectic(ModelInterface):
     ) -> "FlashMDSymplectic":
 
         if model_hypers is not None:
-            raise_if_hypers_mismatch(self.hypers, model_hypers)
+            default_hypers = get_default_hypers("experimental.flashmd_symplectic")[
+                "model"
+            ]
+            raise_if_hypers_mismatch(
+                self.hypers, model_hypers, default_hypers=default_hypers
+            )
 
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)

--- a/src/metatrain/experimental/flashmd_symplectic/model.py
+++ b/src/metatrain/experimental/flashmd_symplectic/model.py
@@ -31,6 +31,7 @@ from metatrain.utils.data import DatasetInfo, TargetInfo
 from metatrain.utils.data.atom_pair_helpers import check_no_atom_pair_targets
 from metatrain.utils.data.target_info import get_energy_target_info
 from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.long_range import DummyLongRangeFeaturizer, LongRangeFeaturizer
 from metatrain.utils.metadata import merge_metadata
 from metatrain.utils.scaler import Scaler
@@ -222,7 +223,13 @@ class FlashMDSymplectic(ModelInterface):
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.outputs
 
-    def restart(self, dataset_info: DatasetInfo) -> "FlashMDSymplectic":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "FlashMDSymplectic":
+
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)
         new_atomic_types = [

--- a/src/metatrain/experimental/mace/model.py
+++ b/src/metatrain/experimental/mace/model.py
@@ -32,6 +32,7 @@ from metatrain.utils.data.atomic_basis_helpers import (
     sparsify_atomic_basis_target,
 )
 from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.metadata import merge_metadata
 from metatrain.utils.sum_over_atoms import sum_over_atoms
 
@@ -307,7 +308,13 @@ class MetaMACE(ModelInterface[ModelHypers]):
 
         self.finetune_config: Dict[str, Any] = {}
 
-    def restart(self, dataset_info: DatasetInfo) -> "MetaMACE":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "MetaMACE":
+
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
         # Check that the new dataset info does not contain new atomic types
         if new_atomic_types := set(dataset_info.atomic_types) - set(
             self.dataset_info.atomic_types

--- a/src/metatrain/experimental/mace/model.py
+++ b/src/metatrain/experimental/mace/model.py
@@ -30,6 +30,7 @@ from metatrain.utils.data.atomic_basis_helpers import (
     sparsify_atomic_basis_target,
 )
 from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.metadata import merge_metadata
 from metatrain.utils.scaler import Scaler
 from metatrain.utils.sum_over_atoms import sum_over_atoms
@@ -306,7 +307,13 @@ class MetaMACE(ModelInterface[ModelHypers]):
 
         self.finetune_config: Dict[str, Any] = {}
 
-    def restart(self, dataset_info: DatasetInfo) -> "MetaMACE":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "MetaMACE":
+
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
         # Check that the new dataset info does not contain new atomic types
         if new_atomic_types := set(dataset_info.atomic_types) - set(
             self.dataset_info.atomic_types

--- a/src/metatrain/experimental/mace/model.py
+++ b/src/metatrain/experimental/mace/model.py
@@ -313,7 +313,10 @@ class MetaMACE(ModelInterface[ModelHypers]):
     ) -> "MetaMACE":
 
         if model_hypers is not None:
-            raise_if_hypers_mismatch(self.hypers, model_hypers)
+            default_hypers = get_default_hypers("experimental.mace")["model"]
+            raise_if_hypers_mismatch(
+                self.hypers, model_hypers, default_hypers=default_hypers
+            )
 
         # Check that the new dataset info does not contain new atomic types
         if new_atomic_types := set(dataset_info.atomic_types) - set(

--- a/src/metatrain/experimental/space/model.py
+++ b/src/metatrain/experimental/space/model.py
@@ -37,6 +37,7 @@ from metatrain.utils.data.atomic_basis_helpers import (
 )
 from metatrain.utils.data.dataset import DatasetInfo, TargetInfo
 from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.metadata import merge_metadata
 
 from . import checkpoints
@@ -168,7 +169,13 @@ class SPACE(ModelInterface[ModelHypers]):
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.outputs
 
-    def restart(self, dataset_info: DatasetInfo) -> "SPACE":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "SPACE":
+
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)
         new_atomic_types = [

--- a/src/metatrain/experimental/space/model.py
+++ b/src/metatrain/experimental/space/model.py
@@ -174,7 +174,10 @@ class SPACE(ModelInterface[ModelHypers]):
     ) -> "SPACE":
 
         if model_hypers is not None:
-            raise_if_hypers_mismatch(self.hypers, model_hypers)
+            default_hypers = get_default_hypers("experimental.space")["model"]
+            raise_if_hypers_mismatch(
+                self.hypers, model_hypers, default_hypers=default_hypers
+            )
 
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)

--- a/src/metatrain/experimental/space/model.py
+++ b/src/metatrain/experimental/space/model.py
@@ -35,6 +35,7 @@ from metatrain.utils.data.atomic_basis_helpers import (
 )
 from metatrain.utils.data.dataset import DatasetInfo, TargetInfo
 from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.metadata import merge_metadata
 from metatrain.utils.scaler import Scaler
 
@@ -166,7 +167,13 @@ class SPACE(ModelInterface[ModelHypers]):
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.outputs
 
-    def restart(self, dataset_info: DatasetInfo) -> "SPACE":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "SPACE":
+
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)
         new_atomic_types = [

--- a/src/metatrain/experimental/space/tests/test_basic.py
+++ b/src/metatrain/experimental/space/tests/test_basic.py
@@ -11,6 +11,7 @@ from metatrain.utils.neighbor_lists import get_system_with_neighbor_lists
 from metatrain.utils.testing import (
     ArchitectureTests,
     CheckpointTests,
+    InputTests,
     OutputTests,
     TorchscriptTests,
 )
@@ -29,6 +30,9 @@ class SPACETests(ArchitectureTests):
         hypers = copy.deepcopy(hypers)
         hypers["num_element_channels"] = 4
         return hypers
+
+
+class TestInput(InputTests, SPACETests): ...
 
 
 class TestOutput(OutputTests, SPACETests):

--- a/src/metatrain/gap/model.py
+++ b/src/metatrain/gap/model.py
@@ -169,7 +169,9 @@ class GAP(ModelInterface[ModelHypers]):
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.outputs
 
-    def restart(self, dataset_info: DatasetInfo) -> "GAP":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "GAP":
         raise NotImplementedError("GAP does not allow restarting training")
 
     @classmethod

--- a/src/metatrain/gap/model.py
+++ b/src/metatrain/gap/model.py
@@ -168,7 +168,9 @@ class GAP(ModelInterface[ModelHypers]):
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.outputs
 
-    def restart(self, dataset_info: DatasetInfo) -> "GAP":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "GAP":
         raise NotImplementedError("GAP does not allow restarting training")
 
     @classmethod

--- a/src/metatrain/llpr/model.py
+++ b/src/metatrain/llpr/model.py
@@ -26,6 +26,7 @@ from metatrain.utils.data.atom_pair_helpers import check_no_atom_pair_targets
 from metatrain.utils.data.target_info import (
     is_auxiliary_output,
 )
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.io import model_from_checkpoint
 from metatrain.utils.metadata import merge_metadata
 from metatrain.utils.neighbor_lists import (
@@ -250,7 +251,13 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
                 bias=False,
             )
 
-    def restart(self, dataset_info: DatasetInfo) -> "LLPRUncertaintyModel":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "LLPRUncertaintyModel":
+
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)
         new_atomic_types = [

--- a/src/metatrain/llpr/model.py
+++ b/src/metatrain/llpr/model.py
@@ -26,6 +26,7 @@ from metatrain.utils.data.atom_pair_helpers import check_no_atom_pair_targets
 from metatrain.utils.data.target_info import (
     is_auxiliary_output,
 )
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.io import model_from_checkpoint
 from metatrain.utils.metadata import merge_metadata
 from metatrain.utils.neighbor_lists import (
@@ -246,7 +247,13 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
                 bias=False,
             )
 
-    def restart(self, dataset_info: DatasetInfo) -> "LLPRUncertaintyModel":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "LLPRUncertaintyModel":
+
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)
         new_atomic_types = [

--- a/src/metatrain/llpr/tests/test_basic.py
+++ b/src/metatrain/llpr/tests/test_basic.py
@@ -8,13 +8,22 @@ from omegaconf import OmegaConf
 from metatrain.pet import PET
 from metatrain.pet import Trainer as PETTrainer
 from metatrain.utils.architectures import get_default_hypers
+from metatrain.utils.data import DatasetInfo
 from metatrain.utils.hypers import init_with_defaults
 from metatrain.utils.loss import LossSpecification
 from metatrain.utils.testing import ArchitectureTests, CheckpointTests
+from metatrain.utils.testing.input import InputTests
 
 
 class LLPRTests(ArchitectureTests):
     architecture = "llpr"
+
+
+class TestInput(InputTests, LLPRTests):
+    def test_restart(
+        self, minimal_model_hypers: dict, dataset_info: DatasetInfo
+    ) -> None:
+        pytest.skip("LLPR's restart does not work without a model checkpoint.")
 
 
 class TestCheckpoints(CheckpointTests, LLPRTests):

--- a/src/metatrain/pet/model.py
+++ b/src/metatrain/pet/model.py
@@ -31,6 +31,7 @@ from metatrain.utils.data.atomic_basis_helpers import (
     sparsify_atomic_basis_target,
 )
 from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.long_range import DummyLongRangeFeaturizer, LongRangeFeaturizer
 from metatrain.utils.metadata import merge_metadata
 from metatrain.utils.sum_over_atoms import sum_over_atoms
@@ -204,7 +205,13 @@ class PET(ModelInterface[ModelHypers]):
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.outputs
 
-    def restart(self, dataset_info: DatasetInfo) -> "PET":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "PET":
+
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)
         new_atomic_types = [

--- a/src/metatrain/pet/model.py
+++ b/src/metatrain/pet/model.py
@@ -204,7 +204,7 @@ class PET(ModelInterface[ModelHypers]):
         return self.outputs
 
     def restart(
-        self, dataset_info: DatasetInfo, model_hypers: Optional[dict] = None
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
     ) -> "PET":
 
         if model_hypers is not None:

--- a/src/metatrain/pet/model.py
+++ b/src/metatrain/pet/model.py
@@ -29,6 +29,7 @@ from metatrain.utils.data.atomic_basis_helpers import (
     sparsify_atomic_basis_target,
 )
 from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.long_range import DummyLongRangeFeaturizer, LongRangeFeaturizer
 from metatrain.utils.metadata import merge_metadata
 from metatrain.utils.scaler import Scaler
@@ -202,7 +203,13 @@ class PET(ModelInterface[ModelHypers]):
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.outputs
 
-    def restart(self, dataset_info: DatasetInfo) -> "PET":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict] = None
+    ) -> "PET":
+
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)
         new_atomic_types = [

--- a/src/metatrain/pet/model.py
+++ b/src/metatrain/pet/model.py
@@ -210,7 +210,10 @@ class PET(ModelInterface[ModelHypers]):
     ) -> "PET":
 
         if model_hypers is not None:
-            raise_if_hypers_mismatch(self.hypers, model_hypers)
+            default_hypers = get_default_hypers("pet")["model"]
+            raise_if_hypers_mismatch(
+                self.hypers, model_hypers, default_hypers=default_hypers
+            )
 
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)

--- a/src/metatrain/scaler/model.py
+++ b/src/metatrain/scaler/model.py
@@ -1,7 +1,7 @@
 import itertools
 import logging
 import warnings
-from typing import Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import metatensor.torch as mts
 import torch
@@ -22,6 +22,7 @@ from metatrain.utils.data.atomic_basis_helpers import (
     sparsify_atomic_basis_target,
 )
 from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.metadata import merge_metadata
 
 from . import checkpoints
@@ -108,13 +109,20 @@ class Scaler(ModelInterface[ModelHypers]):
             is_distributed=is_distributed,
         )
 
-    def restart(self, dataset_info: DatasetInfo) -> "Scaler":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "Scaler":
         """
         Restart the model with a new dataset info.
 
         :param dataset_info: New dataset information to be used.
+        :param model_hypers: New hyperparameters for the model. They must match
+            the existing hyperparameters, otherwise an error is raised.
         :return: The restarted Scaler.
         """
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
 
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)

--- a/src/metatrain/scaler/model.py
+++ b/src/metatrain/scaler/model.py
@@ -16,6 +16,7 @@ from metatomic.torch import (
 )
 
 from metatrain.utils.abc import ModelInterface
+from metatrain.utils.architectures import get_default_hypers
 from metatrain.utils.data import Dataset, DatasetInfo, TargetInfo
 from metatrain.utils.data.atomic_basis_helpers import (
     densify_atomic_basis_dataset_info,
@@ -121,8 +122,10 @@ class Scaler(ModelInterface[ModelHypers]):
         :return: The restarted Scaler.
         """
         if model_hypers is not None:
-            raise_if_hypers_mismatch(self.hypers, model_hypers)
-
+            default_hypers = get_default_hypers("scaler")["model"]
+            raise_if_hypers_mismatch(
+                self.hypers, model_hypers, default_hypers=default_hypers
+            )
 
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)

--- a/src/metatrain/soap_bpnn/model.py
+++ b/src/metatrain/soap_bpnn/model.py
@@ -27,6 +27,7 @@ from metatrain.utils.data.atomic_basis_helpers import (
 )
 from metatrain.utils.data.dataset import DatasetInfo
 from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.long_range import DummyLongRangeFeaturizer, LongRangeFeaturizer
 from metatrain.utils.metadata import merge_metadata
 from metatrain.utils.scaler import Scaler
@@ -423,7 +424,13 @@ class SoapBpnn(ModelInterface[ModelHypers]):
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.outputs
 
-    def restart(self, dataset_info: DatasetInfo) -> "SoapBpnn":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "SoapBpnn":
+
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)
         new_atomic_types = [

--- a/src/metatrain/soap_bpnn/model.py
+++ b/src/metatrain/soap_bpnn/model.py
@@ -29,6 +29,7 @@ from metatrain.utils.data.atomic_basis_helpers import (
 )
 from metatrain.utils.data.dataset import DatasetInfo
 from metatrain.utils.dtype import dtype_to_str
+from metatrain.utils.hypers import raise_if_hypers_mismatch
 from metatrain.utils.long_range import DummyLongRangeFeaturizer, LongRangeFeaturizer
 from metatrain.utils.metadata import merge_metadata
 from metatrain.utils.sum_over_atoms import sum_over_atoms
@@ -425,7 +426,13 @@ class SoapBpnn(ModelInterface[ModelHypers]):
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.outputs
 
-    def restart(self, dataset_info: DatasetInfo) -> "SoapBpnn":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "SoapBpnn":
+
+        if model_hypers is not None:
+            raise_if_hypers_mismatch(self.hypers, model_hypers)
+
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)
         new_atomic_types = [

--- a/src/metatrain/soap_bpnn/model.py
+++ b/src/metatrain/soap_bpnn/model.py
@@ -431,7 +431,10 @@ class SoapBpnn(ModelInterface[ModelHypers]):
     ) -> "SoapBpnn":
 
         if model_hypers is not None:
-            raise_if_hypers_mismatch(self.hypers, model_hypers)
+            default_hypers = get_default_hypers("soap_bpnn")["model"]
+            raise_if_hypers_mismatch(
+                self.hypers, model_hypers, default_hypers=default_hypers
+            )
 
         # merge old and new dataset info
         merged_info = self.dataset_info.union(dataset_info)

--- a/src/metatrain/utils/abc.py
+++ b/src/metatrain/utils/abc.py
@@ -135,7 +135,9 @@ class ModelInterface(torch.nn.Module, Generic[HypersType], metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def restart(self, dataset_info: DatasetInfo) -> "ModelInterface":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict] = None
+    ) -> "ModelInterface":
         """
         Update a model to restart training, potentially with different dataset and/or
         targets.
@@ -146,6 +148,8 @@ class ModelInterface(torch.nn.Module, Generic[HypersType], metaclass=ABCMeta):
 
         :param dataset_info: Information about the new dataset, including the targets
             that will be used for training.
+
+        :param model_hypers: The new hyperparameters for the model.
 
         :return: The updated model, or a new instance of the model, that is able to
             handle the new dataset.

--- a/src/metatrain/utils/abc.py
+++ b/src/metatrain/utils/abc.py
@@ -136,7 +136,7 @@ class ModelInterface(torch.nn.Module, Generic[HypersType], metaclass=ABCMeta):
 
     @abstractmethod
     def restart(
-        self, dataset_info: DatasetInfo, model_hypers: Optional[dict] = None
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
     ) -> "ModelInterface":
         """
         Update a model to restart training, potentially with different dataset and/or

--- a/src/metatrain/utils/abc.py
+++ b/src/metatrain/utils/abc.py
@@ -135,7 +135,9 @@ class ModelInterface(torch.nn.Module, Generic[HypersType], metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def restart(self, dataset_info: DatasetInfo) -> "ModelInterface":
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> "ModelInterface":
         """
         Update a model to restart training, potentially with different dataset and/or
         targets.
@@ -146,6 +148,8 @@ class ModelInterface(torch.nn.Module, Generic[HypersType], metaclass=ABCMeta):
 
         :param dataset_info: Information about the new dataset, including the targets
             that will be used for training.
+
+        :param model_hypers: The new hyperparameters for the model.
 
         :return: The updated model, or a new instance of the model, that is able to
             handle the new dataset.

--- a/src/metatrain/utils/hypers.py
+++ b/src/metatrain/utils/hypers.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import Any, Type, TypedDict, TypeVar
 
 from typing_extensions import TypedDict as TE_TypedDict
@@ -100,8 +101,8 @@ def overwrite_defaults(
 
 
 def get_hypers_diff(
-    old_hypers: dict,
-    new_hypers: dict,
+    old_hypers: Mapping[str, Any],
+    new_hypers: Mapping[str, Any],
 ) -> dict[str, tuple[Any, Any]]:
     """Get the difference between two hypers dictionaries.
 
@@ -121,16 +122,20 @@ def get_hypers_diff(
 
 
 def raise_hypers_mismatch(
-    hypers_diff: dict[str, tuple[Any, Any]],
+    hypers_diff: Mapping[str, tuple[Any, Any]],
 ) -> None:
     """Raise an error if the hypers diff is not empty.
-    
-    The hypers diff can be computed using :func:`get_hypers_diff`.
+
+    The error shows a report of the mismatched hyperparameters.
+
+    :param hypers_diff: A dict with the hyperparameters that are different.
+        It can be computed using :func:`get_hypers_diff`.
     """
     if hypers_diff:
         n_mismatches = len(hypers_diff)
         raise ValueError(
-            f"Found {n_mismatches} mismatch{(n_mismatches != 1) * 'es'} in model hyperparameters.\n"
+            f"Found {n_mismatches} mismatch{(n_mismatches != 1) * 'es'} "
+            "in model hyperparameters.\n"
             f"Mismatched hypers: {list(hypers_diff.keys())}\n"
             "\n-------- Mismatches --------\n\n"
             + "\n".join(
@@ -141,8 +146,8 @@ def raise_hypers_mismatch(
 
 
 def raise_if_hypers_mismatch(
-    old_hypers: dict,
-    new_hypers: dict,
+    old_hypers: Mapping[str, Any],
+    new_hypers: Mapping[str, Any],
 ) -> None:
     """Raise an error if the new hypers do not match the old hypers.
 

--- a/src/metatrain/utils/hypers.py
+++ b/src/metatrain/utils/hypers.py
@@ -1,4 +1,5 @@
-from typing import Type, TypedDict, TypeVar
+from collections.abc import Mapping
+from typing import Any, Type, TypedDict, TypeVar
 
 from typing_extensions import TypedDict as TE_TypedDict
 
@@ -97,3 +98,64 @@ def overwrite_defaults(
     :param new_defaults: A dict with the new default hyperparameters.
     """
     _OVERWRITTEN_DEFAULTS[hypers_cls] = new_defaults
+
+
+def get_hypers_diff(
+    old_hypers: Mapping[str, Any],
+    new_hypers: Mapping[str, Any],
+) -> dict[str, tuple[Any, Any]]:
+    """Get the difference between two hypers dictionaries.
+
+    :param old_hypers: The old hyperparameters.
+    :param new_hypers: The new hyperparameters.
+
+    :return: A dict with the hyperparameters that are different in the new
+        hypers compared to the old hypers. It is assumed that every key in
+        the new hypers is also present in the old hypers.
+    """
+    diff = {}
+    for key, new_value in new_hypers.items():
+        old_value = old_hypers[key]
+        if old_value != new_value:
+            diff[key] = (old_value, new_value)
+    return diff
+
+
+def raise_hypers_mismatch(
+    hypers_diff: Mapping[str, tuple[Any, Any]],
+) -> None:
+    """Raise an error if the hypers diff is not empty.
+
+    The error shows a report of the mismatched hyperparameters.
+
+    :param hypers_diff: A dict with the hyperparameters that are different.
+        It can be computed using :func:`get_hypers_diff`.
+    """
+    if hypers_diff:
+        n_mismatches = len(hypers_diff)
+        raise ValueError(
+            f"Found {n_mismatches} mismatch{(n_mismatches != 1) * 'es'} "
+            "in model hyperparameters.\n"
+            f"Mismatched hypers: {list(hypers_diff.keys())}\n"
+            "\n-------- Mismatches --------\n\n"
+            + "\n".join(
+                f"[Mismatch {i + 1}] {key}\n Previous: {old}\n New: {new}"
+                for i, (key, (old, new)) in enumerate(hypers_diff.items())
+            )
+        )
+
+
+def raise_if_hypers_mismatch(
+    old_hypers: Mapping[str, Any],
+    new_hypers: Mapping[str, Any],
+) -> None:
+    """Raise an error if the new hypers do not match the old hypers.
+
+    :param old_hypers: The old hyperparameters.
+    :param new_hypers: The new hyperparameters.
+    """
+    # Gather mismatchs
+    mismatches = get_hypers_diff(old_hypers, new_hypers)
+
+    if mismatches:
+        raise_hypers_mismatch(mismatches)

--- a/src/metatrain/utils/hypers.py
+++ b/src/metatrain/utils/hypers.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
-from typing import Any, Type, TypedDict, TypeVar
+from typing import Any, Optional, Type, TypedDict, TypeVar
 
+from omegaconf import OmegaConf
 from typing_extensions import TypedDict as TE_TypedDict
 
 
@@ -103,16 +104,28 @@ def overwrite_defaults(
 def get_hypers_diff(
     old_hypers: Mapping[str, Any],
     new_hypers: Mapping[str, Any],
+    default_hypers: Optional[Mapping[str, Any]] = None,
 ) -> dict[str, tuple[Any, Any]]:
     """Get the difference between two hypers dictionaries.
 
     :param old_hypers: The old hyperparameters.
     :param new_hypers: The new hyperparameters.
+    :param default_hypers: Default hyperparameters. If provided, they will be used
+        to fill the missing keys in values of the new hypers that are dicts.
 
     :return: A dict with the hyperparameters that are different in the new
         hypers compared to the old hypers. It is assumed that every key in
         the new hypers is also present in the old hypers.
     """
+
+    if default_hypers is not None:
+        hypers_keys = list(new_hypers.keys())
+        merged = OmegaConf.merge(
+            OmegaConf.create(default_hypers), OmegaConf.create(new_hypers)
+        )
+        merged = OmegaConf.to_container(merged)
+        new_hypers = {k: merged[k] for k in hypers_keys}
+
     diff = {}
     for key, new_value in new_hypers.items():
         old_value = old_hypers[key]
@@ -148,14 +161,17 @@ def raise_hypers_mismatch(
 def raise_if_hypers_mismatch(
     old_hypers: Mapping[str, Any],
     new_hypers: Mapping[str, Any],
+    default_hypers: Optional[Mapping[str, Any]] = None,
 ) -> None:
     """Raise an error if the new hypers do not match the old hypers.
 
     :param old_hypers: The old hyperparameters.
     :param new_hypers: The new hyperparameters.
+    :param default_hypers: Default hyperparameters. If provided, they will be used
+        to fill the missing keys in values of the new hypers that are dicts.
     """
     # Gather mismatchs
-    mismatches = get_hypers_diff(old_hypers, new_hypers)
+    mismatches = get_hypers_diff(old_hypers, new_hypers, default_hypers=default_hypers)
 
     if mismatches:
         raise_hypers_mismatch(mismatches)

--- a/src/metatrain/utils/hypers.py
+++ b/src/metatrain/utils/hypers.py
@@ -1,4 +1,4 @@
-from typing import Type, TypedDict, TypeVar
+from typing import Any, Type, TypedDict, TypeVar
 
 from typing_extensions import TypedDict as TE_TypedDict
 
@@ -97,3 +97,60 @@ def overwrite_defaults(
     :param new_defaults: A dict with the new default hyperparameters.
     """
     _OVERWRITTEN_DEFAULTS[hypers_cls] = new_defaults
+
+
+def get_hypers_diff(
+    old_hypers: dict,
+    new_hypers: dict,
+) -> dict[str, tuple[Any, Any]]:
+    """Get the difference between two hypers dictionaries.
+
+    :param old_hypers: The old hyperparameters.
+    :param new_hypers: The new hyperparameters.
+
+    :return: A dict with the hyperparameters that are different in the new
+        hypers compared to the old hypers. It is assumed that every key in
+        the new hypers is also present in the old hypers.
+    """
+    diff = {}
+    for key, new_value in new_hypers.items():
+        old_value = old_hypers[key]
+        if old_value != new_value:
+            diff[key] = (old_value, new_value)
+    return diff
+
+
+def raise_hypers_mismatch(
+    hypers_diff: dict[str, tuple[Any, Any]],
+) -> None:
+    """Raise an error if the hypers diff is not empty.
+    
+    The hypers diff can be computed using :func:`get_hypers_diff`.
+    """
+    if hypers_diff:
+        n_mismatches = len(hypers_diff)
+        raise ValueError(
+            f"Found {n_mismatches} mismatch{(n_mismatches != 1) * 'es'} in model hyperparameters.\n"
+            f"Mismatched hypers: {list(hypers_diff.keys())}\n"
+            "\n-------- Mismatches --------\n\n"
+            + "\n".join(
+                f"[Mismatch {i + 1}] {key}\n Previous: {old}\n New: {new}"
+                for i, (key, (old, new)) in enumerate(hypers_diff.items())
+            )
+        )
+
+
+def raise_if_hypers_mismatch(
+    old_hypers: dict,
+    new_hypers: dict,
+) -> None:
+    """Raise an error if the new hypers do not match the old hypers.
+
+    :param old_hypers: The old hyperparameters.
+    :param new_hypers: The new hyperparameters.
+    """
+    # Gather mismatchs
+    mismatches = get_hypers_diff(old_hypers, new_hypers)
+
+    if mismatches:
+        raise_hypers_mismatch(mismatches)

--- a/src/metatrain/utils/testing/input.py
+++ b/src/metatrain/utils/testing/input.py
@@ -182,8 +182,8 @@ class InputTests(ArchitectureTests):
         """
         if not self.supports_restart:
             pytest.skip("The architecture does not support restart")
-        if len(default_hypers) == 0:
-            pytest.skip("The architecture does not have any hyperparameters")
+        if len(default_hypers["model"]) == 0:
+            pytest.skip("The model does not have any hyperparameters")
 
         model = self.model_cls(minimal_model_hypers, dataset_info)
 

--- a/src/metatrain/utils/testing/input.py
+++ b/src/metatrain/utils/testing/input.py
@@ -252,20 +252,20 @@ class InputTests(ArchitectureTests):
             pytest.skip("The model does not have any hyperparameters")
 
         # Find the key of a hyper that contains a dictionary, preferably
-        # with a number in it so that we can modify it.
+        # with a number or bool in it so that we can modify it.
         dict_key = None
-        number_key = None
+        modify_key = None
         for k, v in default_hypers["model"].items():
             if isinstance(v, dict) and len(v) > 0:
                 dict_key = k
                 if any(
-                    isinstance(vv, (int, float)) and not isinstance(vv, bool)
+                    isinstance(vv, (int, float))
                     for vv in v.values()
                 ):
-                    number_key = next(
+                    modify_key = next(
                         k
                         for k, v in v.items()
-                        if isinstance(v, (int, float)) and not isinstance(v, bool)
+                        if isinstance(v, (int, float))
                     )
                     break
         if dict_key is None:
@@ -278,18 +278,22 @@ class InputTests(ArchitectureTests):
         nested_hypers["model"][dict_key].popitem()
         model.restart(dataset_info=dataset_info, model_hypers=nested_hypers["model"])
 
-        if number_key is None:
+        if modify_key is None:
             pytest.skip("Couldn't find a hyper to change automatically")
 
         # Initialize a new model with a nested key not being the default,
         # then check that restarting with that key missing raises an error.
         new_hypers = copy.deepcopy(default_hypers)
-        num_type = type(new_hypers["model"][dict_key][number_key])
-        new_hypers["model"][dict_key][number_key] += num_type(1.0)
+        old_val = new_hypers["model"][dict_key][modify_key]
+        if isinstance(old_val, bool):
+            new_val = not old_val
+        else:
+            new_val = type(old_val)(old_val + 1.0)
+        new_hypers["model"][dict_key][modify_key] = new_val
 
         new_model = self.model_cls(new_hypers["model"], dataset_info)
         restart_hypers = copy.deepcopy(new_hypers)
-        restart_hypers["model"][dict_key].pop(number_key)
+        restart_hypers["model"][dict_key].pop(modify_key)
         with pytest.raises(ValueError):
             new_model.restart(
                 dataset_info=dataset_info, model_hypers=restart_hypers["model"]

--- a/src/metatrain/utils/testing/input.py
+++ b/src/metatrain/utils/testing/input.py
@@ -190,8 +190,10 @@ class InputTests(ArchitectureTests):
         # Find an input that is a number or string and change it.
         new_hypers: dict[str, Any] = {}
         for k, v in minimal_model_hypers.items():
-            if isinstance(v, (int, float)):
-                new_hypers[k] = v + 1.0
+            if isinstance(v, bool):
+                new_hypers[k] = not v
+            elif isinstance(v, (int, float)):
+                new_hypers[k] = type(v)(v + 1.0)
                 break
             elif isinstance(v, str):
                 new_hypers[k] = "new_value"
@@ -203,3 +205,92 @@ class InputTests(ArchitectureTests):
         # This shouldn't work, as the hypers have been changed
         with pytest.raises(ValueError):
             model.restart(dataset_info=dataset_info, model_hypers=new_hypers)
+
+    def test_restart_nested_hypers(
+        self, default_hypers: dict, dataset_info: DatasetInfo
+    ) -> None:
+        """Test that the model handles correctly differences in nested
+        hyperparameters when restarting.
+
+        The correct behavior should be: if the nested hyperparameter is missing
+        in the new hypers, this is only valid if the nested hyperparameter is
+        the default in the model's hypers. Otherwise, it should raise an error.
+
+        This test is skipped if the architecture does not support restarting
+        (which should be indicated by setting ``supports_restart = False``)
+        or if the architecture does not have any hyperparameters.
+
+        If this test is failing and both ``test_restart`` and
+        ``test_restart_hypers_mismatch`` are failing, you probably need to make
+        sure that the default hyperparameters are passed to the function that
+        computes the difference between the hypers in the ``restart`` method.
+
+        .. code-block:: python
+
+            from metatrain.utils.architectures import get_default_hypers
+            from metatrain.utils.hypers import raise_if_hypers_mismatch
+
+
+            def restart(
+                self,
+                dataset_info: DatasetInfo,
+                model_hypers: Optional[dict[str, Any]] = None,
+            ):
+                if model_hypers is not None:
+                    default_hypers = get_default_hypers("soap_bpnn")["model"]
+                    raise_if_hypers_mismatch(
+                        self.hypers, model_hypers, default_hypers=default_hypers
+                    )
+                # Rest of the restart logic...
+
+        :param default_hypers: The default hyperparameters for the architecture.
+        :param dataset_info: The dataset information used to initialize the model.
+        """
+        if not self.supports_restart:
+            pytest.skip("The architecture does not support restart")
+        if len(default_hypers["model"]) == 0:
+            pytest.skip("The model does not have any hyperparameters")
+
+        # Find the key of a hyper that contains a dictionary, preferably
+        # with a number in it so that we can modify it.
+        dict_key = None
+        number_key = None
+        for k, v in default_hypers["model"].items():
+            if isinstance(v, dict) and len(v) > 0:
+                dict_key = k
+                if any(
+                    isinstance(vv, (int, float)) and not isinstance(vv, bool)
+                    for vv in v.values()
+                ):
+                    number_key = next(
+                        k
+                        for k, v in v.items()
+                        if isinstance(v, (int, float)) and not isinstance(v, bool)
+                    )
+                    break
+        if dict_key is None:
+            pytest.skip("The model does not have any nested hyperparameters")
+
+        model = self.model_cls(default_hypers["model"], dataset_info)
+
+        # Pop a key from the nested dictionary and try to restart, it should work.
+        nested_hypers = copy.deepcopy(default_hypers)
+        nested_hypers["model"][dict_key].popitem()
+        model.restart(dataset_info=dataset_info, model_hypers=nested_hypers["model"])
+
+        if number_key is None:
+            pytest.skip("Couldn't find a hyper to change automatically")
+
+        # Initialize a new model with a nested key not being the default,
+        # then check that restarting with that key missing raises an error.
+        new_hypers = copy.deepcopy(default_hypers)
+        num_type = type(new_hypers["model"][dict_key][number_key])
+        new_hypers["model"][dict_key][number_key] += num_type(1.0)
+
+        new_model = self.model_cls(new_hypers["model"], dataset_info)
+        restart_hypers = copy.deepcopy(new_hypers)
+        restart_hypers["model"][dict_key].pop(number_key)
+        with pytest.raises(ValueError):
+            new_model.restart(
+                dataset_info=dataset_info, model_hypers=restart_hypers["model"]
+            )

--- a/src/metatrain/utils/testing/input.py
+++ b/src/metatrain/utils/testing/input.py
@@ -259,10 +259,15 @@ class InputTests(ArchitectureTests):
         for k, v in default_hypers["model"].items():
             if isinstance(v, dict) and len(v) > 0:
                 dict_key = k
-                if any(isinstance(vv, (int, float)) for vv in v.values()):
-                    modify_key = next(
-                        k for k, v in v.items() if isinstance(v, (int, float))
-                    )
+                for kk, vv in v.items():
+                    if (
+                        kk != "precision"
+                        and isinstance(vv, (int, float))
+                        and not isinstance(vv, bool)
+                    ):
+                        modify_key = kk
+                        break
+                if modify_key is not None:
                     break
         if dict_key is None:
             pytest.skip("The model does not have any nested hyperparameters")
@@ -281,10 +286,7 @@ class InputTests(ArchitectureTests):
         # then check that restarting with that key missing raises an error.
         new_hypers = copy.deepcopy(default_hypers)
         old_val = new_hypers["model"][dict_key][modify_key]
-        if isinstance(old_val, bool):
-            new_val = not old_val
-        else:
-            new_val = type(old_val)(old_val + 1.0)
+        new_val = type(old_val)(old_val + 1.0)
         new_hypers["model"][dict_key][modify_key] = new_val
 
         with warnings.catch_warnings():

--- a/src/metatrain/utils/testing/input.py
+++ b/src/metatrain/utils/testing/input.py
@@ -1,9 +1,11 @@
 import copy
+from typing import Any
 
 import pytest
 from omegaconf import OmegaConf
 
 from metatrain.utils.architectures import check_architecture_options
+from metatrain.utils.data import DatasetInfo
 from metatrain.utils.pydantic import MetatrainValidationError
 
 from .architectures import ArchitectureTests
@@ -11,6 +13,9 @@ from .architectures import ArchitectureTests
 
 class InputTests(ArchitectureTests):
     """Test suite to check that the model handles inputs correctly."""
+
+    supports_restart: bool = True
+    """Whether the architecture supports restarting training."""
 
     def test_atomic_baseline(self, default_hypers: dict) -> None:
         """Test that the trainer can accept atomic baselines.
@@ -104,3 +109,97 @@ class InputTests(ArchitectureTests):
             check_architecture_options(
                 name=self.architecture, options=OmegaConf.to_container(hypers)
             )
+
+    def test_restart(
+        self, minimal_model_hypers: dict, dataset_info: DatasetInfo
+    ) -> None:
+        """Test that the model can be restarted with the same hyperparameters
+        and same dataset information.
+
+        If the model doesn't support restarting (which should be indicated by
+        setting ``supports_restart = False``), a call to ``model.restart()``
+        is supposed to raise a ``NotImplementedError``.
+
+        If your model supports restarting, but this test is failing, you need
+        to make sure that the model's ``restart`` method is implemented
+        correctly. Essentially, a call to ``model.restart()`` with the same
+        dataset information and same model hyperparameters should
+        keep the model unchanged.
+
+        :param minimal_model_hypers: The hyperparameters used to initialize the
+            model.
+        :param dataset_info: The dataset information used to initialize the model.
+        """
+
+        model = self.model_cls(minimal_model_hypers, dataset_info)
+
+        if not self.supports_restart:
+            with pytest.raises(NotImplementedError):
+                model.restart(dataset_info=dataset_info)
+            return
+
+        # This should work, as we are not changing the hypers
+        model.restart(dataset_info=dataset_info)
+        model.restart(dataset_info=dataset_info, model_hypers={})
+        model.restart(dataset_info=dataset_info, model_hypers=minimal_model_hypers)
+
+    def test_restart_hypers_mismatch(
+        self,
+        default_hypers: dict,
+        minimal_model_hypers: dict,
+        dataset_info: DatasetInfo,
+    ) -> None:
+        """Test that the model throws an error when there is an attempt to
+        restart training with different model hyperparameters.
+
+        This test is skipped if the architecture does not support restarting
+        (which should be indicated by setting ``supports_restart = False``)
+        or if the architecture does not have any hyperparameters.
+
+        If this test is failing, you need to make sure that the model's
+        ``restart`` method checks that the provided hyperparameters
+        match the ones used to initialize the model. An easy way to do this
+        is by doing the following in your model's ``restart`` method:
+
+        .. code-block:: python
+
+            from metatrain.utils.hypers import raise_if_hypers_mismatch
+
+
+            def restart(
+                self,
+                dataset_info: DatasetInfo,
+                model_hypers: Optional[dict[str, Any]] = None,
+            ):
+                if model_hypers is not None:
+                    raise_if_hypers_mismatch(self.hypers, model_hypers)
+                # Rest of the restart logic...
+
+        :param default_hypers: The default hyperparameters for the architecture.
+        :param minimal_model_hypers: The hyperparameters used to initialize the
+            model.
+        :param dataset_info: The dataset information used to initialize the model.
+        """
+        if not self.supports_restart:
+            pytest.skip("The architecture does not support restart")
+        if len(default_hypers) == 0:
+            pytest.skip("The architecture does not have any hyperparameters")
+
+        model = self.model_cls(minimal_model_hypers, dataset_info)
+
+        # Find an input that is a number or string and change it.
+        new_hypers: dict[str, Any] = {}
+        for k, v in minimal_model_hypers.items():
+            if isinstance(v, (int, float)):
+                new_hypers[k] = v + 1.0
+                break
+            elif isinstance(v, str):
+                new_hypers[k] = "new_value"
+                break
+        else:
+            # No numbers or strings found, just change any value to a string
+            new_hypers[list(minimal_model_hypers.keys())[0]] = "new_value"
+
+        # This shouldn't work, as the hypers have been changed
+        with pytest.raises(ValueError):
+            model.restart(dataset_info=dataset_info, model_hypers=new_hypers)

--- a/src/metatrain/utils/testing/input.py
+++ b/src/metatrain/utils/testing/input.py
@@ -253,7 +253,7 @@ class InputTests(ArchitectureTests):
             pytest.skip("The model does not have any hyperparameters")
 
         # Find the key of a hyper that contains a dictionary, preferably
-        # with a number or bool in it so that we can modify it.
+        # with a number in it so that we can modify it.
         dict_key = None
         modify_key = None
         for k, v in default_hypers["model"].items():

--- a/src/metatrain/utils/testing/input.py
+++ b/src/metatrain/utils/testing/input.py
@@ -1,9 +1,11 @@
 import copy
+from typing import Any
 
 import pytest
 from omegaconf import OmegaConf
 
 from metatrain.utils.architectures import check_architecture_options
+from metatrain.utils.data import DatasetInfo
 from metatrain.utils.pydantic import MetatrainValidationError
 
 from .architectures import ArchitectureTests
@@ -11,6 +13,9 @@ from .architectures import ArchitectureTests
 
 class InputTests(ArchitectureTests):
     """Test suite to check that the model handles inputs correctly."""
+
+    supports_restart: bool = True
+    """Whether the architecture supports restarting training."""
 
     def test_atomic_baseline(self, default_hypers: dict) -> None:
         """Test that the trainer can accept atomic baselines.
@@ -104,3 +109,97 @@ class InputTests(ArchitectureTests):
             check_architecture_options(
                 name=self.architecture, options=OmegaConf.to_container(hypers)
             )
+
+    def test_restart(
+        self, minimal_model_hypers: dict, dataset_info: DatasetInfo
+    ) -> None:
+        """Test that the model can be restarted with the same hyperparameters
+        and same dataset information.
+
+        If the model doesn't support restarting (which should be indicated by
+        setting ``supports_restart = False``), a call to ``model.restart()``
+        is supposed to raise a ``NotImplementedError``.
+
+        If your model supports restarting, but this test is failing, you need
+        to make sure that the model's ``restart`` method is implemented
+        correctly. Essentially, a call to ``model.restart()`` with the same
+        dataset information and same model hyperparameters should
+        keep the model unchanged.
+
+        :param minimal_model_hypers: The hyperparameters used to initialize the
+            model.
+        :param dataset_info: The dataset information used to initialize the model.
+        """
+
+        model = self.model_cls(minimal_model_hypers, dataset_info)
+
+        if not self.supports_restart:
+            with pytest.raises(NotImplementedError):
+                model.restart(dataset_info=dataset_info)
+            return
+
+        # This should work, as we are not changing the hypers
+        model.restart(dataset_info=dataset_info)
+        model.restart(dataset_info=dataset_info, model_hypers={})
+        model.restart(dataset_info=dataset_info, model_hypers=minimal_model_hypers)
+
+    def test_restart_hypers_mismatch(
+        self,
+        default_hypers: dict,
+        minimal_model_hypers: dict,
+        dataset_info: DatasetInfo,
+    ) -> None:
+        """Test that the model throws an error when there is an attempt to
+        restart training with different model hyperparameters.
+
+        This test is skipped if the architecture does not support restarting
+        (which should be indicated by setting ``supports_restart = False``)
+        or if the architecture does not have any hyperparameters.
+
+        If this test is failing, you need to make sure that the model's
+        ``restart`` method checks that the provided hyperparameters
+        match the ones used to initialize the model. An easy way to do this
+        is by doing the following in your model's ``restart`` method:
+
+        .. code-block:: python
+
+            from metatrain.utils.hypers import raise_if_hypers_mismatch
+
+
+            def restart(
+                self,
+                dataset_info: DatasetInfo,
+                model_hypers: Optional[dict[str, Any]] = None,
+            ):
+                if model_hypers is not None:
+                    raise_if_hypers_mismatch(self.hypers, model_hypers)
+                # Rest of the restart logic...
+
+        :param default_hypers: The default hyperparameters for the architecture.
+        :param minimal_model_hypers: The hyperparameters used to initialize the
+            model.
+        :param dataset_info: The dataset information used to initialize the model.
+        """
+        if not self.supports_restart:
+            pytest.skip("The architecture does not support restart")
+        if len(default_hypers["model"]) == 0:
+            pytest.skip("The model does not have any hyperparameters")
+
+        model = self.model_cls(minimal_model_hypers, dataset_info)
+
+        # Find an input that is a number or string and change it.
+        new_hypers: dict[str, Any] = {}
+        for k, v in minimal_model_hypers.items():
+            if isinstance(v, (int, float)):
+                new_hypers[k] = v + 1.0
+                break
+            elif isinstance(v, str):
+                new_hypers[k] = "new_value"
+                break
+        else:
+            # No numbers or strings found, just change any value to a string
+            new_hypers[list(minimal_model_hypers.keys())[0]] = "new_value"
+
+        # This shouldn't work, as the hypers have been changed
+        with pytest.raises(ValueError):
+            model.restart(dataset_info=dataset_info, model_hypers=new_hypers)

--- a/src/metatrain/utils/testing/input.py
+++ b/src/metatrain/utils/testing/input.py
@@ -1,4 +1,5 @@
 import copy
+import warnings
 from typing import Any
 
 import pytest
@@ -258,14 +259,9 @@ class InputTests(ArchitectureTests):
         for k, v in default_hypers["model"].items():
             if isinstance(v, dict) and len(v) > 0:
                 dict_key = k
-                if any(
-                    isinstance(vv, (int, float))
-                    for vv in v.values()
-                ):
+                if any(isinstance(vv, (int, float)) for vv in v.values()):
                     modify_key = next(
-                        k
-                        for k, v in v.items()
-                        if isinstance(v, (int, float))
+                        k for k, v in v.items() if isinstance(v, (int, float))
                     )
                     break
         if dict_key is None:
@@ -294,7 +290,10 @@ class InputTests(ArchitectureTests):
         new_model = self.model_cls(new_hypers["model"], dataset_info)
         restart_hypers = copy.deepcopy(new_hypers)
         restart_hypers["model"][dict_key].pop(modify_key)
-        with pytest.raises(ValueError):
-            new_model.restart(
-                dataset_info=dataset_info, model_hypers=restart_hypers["model"]
-            )
+        with warnings.catch_warnings():
+            # Ignore warnings, we might be asking for very strange hypers
+            warnings.filterwarnings("ignore", category=UserWarning)
+            with pytest.raises(ValueError):
+                new_model.restart(
+                    dataset_info=dataset_info, model_hypers=restart_hypers["model"]
+                )

--- a/src/metatrain/utils/testing/input.py
+++ b/src/metatrain/utils/testing/input.py
@@ -287,13 +287,14 @@ class InputTests(ArchitectureTests):
             new_val = type(old_val)(old_val + 1.0)
         new_hypers["model"][dict_key][modify_key] = new_val
 
-        new_model = self.model_cls(new_hypers["model"], dataset_info)
+        with warnings.catch_warnings():
+            # Ignore warnings, we might be asking for strange hypers
+            warnings.filterwarnings("ignore", category=UserWarning)
+            new_model = self.model_cls(new_hypers["model"], dataset_info)
+
         restart_hypers = copy.deepcopy(new_hypers)
         restart_hypers["model"][dict_key].pop(modify_key)
-        with warnings.catch_warnings():
-            # Ignore warnings, we might be asking for very strange hypers
-            warnings.filterwarnings("ignore", category=UserWarning)
-            with pytest.raises(ValueError):
-                new_model.restart(
-                    dataset_info=dataset_info, model_hypers=restart_hypers["model"]
-                )
+        with pytest.raises(ValueError):
+            new_model.restart(
+                dataset_info=dataset_info, model_hypers=restart_hypers["model"]
+            )

--- a/tests/utils/test_abc.py
+++ b/tests/utils/test_abc.py
@@ -71,7 +71,9 @@ class MyModel(ModelInterface):
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         raise NotImplementedError()
 
-    def restart(self, dataset_info: DatasetInfo) -> ModelInterface:
+    def restart(
+        self, dataset_info: DatasetInfo, model_hypers: Optional[dict[str, Any]] = None
+    ) -> ModelInterface:
         raise NotImplementedError()
 
     @classmethod


### PR DESCRIPTION
This is a first design of something that was discussed today in the devel meeting.

When restarting, it should be checked that if the user has provided model hypers in the input yaml, those match the hypers present in the checkpoint.

This enables the possibility that in the future, architectures will allow not only perfect matches, but also updating the model to some compatible hypers. This is for example the case in #1209 , which is what spawned the discussion leading to this PR.

@Luthaf @PicoCentauri could you check if something like this would work?

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1232.org.readthedocs.build/en/1232/

<!-- readthedocs-preview metatrain end -->