### PR TITLE
Pass DatasetInfo with sparse atomic basis targets to the Scaler

### DIFF
--- a/src/metatrain/experimental/dpa3/tests/test_basic.py
+++ b/src/metatrain/experimental/dpa3/tests/test_basic.py
@@ -124,6 +124,8 @@ class TestExported(ExportedTests, DPA3Tests):
 
 
 class TestTraining(TrainingTests, DPA3Tests):
+    supports_atomic_basis = False
+
     @pytest.mark.skip(reason="DPA3: multi-epoch training too slow for CI time limits")
     def test_continue_restart_num_epochs(self, *a, **kw):
         pass

--- a/src/metatrain/experimental/flashmd/tests/test_basic.py
+++ b/src/metatrain/experimental/flashmd/tests/test_basic.py
@@ -81,6 +81,8 @@ class TestCheckpoints(CheckpointTests, FlashMDTests):
 
 
 class TestTraining(TrainingTests, FlashMDTests):
+    supports_atomic_basis = False
+
     @pytest.fixture
     def default_hypers(self):
         hypers = get_default_hypers(self.architecture)

--- a/src/metatrain/experimental/mace/model.py
+++ b/src/metatrain/experimental/mace/model.py
@@ -304,7 +304,7 @@ class MetaMACE(ModelInterface[ModelHypers]):
         self.additive_models = torch.nn.ModuleList([composition_model])
 
         scaler_hypers = get_default_hypers("scaler")["model"]
-        self.scaler = Scaler(hypers=scaler_hypers, dataset_info=train_dataset_info)
+        self.scaler = Scaler(hypers=scaler_hypers, dataset_info=dataset_info)
 
         self.finetune_config: Dict[str, Any] = {}
 
@@ -351,7 +351,7 @@ class MetaMACE(ModelInterface[ModelHypers]):
                 },
             ),
         )
-        self.scaler = self.scaler.restart(train_dataset_info)
+        self.scaler = self.scaler.restart(dataset_info)
 
         return self
 

--- a/src/metatrain/experimental/mace/tests/test_basic.py
+++ b/src/metatrain/experimental/mace/tests/test_basic.py
@@ -210,7 +210,25 @@ class TestTorchscript(TorchscriptTests, MACETests):
 class TestExported(ExportedTests, MACETests): ...
 
 
-class TestTraining(TrainingTests, MACETests): ...
+class TestTraining(TrainingTests, MACETests):
+    def test_train_atomic_basis_target(
+        self,
+        source,
+        monkeypatch,
+        tmp_path,
+        dataset_info_spherical_atomic_basis,
+        default_hypers,
+        model_hypers,
+    ) -> None:
+        if source == "from_file":
+            pytest.skip("a pretrained MACE has an energy head, not an atomic basis")
+        super().test_train_atomic_basis_target(
+            monkeypatch,
+            tmp_path,
+            dataset_info_spherical_atomic_basis,
+            default_hypers,
+            model_hypers,
+        )
 
 
 class TestCheckpoints(CheckpointTests, MACETests):

--- a/src/metatrain/experimental/space/model.py
+++ b/src/metatrain/experimental/space/model.py
@@ -158,7 +158,7 @@ class SPACE(ModelInterface[ModelHypers]):
 
         # scaler: this is also handled by the trainer at training time
         scaler_hypers = get_default_hypers("scaler")["model"]
-        self.scaler = Scaler(hypers=scaler_hypers, dataset_info=train_dataset_info)
+        self.scaler = Scaler(hypers=scaler_hypers, dataset_info=dataset_info)
 
         self.single_label = Labels.single()
 
@@ -218,7 +218,7 @@ class SPACE(ModelInterface[ModelHypers]):
                 },
             ),
         )
-        self.scaler.restart(train_dataset_info)
+        self.scaler.restart(dataset_info)
 
         # Actual removal (if any) is deferred to ``apply_finetuning_strategy``
         # (called later, once training starts), since ``inherit_heads`` needs these

