### PR TITLE
SPACE: incorrect `model.scaler` call in distributed case

### DIFF
--- a/src/metatrain/experimental/space/trainer.py
+++ b/src/metatrain/experimental/space/trainer.py
@@ -496,7 +496,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
                 # not per-property. This transformation only applies to targets with
                 # per-property scales (i.e. multiple blocks or multiple properties), and
                 # leaves the others unchanged.
-                predictions = (model.module if is_distributed else model).scaler(
+                predictions = model.scaler(
                     systems,
                     predictions,
                     remove=False,
@@ -623,7 +623,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
                     # per-target, and not per-property. This transformation only applies
                     # to targets with per-property scales (i.e. multiple blocks or
                     # multiple properties), and leaves the others unchanged.
-                    predictions = (model.module if is_distributed else model).scaler(
+                    predictions = model.scaler(
                         systems,
                         predictions,
                         remove=False,


### PR DESCRIPTION
PR #1107 introduced a bug in calling the forward method of the `Scaler` when applying per-property scales, but only in the distributed case.

Distributed is already properly handled by `model` in trainer.py, so doesn't need the conditional involving `model.module`.

# Contributor (creator of pull-request) checklist

 - ~[ ] Tests updated (for new features and bugfixes)?~
 - ~[ ] Documentation updated (for new features)?~
 - ~[ ] Issue referenced (for PRs that solve an issue)?~

# Maintainer/Reviewer checklist

 - ~[ ] CHANGELOG updated with public API or any other important changes?~
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1236.org.readthedocs.build/en/1236/

<!-- readthedocs-preview metatrain end -->