### PR TITLE
Keep DataLoader workers on Python 3.14

### DIFF
--- a/src/metatrain/utils/data/dataloaders.py
+++ b/src/metatrain/utils/data/dataloaders.py
@@ -45,6 +45,10 @@ def build_train_dataloaders(
     """
     dataloaders: List[DataLoader] = []
     epoch_samplers: List[Any] = []
+    # request fork explicitly: the default start method is "forkserver" on
+    # Python >= 3.14, but our datasets and collate functions rely on fork's
+    # memory sharing and are not picklable
+    mp_context = "fork" if num_workers > 0 else None
     for train_dataset, train_sampler in zip(
         train_datasets, train_distributed_samplers, strict=True
     ):
@@ -67,6 +71,7 @@ def build_train_dataloaders(
                     batch_sampler=batch_sampler,
                     collate_fn=collate_fn_train,
                     num_workers=num_workers,
+                    multiprocessing_context=mp_context,
                 )
             )
         else:
@@ -88,6 +93,7 @@ def build_train_dataloaders(
                     drop_last=(train_sampler is None),
                     collate_fn=collate_fn_train,
                     num_workers=num_workers,
+                    multiprocessing_context=mp_context,
                 )
             )
     return dataloaders, epoch_samplers
@@ -123,6 +129,10 @@ def build_val_dataloaders(
     :return: One ``DataLoader`` per dataset in ``val_datasets``.
     """
     dataloaders: List[DataLoader] = []
+    # request fork explicitly: the default start method is "forkserver" on
+    # Python >= 3.14, but our datasets and collate functions rely on fork's
+    # memory sharing and are not picklable
+    mp_context = "fork" if num_workers > 0 else None
     for val_dataset, val_sampler in zip(
         val_datasets, val_distributed_samplers, strict=True
     ):
@@ -142,6 +152,7 @@ def build_val_dataloaders(
                     batch_sampler=batch_sampler,
                     collate_fn=collate_fn_val,
                     num_workers=num_workers,
+                    multiprocessing_context=mp_context,
                 )
             )
         else:
@@ -154,6 +165,7 @@ def build_val_dataloaders(
                     drop_last=False,
                     collate_fn=collate_fn_val,
                     num_workers=num_workers,
+                    multiprocessing_context=mp_context,
                 )
             )
     return dataloaders

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -2,6 +2,7 @@ import io
 import math
 import multiprocessing
 import os
+import sys
 import warnings
 import zipfile
 from pathlib import Path
@@ -1148,7 +1149,7 @@ def get_num_workers() -> int:
     :return: A good number of workers for data loading.
     """
 
-    if multiprocessing.get_start_method(allow_none=False) != "fork":
+    if not fork_is_available():
         return 0
 
     # len(os.sched_getaffinity(0)) detects thread counts set by slurm,
@@ -1167,20 +1168,40 @@ def get_num_workers() -> int:
     return num_workers
 
 
+def fork_is_available() -> bool:
+    """
+    Whether the "fork" multiprocessing start method can be used for
+    ``DataLoader`` workers.
+
+    Restricted to Linux: fork is unsafe on macOS (system frameworks are not
+    fork-safe) and unavailable on Windows. Checked against the list of
+    available start methods rather than the default one, because the default
+    changed from "fork" to "forkserver" on Linux in Python 3.14 while fork
+    remains available; metatrain requests it explicitly when building
+    ``DataLoader`` objects.
+
+    :return: Whether "fork" can be used for ``DataLoader`` workers.
+    """
+    return (
+        sys.platform.startswith("linux")
+        and "fork" in multiprocessing.get_all_start_methods()
+    )
+
+
 def validate_num_workers(num_workers: int) -> None:
     """
     Gets a good number of workers for data loading.
 
     :param num_workers: The number of workers to validate.
     :raises ValueError: If the number of workers is greater than 0 and the
-        multiprocessing start method is not "fork".
+        "fork" multiprocessing start method is not available.
     """
 
-    if multiprocessing.get_start_method(allow_none=False) != "fork" and num_workers > 0:
+    if num_workers > 0 and not fork_is_available():
         raise ValueError(
-            "You are using a start method for multiprocessing that is not "
-            "'fork' (this is likely because you are on macOS or Windows). "
-            "In this case, num_workers must be set to 0."
+            "Parallel data loading relies on the 'fork' multiprocessing "
+            "start method, which is only available on Linux. On this "
+            "platform, num_workers must be set to 0."
         )
 
 


### PR DESCRIPTION
Python 3.14 changes the default multiprocessing start method on Linux from fork to forkserver. get_num_workers() used the default method, so automatic worker selection drops to 0 with Python 3.14, and an explicit num_workers > 0 raises a ValueError wrongly blaming macOS/Windows.


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1243.org.readthedocs.build/en/1243/

<!-- readthedocs-preview metatrain end -->