### PR TITLE
Fix segmentation fault at composition model initialization from a checkpoint on cuda

### DIFF
--- a/src/metatrain/composition/model.py
+++ b/src/metatrain/composition/model.py
@@ -480,9 +480,12 @@ class CompositionModel(ModelInterface[ModelHypers]):
         model, e.g. ``load_state_dict``.
         """
         for k in self.dataset_info.targets:
-            self.model.weights[k] = mts.load_buffer(
-                self.__getattr__(k + "_composition_buffer")
-            )
+            buffer = self.__getattr__(k + "_composition_buffer")
+            # ``mts.load_buffer`` dereferences the buffer on the host, so it
+            # segfaults on a GPU buffer: deserialize on the CPU and move the
+            # weights back to the buffer's device.
+            weights = mts.load_buffer(buffer.to(device="cpu"))
+            self.model.weights[k] = weights.to(device=buffer.device)
 
     def get_checkpoint(self) -> Dict:
         """


### PR DESCRIPTION
As in the title

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1233.org.readthedocs.build/en/1233/

<!-- readthedocs-preview metatrain end -->