### PR TITLE
Build augmentation system ids on the tensor's device

### DIFF
--- a/src/metatrain/utils/augmentation.py
+++ b/src/metatrain/utils/augmentation.py
@@ -158,7 +158,9 @@ def _tensor_system_ids(tensor: TensorMap, n_systems: int) -> Optional[torch.Tens
         # order-preserving dedup: the first-appearance order must match `systems`
         seen = dict.fromkeys(column.tolist())
         if len(seen) == n_systems:
-            return torch.tensor(list(seen.keys()), dtype=torch.int32)
+            return torch.tensor(
+                list(seen.keys()), dtype=torch.int32, device=column.device
+            )
     return None
 
 

--- a/tests/utils/test_augmentation.py
+++ b/tests/utils/test_augmentation.py
@@ -53,10 +53,10 @@ _HAMILTONIAN_IRREPS = {
 }
 
 
-def _transformation(batch_size: int) -> list:
+def _transformation(batch_size: int, device: str = "cpu") -> list:
     # apply_augmentations expects List[torch.Tensor] where each matrix R satisfies
     # positions_rotated = positions @ R.T, matching how the test datasets were built
-    t = torch.tensor(_R.T, dtype=torch.float64)
+    t = torch.tensor(_R.T, dtype=torch.float64, device=device)
     return [t] * batch_size
 
 
@@ -68,7 +68,7 @@ def _relabel_system_samples(tensor: TensorMap, system_ids: torch.Tensor) -> Tens
     for block in tensor.blocks():
         position = block.samples.names.index("system")
         values = block.samples.values.clone()
-        values[:, position] = system_ids[values[:, position]]
+        values[:, position] = system_ids.to(values.device)[values[:, position]]
         blocks.append(
             TensorBlock(
                 values=block.values,
@@ -101,29 +101,35 @@ def _dataset_info(target_name: str, target_type: dict, sample_kind: str) -> Data
 
 
 def _load_systems_and_targets(
-    target_name: str, batch_size: int
+    target_name: str, batch_size: int, device: str = "cpu"
 ) -> tuple[list[System], TensorMap, TensorMap]:
     """Load the first ``batch_size`` systems together with their unrotated and
-    DFT-rotated ``target_name`` references, joined along samples."""
+    DFT-rotated ``target_name`` references, joined along samples, on ``device``."""
     dataset_unrotated = DiskDataset(RESOURCES_PATH / "spherical_targets_unrotated.zip")
     dataset_rotated = DiskDataset(RESOURCES_PATH / "spherical_targets_rotated.zip")
-    X = [dataset_unrotated[i]["system"].to(torch.float64) for i in range(batch_size)]
+    X = [
+        dataset_unrotated[i]["system"].to(dtype=torch.float64, device=device)
+        for i in range(batch_size)
+    ]
     fX = mts.join(
         [dataset_unrotated[i][target_name] for i in range(batch_size)], axis="samples"
-    )
+    ).to(device=device)
     fRX = mts.join(
         [dataset_rotated[i][target_name] for i in range(batch_size)], axis="samples"
-    )
+    ).to(device=device)
     return X, fX, fRX
 
 
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
 @pytest.mark.parametrize("batch_size", [1, 2])
-def test_rotation_per_structure_spherical(batch_size):
+def test_rotation_per_structure_spherical(batch_size, device):
     """Tests that the rotational augmenter rotates a dipole moment consistent with
     targets computed from DFT"""
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
 
     target_name = "mtt::dipole_moment"
-    X, fX, fRX = _load_systems_and_targets(target_name, batch_size)
+    X, fX, fRX = _load_systems_and_targets(target_name, batch_size, device)
 
     dataset_info = _dataset_info(
         target_name,
@@ -136,22 +142,27 @@ def test_rotation_per_structure_spherical(batch_size):
     _, RfX, _ = rotational_augmenter.apply_augmentations(
         X,
         {target_name: fX},
-        _transformation(batch_size),
+        _transformation(batch_size, device),
         extra_data={},
     )
     RfX = RfX[target_name]
 
-    # Check that the rotated target matches the reference
+    # Check that the rotated target matches the reference, without leaving the device
+    assert RfX.device.type == torch.device(device).type
     mts.allclose_raise(RfX, fRX, atol=1e-5)
 
 
-def test_apply_augmentations_extra_data():
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_apply_augmentations_extra_data(device):
     """Tests that spherical extra data is rotated exactly like a target, while extra
     data whose name ends in ``_mask`` is passed through untouched (loss masks are not
     physical quantities and must not be rotated)."""
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
     target_name = "mtt::dipole_moment"
     batch_size = 2
-    X, fX, fRX = _load_systems_and_targets(target_name, batch_size)
+    X, fX, fRX = _load_systems_and_targets(target_name, batch_size, device)
 
     target_type = {"spherical": {"irreps": [{"o3_lambda": 1, "o3_sigma": 1}]}}
     target_info = _dataset_info(target_name, target_type, "system")
@@ -160,13 +171,13 @@ def test_apply_augmentations_extra_data():
     rotational_augmenter = O3Augmenter(target_info.targets, extra_info.targets)
 
     mask = TensorMap(
-        keys=Labels(["_"], torch.tensor([[0]])),
+        keys=Labels(["_"], torch.tensor([[0]], device=device)),
         blocks=[
             TensorBlock(
-                values=torch.tensor([[1.0], [0.0]], dtype=torch.float64),
-                samples=Labels(["system"], torch.tensor([[0], [1]])),
+                values=torch.tensor([[1.0], [0.0]], dtype=torch.float64, device=device),
+                samples=Labels(["system"], torch.tensor([[0], [1]], device=device)),
                 components=[],
-                properties=Labels(["_"], torch.tensor([[0]])),
+                properties=Labels(["_"], torch.tensor([[0]], device=device)),
             )
         ],
     )
@@ -174,7 +185,7 @@ def test_apply_augmentations_extra_data():
     _, _, new_extra_data = rotational_augmenter.apply_augmentations(
         X,
         {target_name: fX},
-        _transformation(batch_size),
+        _transformation(batch_size, device),
         extra_data={extra_name: fX, "mtt::dipole_moment_mask": mask},
     )
 
@@ -186,13 +197,16 @@ def test_apply_augmentations_extra_data():
     )
 
 
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
 @pytest.mark.parametrize("batch_size", [1, 2])
-def test_rotation_per_atom_spherical(batch_size):
+def test_rotation_per_atom_spherical(batch_size, device):
     """Tests that the rotational augmenter rotates electron density projections
     consistent with targets computed from DFT"""
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
 
     target_name = "mtt::electron_density_basis_projs"
-    X, fX, fRX = _load_systems_and_targets(target_name, batch_size)
+    X, fX, fRX = _load_systems_and_targets(target_name, batch_size, device)
 
     dataset_info = _dataset_info(
         target_name, {"spherical": {"irreps": _ELECTRON_DENSITY_IRREPS}}, "atom"
@@ -203,28 +217,33 @@ def test_rotation_per_atom_spherical(batch_size):
     _, RfX, _ = rotational_augmenter.apply_augmentations(
         X,
         {target_name: fX},
-        _transformation(batch_size),
+        _transformation(batch_size, device),
         extra_data={},
     )
     RfX = RfX[target_name]
 
-    # Check that the rotated target matches the reference
+    # Check that the rotated target matches the reference, without leaving the device
+    assert RfX.device.type == torch.device(device).type
     mts.allclose_raise(RfX, fRX, atol=1e-5)
 
 
-def test_distinct_transformations_per_system():
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_distinct_transformations_per_system(device):
     """Tests that each system's target rows are transformed by that system's own
     matrix. metatomic's ``transform_tensor`` pairs ``system_ids[i]`` positionally
     with ``transformations[i]``, so this only holds if the ids recovered from the
     tensor come out in the same order as the ``systems`` list. Every other test
     applies the same matrix to all systems and would not notice a mix-up.
     """
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
     target_name = "mtt::electron_density_basis_projs"
 
     # Absolute dataset ids, deliberately not 0, ..., n-1
     system_ids = torch.tensor([3, 8])
 
-    X, fX, _ = _load_systems_and_targets(target_name, 2)
+    X, fX, _ = _load_systems_and_targets(target_name, 2, device)
     fX = _relabel_system_samples(fX, system_ids)
 
     # system 0 is left alone while system 1 is rotated, so the expected result
@@ -235,7 +254,7 @@ def test_distinct_transformations_per_system():
         mts.join(
             [dataset_unrotated[0][target_name], dataset_rotated[1][target_name]],
             axis="samples",
-        ),
+        ).to(device=device),
         system_ids,
     )
 
@@ -245,8 +264,8 @@ def test_distinct_transformations_per_system():
     rotational_augmenter = O3Augmenter(dataset_info.targets, {})
 
     transformations = [
-        torch.eye(3, dtype=torch.float64),
-        torch.tensor(_R.T, dtype=torch.float64),
+        torch.eye(3, dtype=torch.float64, device=device),
+        torch.tensor(_R.T, dtype=torch.float64, device=device),
     ]
     _, RfX, _ = rotational_augmenter.apply_augmentations(
         X, {target_name: fX}, transformations, extra_data={}
@@ -696,16 +715,20 @@ def test_cartesian_rank3():
     torch.testing.assert_close(new_targets[target_name].block().values, expected)
 
 
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
 @pytest.mark.parametrize("batch_size", [1, 2])
-def test_rotation_per_atom_spherical_atomicbasis(batch_size):
+def test_rotation_per_atom_spherical_atomicbasis(batch_size, device):
     """Tests that the rotational augmenter rotates a Hamiltonian in the coupled basis
     (rank-1 tensors with an atomic basis) consistent with targets computed from DFT.
 
     Previously this raised ValueError; metatomic's transform_tensor now handles
     atomic basis targets via per-block row-index indexing.
     """
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
     target_name = "mtt::hamiltonian_nodes"
-    X, fX, fRX = _load_systems_and_targets(target_name, batch_size)
+    X, fX, fRX = _load_systems_and_targets(target_name, batch_size, device)
 
     dataset_info = _dataset_info(
         target_name,
@@ -718,12 +741,13 @@ def test_rotation_per_atom_spherical_atomicbasis(batch_size):
     _, RfX, _ = rotational_augmenter.apply_augmentations(
         X,
         {target_name: fX},
-        _transformation(batch_size),
+        _transformation(batch_size, device),
         extra_data={},
     )
     RfX = RfX[target_name]
 
-    # Check that the rotated target matches the reference
+    # Check that the rotated target matches the reference, without leaving the device
+    assert RfX.device.type == torch.device(device).type
     mts.allclose_raise(RfX, fRX, atol=1e-5)
 
 
@@ -740,6 +764,8 @@ def test_rotation_after_atomic_basis_prepare_transform():
     non-contiguous absolute "system" ids, and checks the final result against the
     DFT-rotated reference.
     """
+    # CPU only: the atomic-basis "prepare" transform builds its layout on the CPU and
+    # cannot yet be driven with a GPU batch, independently of the augmentation itself.
     target_name = "mtt::hamiltonian_nodes"
     batch_size = 2
 
@@ -788,16 +814,20 @@ def test_rotation_after_atomic_basis_prepare_transform():
     mts.allclose_raise(reversed_targets[target_name], fRX, atol=1e-5)
 
 
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
 @pytest.mark.parametrize("batch_size", [1, 2])
-def test_rotation_per_atom_spherical_rank2(batch_size):
+def test_rotation_per_atom_spherical_rank2(batch_size, device):
     """Tests that the rotational augmenter rotates a Hamiltonian in the uncoupled basis
     (rank-2 tensors with an atomic basis) consistent with targets computed from DFT.
 
     Previously this raised ValueError; metatomic's transform_tensor now handles
     atomic basis targets via per-block row-index indexing.
     """
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
     target_name = "mtt::hamiltonian_nodes_uncoupled"
-    X, fX, fRX = _load_systems_and_targets(target_name, batch_size)
+    X, fX, fRX = _load_systems_and_targets(target_name, batch_size, device)
 
     dataset_info = _dataset_info(
         target_name,
@@ -810,10 +840,11 @@ def test_rotation_per_atom_spherical_rank2(batch_size):
     _, RfX, _ = rotational_augmenter.apply_augmentations(
         X,
         {target_name: fX},
-        _transformation(batch_size),
+        _transformation(batch_size, device),
         extra_data={},
     )
     RfX = RfX[target_name]
 
-    # Check that the rotated target matches the reference
+    # Check that the rotated target matches the reference, without leaving the device
+    assert RfX.device.type == torch.device(device).type
     mts.allclose_raise(RfX, fRX, atol=1e-5)


### PR DESCRIPTION
Function `_tensor_system_ids` in augmentation.py builds its result with `torch.tensor(...)` and no `device=`, so it always returns a CPU tensor. This raises an error when the tensor in question is on GPU:

```
RuntimeError: Expected all tensors to be on the same device, but got
test_elements is on cpu, different from other tensors on cuda:0
```

As this function is only currently used by workers in the collate function, everything happens on CPU. However, when using the function outside (as an augmentation routine it is useful for other things, i.e. custom loss functions), it raises an error if training on GPU.


This PR sets the correct device in the function in question, and parametrizes augmentation tests with device to run on both CPU and cuda.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - ~[ ] Documentation updated (for new features)?~
 - ~[ ] Issue referenced (for PRs that solve an issue)?~

# Maintainer/Reviewer checklist

 - ~[ ] CHANGELOG updated with public API or any other important changes?~
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1234.org.readthedocs.build/en/1234/

<!-- readthedocs-preview metatrain end -->