--- a/src/metatrain/pet/model.py
+++ b/src/metatrain/pet/model.py
@@ -195,7 +195,7 @@ class PET(ModelInterface[ModelHypers]):
 
         # scaler: this is also handled by the trainer at training time
         scaler_hypers = get_default_hypers("scaler")["model"]
-        self.scaler = Scaler(hypers=scaler_hypers, dataset_info=train_dataset_info)
+        self.scaler = Scaler(hypers=scaler_hypers, dataset_info=dataset_info)
 
         self.single_label = Labels.single()
 
@@ -254,7 +254,7 @@ class PET(ModelInterface[ModelHypers]):
                 },
             ),
         )
-        self.scaler = self.scaler.restart(train_dataset_info)
+        self.scaler = self.scaler.restart(dataset_info)
 
         # Actual removal (if any) is deferred to ``apply_finetuning_strategy``
         # (called later, once training starts), since ``inherit_heads`` needs these

--- a/src/metatrain/soap_bpnn/model.py
+++ b/src/metatrain/soap_bpnn/model.py
@@ -420,7 +420,7 @@ class SoapBpnn(ModelInterface[ModelHypers]):
 
         # scaler: this is also handled by the trainer at training time
         scaler_hypers = get_default_hypers("scaler")["model"]
-        self.scaler = Scaler(hypers=scaler_hypers, dataset_info=train_dataset_info)
+        self.scaler = Scaler(hypers=scaler_hypers, dataset_info=dataset_info)
 
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.outputs
@@ -466,7 +466,7 @@ class SoapBpnn(ModelInterface[ModelHypers]):
                 },
             ),
         )
-        self.scaler = self.scaler.restart(train_dataset_info)
+        self.scaler = self.scaler.restart(dataset_info)
 
         return self
 

--- a/src/metatrain/utils/testing/training.py
+++ b/src/metatrain/utils/testing/training.py
@@ -3,10 +3,15 @@ from pathlib import Path
 from typing import Any
 
 import metatensor.torch as mts
+import pytest
 import torch
+from metatensor.torch import Labels, TensorBlock, TensorMap
+from metatomic.torch import System
 from omegaconf import OmegaConf
 
+from metatrain.utils.data import Dataset, DatasetInfo, DiskDataset
 from metatrain.utils.data.readers import read_systems
+from metatrain.utils.data.writers import DiskDatasetWriter
 from metatrain.utils.hypers import init_with_defaults
 from metatrain.utils.io import model_from_checkpoint
 from metatrain.utils.loss import LossSpecification
@@ -21,6 +26,13 @@ class TrainingTests(ArchitectureTests):
     """Puts architectures to test in real training scenarios."""
 
     check_gradients: bool = True
+
+    supports_atomic_basis: bool = True
+    """Whether the architecture can be trained on atomic-basis targets.
+
+    Set to ``False`` in architectures that do not support them, to skip
+    :meth:`test_train_atomic_basis_target`.
+    """
 
     def test_train(
         self,
@@ -63,6 +75,113 @@ class TrainingTests(ArchitectureTests):
 
         trainer = self.trainer_cls(hypers["training"])
         trainer.train(
+            model=model,
+            dtype=dtype,
+            devices=[torch.device("cpu")],
+            train_datasets=[dataset],
+            val_datasets=[dataset],
+            checkpoint_dir=".",
+        )
+
+    def _atomic_basis_dataset(
+        self, dataset_info: DatasetInfo, path: Path, n_systems: int = 2
+    ) -> Dataset:
+        """Random values laid out like the atomic-basis target of ``dataset_info``.
+
+        Written to disk because atomic-basis targets need the
+        ``mtt::aux::system_index`` that only a ``DiskDataset`` provides.
+
+        :param dataset_info: Dataset info describing the atomic-basis target.
+        :param path: Path to write the dataset to.
+        :param n_systems: Number of random systems to generate.
+        :return: Dataset with random values laid out like the atomic-basis target
+        """
+        target_name = next(iter(dataset_info.targets))
+        layout = dataset_info.targets[target_name].layout
+        types = torch.tensor(sorted(dataset_info.atomic_types))
+
+        writer = DiskDatasetWriter(str(path))
+        for _ in range(n_systems):
+            system = System(
+                types=types,
+                positions=torch.rand((len(types), 3), dtype=torch.float64) * 5.0,
+                cell=torch.zeros((3, 3), dtype=torch.float64),
+                pbc=torch.tensor([False, False, False]),
+            )
+            blocks = []
+            for key, block in layout.items():
+                atoms = torch.nonzero(types == int(key["atom_type"])).reshape(-1)
+                blocks.append(
+                    TensorBlock(
+                        values=torch.rand(
+                            (
+                                len(atoms),
+                                len(block.components[0]),
+                                len(block.properties),
+                            ),
+                            dtype=torch.float64,
+                        ),
+                        samples=Labels(
+                            ["system", "atom"],
+                            torch.stack([torch.zeros_like(atoms), atoms], dim=1).to(
+                                torch.int32
+                            ),
+                        ),
+                        components=block.components,
+                        properties=block.properties,
+                    )
+                )
+            writer.write([system], {target_name: TensorMap(layout.keys, blocks)})
+        writer.finish()
+        return DiskDataset(str(path))
+
+    def test_train_atomic_basis_target(
+        self,
+        monkeypatch: Any,
+        tmp_path: Path,
+        dataset_info_spherical_atomic_basis: DatasetInfo,
+        default_hypers: dict[str, Any],
+        model_hypers: dict[str, Any],
+        dtype: torch.dtype = torch.float32,
+    ) -> None:
+        """Tests that a model can be trained on an atomic-basis target.
+
+        These are stored sparsely, one block per
+        ``(o3_lambda, o3_sigma, atom_type)``, and densified for training, so
+        everything reading the raw data has to densify it first.
+
+        :param monkeypatch: Pytest fixture to modify the current working
+            directory.
+        :param tmp_path: Temporary path to use for the dataset and checkpoints.
+        :param dataset_info_spherical_atomic_basis: Dataset info describing the
+            atomic-basis target.
+        :param default_hypers: Default hyperparameters for the architecture.
+        :param model_hypers: Hyperparameters to initialize the model.
+        :param dtype: Data type to use for training.
+        """
+        if not self.supports_atomic_basis:
+            pytest.skip(f"{self.architecture} does not support atomic-basis targets")
+
+        monkeypatch.chdir(tmp_path)
+
+        dataset_info = dataset_info_spherical_atomic_basis
+        dataset = self._atomic_basis_dataset(dataset_info, tmp_path / "dataset.zip")
+
+        model = self.model_cls(model_hypers, dataset_info)
+
+        hypers = copy.deepcopy(default_hypers)
+        if "num_epochs" in hypers["training"]:
+            hypers["training"]["num_epochs"] = 0
+        if "batch_size" in hypers["training"]:
+            hypers["training"]["batch_size"] = 1
+        if "loss" in hypers["training"]:
+            loss_conf = OmegaConf.create(
+                {k: init_with_defaults(LossSpecification) for k in dataset_info.targets}
+            )
+            OmegaConf.resolve(loss_conf)
+            hypers["training"]["loss"] = loss_conf
+
+        self.trainer_cls(hypers["training"]).train(
             model=model,
             dtype=dtype,
             devices=[torch.device("cpu")],


### PR DESCRIPTION
When training SOAP-BPNN, MACE, SPACE, and PET with `scale_targets: true` (i.e. fitting the scales from the data 'from-scratch'), an error is raised:


This happens because the Scaler is initialized with densified atomic basis targets, and as such does not recognise them as atomic basis targets (i.e. no "atom_type" key dimension(s)).

This PR passes the raw `DatasetInfo` to the Scaler, and adds corresponding architecture tests.

<!-- What does this implement/fix? Explain your changes here. -->



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - ~[ ] Documentation updated (for new features)?~
 - ~[ ] Issue referenced (for PRs that solve an issue)?~

# Maintainer/Reviewer checklist

 - ~[ ] CHANGELOG updated with public API or any other important changes?~
 - [ ] GPU tests passed (maintainer comment: "cscs-ci run")?


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1242.org.readthedocs.build/en/1242/

<!-- readthedocs-preview metatrain end -->