### PR TITLE
Avoid and hide deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,8 +198,6 @@ filterwarnings = [
     "ignore:The TorchScript type system doesn't support instance-level annotations on empty non-base types",
     # Sphericart double backward warning
     "ignore:Second derivatives of the spherical harmonics with respect to the Cartesian coordinates were not requested at class creation.",
-    # Multi-threaded tests clash with multi-process data-loading
-    "ignore:This process \\(pid=\\d+\\) is multi-threaded, use of fork\\(\\) may lead to deadlocks in the child.:DeprecationWarning",
     # Initialization of tensors of zero size
     "ignore:Initializing zero-element tensors is a no-op:UserWarning",
     # MACE warning with newer versions of pytorch (because they use e3nn==0.4.4)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,8 @@ filterwarnings = [
     "ignore:The TorchScript type system doesn't support instance-level annotations on empty non-base types",
     # Sphericart double backward warning
     "ignore:Second derivatives of the spherical harmonics with respect to the Cartesian coordinates were not requested at class creation.",
+    # Multi-threaded tests clash with multi-process data-loading
+    "ignore:This process \\(pid=\\d+\\) is multi-threaded, use of fork\\(\\) may lead to deadlocks in the child.:DeprecationWarning",
     # Initialization of tensors of zero size
     "ignore:Initializing zero-element tensors is a no-op:UserWarning",
     # MACE warning with newer versions of pytorch (because they use e3nn==0.4.4)

--- a/src/metatrain/composition/model.py
+++ b/src/metatrain/composition/model.py
@@ -343,7 +343,6 @@ class CompositionModel(ModelInterface[ModelHypers]):
 
     def _add_output(self, target_name: str, target_info: TargetInfo) -> None:
         self.outputs[target_name] = ModelOutput(
-            quantity=target_info.quantity,
             unit=target_info.unit,
             sample_kind="atom",
             description=target_info.description,

--- a/src/metatrain/composition/tests/test_errors.py
+++ b/src/metatrain/composition/tests/test_errors.py
@@ -108,4 +108,4 @@ def test_forward_unknown_output_raises():
 
     systems = read_systems(DATASET_PATH)
     with pytest.raises(ValueError, match="not supported"):
-        model(systems[:1], {"nonexistent": ModelOutput(quantity="energy")})
+        model(systems[:1], {"nonexistent": ModelOutput()})

--- a/src/metatrain/experimental/classifier/model.py
+++ b/src/metatrain/experimental/classifier/model.py
@@ -91,7 +91,7 @@ class Classifier(ModelInterface[ModelHypers]):
 
         # Store capabilities
         outputs = {name: ModelOutput() for name in self.dataset_info.targets.keys()}
-        outputs["feature"] = ModelOutput(quantity="", unit="", sample_kind="system")
+        outputs["feature"] = ModelOutput(unit="", sample_kind="system")
         self.capabilities = ModelCapabilities(
             outputs=outputs,
             atomic_types=old_capabilities.atomic_types,

--- a/src/metatrain/experimental/classifier/trainer.py
+++ b/src/metatrain/experimental/classifier/trainer.py
@@ -202,11 +202,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
                 # Forward pass - request logits for training
                 outputs = model(
                     systems,
-                    {
-                        target_name_logits: ModelOutput(
-                            quantity="", unit="", sample_kind="system"
-                        )
-                    },
+                    {target_name_logits: ModelOutput(unit="", sample_kind="system")},
                     None,
                 )
 
@@ -252,7 +248,7 @@ class Trainer(TrainerInterface[TrainerHypers]):
                         systems,
                         {
                             target_name_logits: ModelOutput(
-                                quantity="", unit="", sample_kind="system"
+                                unit="", sample_kind="system"
                             )
                         },
                         None,

--- a/src/metatrain/experimental/dpa3/model.py
+++ b/src/metatrain/experimental/dpa3/model.py
@@ -214,7 +214,6 @@ class DPA3(ModelInterface[ModelHypers]):
             block.properties for block in target.layout.blocks()
         ]
         self.outputs[target_name] = ModelOutput(
-            quantity=target.quantity,
             unit=target.unit,
             sample_kind="atom",
         )

--- a/src/metatrain/experimental/dpa3/tests/test_compile.py
+++ b/src/metatrain/experimental/dpa3/tests/test_compile.py
@@ -55,7 +55,7 @@ def test_forward_from_batch_matches_forward():
     # Standard forward
     out = model(
         systems,
-        {"mtt::U0": ModelOutput(quantity="energy", unit="", sample_kind="system")},
+        {"mtt::U0": ModelOutput(unit="", sample_kind="system")},
     )
     # Verify the standard forward works
     assert out["mtt::U0"].block().values.numel() > 0

--- a/src/metatrain/experimental/dpa3/tests/test_pretrained.py
+++ b/src/metatrain/experimental/dpa3/tests/test_pretrained.py
@@ -141,9 +141,7 @@ def test_pretrained_forward_matches():
     for s in systems:
         get_system_with_neighbor_lists(s, base.requested_neighbor_lists())
 
-    output_request = {
-        "mtt::U0": ModelOutput(quantity="energy", unit="", sample_kind="system")
-    }
+    output_request = {"mtt::U0": ModelOutput(unit="", sample_kind="system")}
     base_out = base(systems, output_request)
     pretrained_out = pretrained(systems, output_request)
 
@@ -179,9 +177,7 @@ def test_pretrained_checkpoint_roundtrip():
     for s in systems:
         get_system_with_neighbor_lists(s, pretrained.requested_neighbor_lists())
 
-    output_request = {
-        "mtt::U0": ModelOutput(quantity="energy", unit="", sample_kind="system")
-    }
+    output_request = {"mtt::U0": ModelOutput(unit="", sample_kind="system")}
     orig_out = pretrained(systems, output_request)
     reloaded_out = reloaded(systems, output_request)
 

--- a/src/metatrain/experimental/dpa3/tests/test_regression.py
+++ b/src/metatrain/experimental/dpa3/tests/test_regression.py
@@ -44,7 +44,7 @@ def test_regression_init():
 
     output = model(
         systems,
-        {"mtt::U0": ModelOutput(quantity="energy", unit="", sample_kind="system")},
+        {"mtt::U0": ModelOutput(unit="", sample_kind="system")},
     )
 
     expected_output = torch.tensor(

--- a/src/metatrain/experimental/flashmd/model.py
+++ b/src/metatrain/experimental/flashmd/model.py
@@ -306,10 +306,8 @@ class FlashMD(ModelInterface[ModelHypers]):
 
     def requested_inputs(self) -> Dict[str, ModelOutput]:
         return {
-            "momentum": ModelOutput(
-                quantity="momentum", unit="(eV*u)^(1/2)", sample_kind="atom"
-            ),
-            "mass": ModelOutput(quantity="mass", unit="u", sample_kind="atom"),
+            "momentum": ModelOutput(unit="(eV*u)^(1/2)", sample_kind="atom"),
+            "mass": ModelOutput(unit="u", sample_kind="atom"),
         }
 
     def forward(
@@ -1256,7 +1254,6 @@ class FlashMD(ModelInterface[ModelHypers]):
             ] + [len(block.properties.values)]
 
         self.outputs[target_name] = ModelOutput(
-            quantity=target_info.quantity,
             unit=target_info.unit,
             sample_kind="atom",
             description=target_info.description,

--- a/src/metatrain/experimental/flashmd/modules/additive.py
+++ b/src/metatrain/experimental/flashmd/modules/additive.py
@@ -41,7 +41,6 @@ class PositionAdditive(torch.nn.Module):
                 # skip momenta targets unless `also_momenta` is True
                 continue
             self.outputs[key] = ModelOutput(
-                quantity=value.quantity,
                 unit=value.unit,
                 sample_kind="atom",
                 description=value.description,
@@ -63,7 +62,6 @@ class PositionAdditive(torch.nn.Module):
                 # skip momenta targets unless `also_momenta` is True
                 continue
             self.outputs[key] = ModelOutput(
-                quantity=value.quantity,
                 unit=value.unit,
                 sample_kind="atom",
                 description=value.description,

--- a/src/metatrain/experimental/flashmd/tests/test_functionality.py
+++ b/src/metatrain/experimental/flashmd/tests/test_functionality.py
@@ -100,8 +100,8 @@ def test_forward():
         system.add_data("momentum", tmap)
 
     outputs = {
-        "position": ModelOutput(quantity="length", unit="angstrom", sample_kind="atom"),
-        "momentum": ModelOutput(quantity="length", unit="angstrom", sample_kind="atom"),
+        "position": ModelOutput(unit="angstrom", sample_kind="atom"),
+        "momentum": ModelOutput(unit="angstrom", sample_kind="atom"),
     }
     result_dict = model(systems, outputs)
 

--- a/src/metatrain/experimental/flashmd_symplectic/model.py
+++ b/src/metatrain/experimental/flashmd_symplectic/model.py
@@ -288,10 +288,8 @@ class FlashMDSymplectic(ModelInterface):
 
     def requested_inputs(self) -> Dict[str, ModelOutput]:
         return {
-            "momentum": ModelOutput(
-                quantity="momentum", unit="(eV*u)^(1/2)", sample_kind="atom"
-            ),
-            "mass": ModelOutput(quantity="mass", unit="u", sample_kind="atom"),
+            "momentum": ModelOutput(unit="(eV*u)^(1/2)", sample_kind="atom"),
+            "mass": ModelOutput(unit="u", sample_kind="atom"),
         }
 
     def forward(

--- a/src/metatrain/experimental/flashmd_symplectic/tests/test_functionality.py
+++ b/src/metatrain/experimental/flashmd_symplectic/tests/test_functionality.py
@@ -100,8 +100,8 @@ def test_forward():
         system.add_data("momentum", tmap)
 
     outputs = {
-        "position": ModelOutput(quantity="length", unit="angstrom", sample_kind="atom"),
-        "momentum": ModelOutput(quantity="length", unit="angstrom", sample_kind="atom"),
+        "position": ModelOutput(unit="angstrom", sample_kind="atom"),
+        "momentum": ModelOutput(unit="angstrom", sample_kind="atom"),
     }
     result_dict = model(systems, outputs)
 

--- a/src/metatrain/experimental/mace/model.py
+++ b/src/metatrain/experimental/mace/model.py
@@ -284,7 +284,6 @@ class MetaMACE(ModelInterface[ModelHypers]):
         targets = dataset_info.targets
         self.outputs = {
             k: ModelOutput(
-                quantity=targets[k].quantity if k in targets else "",
                 unit=targets[k].unit if k in targets else "",
                 sample_kind="atom",
             )

--- a/src/metatrain/experimental/space/model.py
+++ b/src/metatrain/experimental/space/model.py
@@ -644,7 +644,6 @@ class SPACE(ModelInterface[ModelHypers]):
 
     def _add_output(self, target_name: str, target_info: TargetInfo) -> None:
         self.outputs[target_name] = ModelOutput(
-            quantity=target_info.quantity,
             unit=target_info.unit,
             sample_kind="atom",
         )

--- a/src/metatrain/experimental/space/tests/test_functionality.py
+++ b/src/metatrain/experimental/space/tests/test_functionality.py
@@ -159,7 +159,7 @@ def test_multiple_targets():
     model = SPACE(hypers, dataset_info)
     system = _make_system(model)
     outputs = {
-        "energy": ModelOutput(quantity="energy", unit="eV", sample_kind="system"),
+        "energy": ModelOutput(unit="eV", sample_kind="system"),
         "dipole": ModelOutput(sample_kind="system"),
         "non_conservative_stress": ModelOutput(sample_kind="system"),
     }

--- a/src/metatrain/experimental/space/tests/test_regression.py
+++ b/src/metatrain/experimental/space/tests/test_regression.py
@@ -61,7 +61,7 @@ def test_regression_init():
 
     output = model(
         systems,
-        {"mtt::U0": ModelOutput(quantity="energy", unit="", sample_kind="system")},
+        {"mtt::U0": ModelOutput(unit="", sample_kind="system")},
     )
 
     expected_output = torch.tensor(
@@ -158,7 +158,7 @@ def test_regression_train():
     model = torch.jit.script(model)
     output = model(
         systems[:5],
-        {"mtt::U0": ModelOutput(quantity="energy", unit="", sample_kind="system")},
+        {"mtt::U0": ModelOutput(unit="", sample_kind="system")},
     )
 
     expected_output = torch.tensor(
@@ -258,11 +258,7 @@ def test_regression_train_spherical(device):
     ]
     output = model(
         systems,
-        {
-            "mtt::electron_density_basis": ModelOutput(
-                quantity="", unit="", sample_kind="atom"
-            )
-        },
+        {"mtt::electron_density_basis": ModelOutput(unit="", sample_kind="atom")},
     )
 
     expected_output = torch.tensor(

--- a/src/metatrain/experimental/space/trainer.py
+++ b/src/metatrain/experimental/space/trainer.py
@@ -58,7 +58,6 @@ def _get_requested_outputs(targets, target_info_dict):
     requested_outputs = {}
     for name, target in targets.items():
         requested_outputs[name] = ModelOutput(
-            quantity=target_info_dict[name].quantity,
             unit=target_info_dict[name].unit,
             sample_kind=target_info_dict[name].sample_kind,
             explicit_gradients=target.block(0).gradients_list(),

--- a/src/metatrain/gap/model.py
+++ b/src/metatrain/gap/model.py
@@ -73,7 +73,6 @@ class GAP(ModelInterface[ModelHypers]):
 
         self.outputs = {
             key: ModelOutput(
-                quantity=value.quantity,
                 unit=value.unit,
                 sample_kind="system",
                 description=value.description,

--- a/src/metatrain/llpr/model.py
+++ b/src/metatrain/llpr/model.py
@@ -155,7 +155,6 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
             self.outputs_list.append(name)
             uncertainty_name = _get_uncertainty_name(name)
             additional_capabilities[uncertainty_name] = ModelOutput(
-                quantity=output.quantity,
                 unit=output.unit,
                 sample_kind=output.sample_kind,
                 description=output.description,
@@ -216,13 +215,10 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
             )
             if ensemble_output_name == "mtt::aux::energy_ensemble":
                 ensemble_output_name = "energy_ensemble"
-            explicit_gradients = _ensemble_explicit_gradients(
-                old_capabilities.outputs[name]
-            )
+            explicit_gradients = self._ensemble_explicit_gradients(name)
             if len(explicit_gradients) > 0:
                 self.ensemble_gradient_outputs.append(ensemble_output_name)
             ensemble_outputs[ensemble_output_name] = ModelOutput(
-                quantity=old_capabilities.outputs[name].quantity,
                 unit=old_capabilities.outputs[name].unit,
                 sample_kind=old_capabilities.outputs[name].sample_kind,
                 explicit_gradients=explicit_gradients,
@@ -1146,10 +1142,9 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
             if ensemble_name == "mtt::aux::energy_ensemble":
                 ensemble_name = "energy_ensemble"
             new_outputs[ensemble_name] = ModelOutput(
-                quantity=old_outputs[name].quantity,
                 unit=old_outputs[name].unit,
                 sample_kind=old_outputs[name].sample_kind,
-                explicit_gradients=_ensemble_explicit_gradients(old_outputs[name]),
+                explicit_gradients=self._ensemble_explicit_gradients(name),
                 description=f"ensemble of {name}",
             )
         self.capabilities = ModelCapabilities(
@@ -1314,29 +1309,18 @@ class LLPRUncertaintyModel(ModelInterface[ModelHypers]):
     def supported_outputs(self) -> Dict[str, ModelOutput]:
         return self.capabilities.outputs
 
+    def _ensemble_explicit_gradients(self, name: str) -> List[str]:
+        """Explicit gradients the ensemble of the ``name`` target is able to produce.
 
-def _ensemble_explicit_gradients(output: ModelOutput) -> List[str]:
-    """Explicit gradients the ensemble of ``output`` is able to produce.
+        Only energy targets are currently supported.
 
-    ``_add_energy_ensemble_gradients`` differentiates one per-system scalar per
-    ensemble member, so what matters is that the output *is* a per-system energy,
-    not what it is called: an energy target may carry any name (``mtt::my_energy``)
-    and any variant (``energy/pbesol``). Selecting on the quantity rather than on the
-    name keeps all of those working.
-
-    Other quantities get nothing: positions/strain gradients of them are not what
-    this computes.
-
-    Note that ``sample_kind`` is deliberately *not* consulted here. In capabilities
-    it describes what the wrapped model is able to produce (PET reports ``"atom"``
-    for its energy even when the target is per-system), not what a given call asks
-    for. Whether the *requested* sample kind is supported is checked in ``forward``,
-    where the request is actually known.
-
-    :param output: the wrapped model's output the ensemble is built from.
-    :return: gradient names for the corresponding ensemble output.
-    """
-    return ["positions", "strain"] if output.quantity == "energy" else []
+        :param name: name of the target the ensemble is built from.
+        :return: gradient names for the corresponding ensemble output.
+        """
+        target = self.dataset_info.targets.get(name)
+        if target is None or target.quantity != "energy":
+            return []
+        return ["positions", "strain"]
 
 
 def _get_uncertainty_name(name: str) -> str:

--- a/src/metatrain/pet/model.py
+++ b/src/metatrain/pet/model.py
@@ -270,7 +270,7 @@ class PET(ModelInterface[ModelHypers]):
     def requested_inputs(self) -> Dict[str, ModelOutput]:
         if self.system_conditioning is not None:
             return {
-                key: ModelOutput(quantity="", unit="", sample_kind="system")
+                key: ModelOutput(unit="", sample_kind="system")
                 for key in self.system_conditioning.required_data_keys
             }
         return {}
@@ -1051,7 +1051,6 @@ class PET(ModelInterface[ModelHypers]):
             ] + [len(block.properties.values)]
 
         self.outputs[target_name] = ModelOutput(
-            quantity=target_info.quantity,
             unit=target_info.unit,
             sample_kind="atom",
             description=target_info.description,

--- a/src/metatrain/pet/tests/test_regression.py
+++ b/src/metatrain/pet/tests/test_regression.py
@@ -60,7 +60,7 @@ def test_regression_init():
 
     output = model(
         systems,
-        {"mtt::U0": ModelOutput(quantity="energy", unit="", sample_kind="system")},
+        {"mtt::U0": ModelOutput(unit="", sample_kind="system")},
     )
 
     expected_output = torch.tensor(
@@ -307,7 +307,7 @@ def test_regression_energy_non_conservative_stress(batch_size):
     outputs = model(
         eval_systems,
         {
-            "energy": ModelOutput(quantity="energy", unit="", sample_kind="system"),
+            "energy": ModelOutput(unit="", sample_kind="system"),
             "non_conservative_stress": ModelOutput(sample_kind="system"),
         },
     )
@@ -426,11 +426,7 @@ def test_regression_train_spherical(device):
     ]
     output = model(
         systems,
-        {
-            "mtt::electron_density_basis": ModelOutput(
-                quantity="", unit="", sample_kind="atom"
-            )
-        },
+        {"mtt::electron_density_basis": ModelOutput(unit="", sample_kind="atom")},
     )
 
     expected_output = torch.tensor(

--- a/src/metatrain/scaler/model.py
+++ b/src/metatrain/scaler/model.py
@@ -304,7 +304,6 @@ class Scaler(ModelInterface[ModelHypers]):
 
     def _add_output(self, target_name: str, target_info: TargetInfo) -> None:
         self.outputs[target_name] = ModelOutput(
-            quantity=target_info.quantity,
             unit=target_info.unit,
             sample_kind="atom",
             description=target_info.description,

--- a/src/metatrain/scaler/tests/test_scaler.py
+++ b/src/metatrain/scaler/tests/test_scaler.py
@@ -2640,7 +2640,6 @@ def test_scaler_with_neighbor_list_additive_model():
 
     outputs = {
         "energy": ModelOutput(
-            quantity="",
             unit="",
             sample_kind="system",
         )

--- a/src/metatrain/soap_bpnn/model.py
+++ b/src/metatrain/soap_bpnn/model.py
@@ -1232,7 +1232,6 @@ class SoapBpnn(ModelInterface[ModelHypers]):
         ]
 
         self.outputs[target_name] = ModelOutput(
-            quantity=target.quantity,
             unit=target.unit,
             sample_kind="atom",
             description=target.description,

--- a/src/metatrain/soap_bpnn/tests/test_functionality.py
+++ b/src/metatrain/soap_bpnn/tests/test_functionality.py
@@ -49,7 +49,7 @@ def test_scalar_output(legacy):
     system = _make_system(model)
     output = model(
         [system],
-        {"energy": ModelOutput(quantity="energy", unit="eV", sample_kind="system")},
+        {"energy": ModelOutput(unit="eV", sample_kind="system")},
     )
     values = output["energy"].block().values
     assert values.shape == (1, 1)
@@ -163,7 +163,7 @@ def test_mlp_head(add_lambda_basis):
     system = _make_system(model)
     output = model(
         [system],
-        {"energy": ModelOutput(quantity="energy", unit="eV", sample_kind="system")},
+        {"energy": ModelOutput(unit="eV", sample_kind="system")},
     )
     values = output["energy"].block().values
     assert values.shape == (1, 1)
@@ -195,7 +195,7 @@ def test_multiple_targets(legacy, add_lambda_basis):
     model = SoapBpnn(hypers, dataset_info)
     system = _make_system(model)
     outputs = {
-        "energy": ModelOutput(quantity="energy", unit="eV", sample_kind="system"),
+        "energy": ModelOutput(unit="eV", sample_kind="system"),
         "non_conservative_stress": ModelOutput(sample_kind="system"),
     }
     result = model([system], outputs)

--- a/src/metatrain/soap_bpnn/tests/test_regression.py
+++ b/src/metatrain/soap_bpnn/tests/test_regression.py
@@ -46,7 +46,7 @@ def test_regression_init():
 
     output = model(
         systems,
-        {"mtt::U0": ModelOutput(quantity="energy", unit="", sample_kind="system")},
+        {"mtt::U0": ModelOutput(unit="", sample_kind="system")},
     )
 
     expected_output = torch.tensor(
@@ -128,7 +128,7 @@ def test_regression_train(device):
     ]
     output = model(
         systems[:5],
-        {"mtt::U0": ModelOutput(quantity="energy", unit="", sample_kind="system")},
+        {"mtt::U0": ModelOutput(unit="", sample_kind="system")},
     )
 
     expected_output = torch.tensor(
@@ -219,11 +219,7 @@ def test_regression_train_spherical(device):
     ]
     output = model(
         systems,
-        {
-            "mtt::electron_density_basis": ModelOutput(
-                quantity="", unit="", sample_kind="atom"
-            )
-        },
+        {"mtt::electron_density_basis": ModelOutput(unit="", sample_kind="atom")},
     )
 
     expected_output = torch.tensor(

--- a/src/metatrain/utils/additive/zbl.py
+++ b/src/metatrain/utils/additive/zbl.py
@@ -57,7 +57,6 @@ class ZBL(torch.nn.Module):
 
         self.outputs = {
             key: ModelOutput(
-                quantity=value.quantity,
                 unit=value.unit,
                 sample_kind="atom",
                 description=value.description,

--- a/src/metatrain/utils/data/dataset.py
+++ b/src/metatrain/utils/data/dataset.py
@@ -95,7 +95,7 @@ class DatasetInfo:
     ):
         # verify that `length_unit` and `atomic_types` are valid for metatomic
         _ = ModelCapabilities(
-            outputs={"energy": ModelOutput()},
+            outputs={"energy": ModelOutput(unit="eV")},
             length_unit=length_unit,
             atomic_types=atomic_types,
         )

--- a/src/metatrain/utils/data/target_info.py
+++ b/src/metatrain/utils/data/target_info.py
@@ -52,8 +52,8 @@ class TargetInfo:
         self._check_layout(layout)
         self.layout = layout
 
-        # verify that `quantity`, `unit` and `description` are valid for metatomic
-        _ = ModelOutput(quantity=quantity, unit=unit, description=description)
+        # verify that `unit` and `description` are valid for metatomic
+        _ = ModelOutput(unit=unit, description=description)
 
         self.quantity = quantity
         self.unit = unit

--- a/src/metatrain/utils/evaluate_model.py
+++ b/src/metatrain/utils/evaluate_model.py
@@ -269,7 +269,6 @@ def _get_model_outputs(
             length_unit="",  # this is only needed for unit conversions in MD engines
             outputs={
                 key: ModelOutput(
-                    quantity=value.quantity,
                     unit=value.unit,
                     sample_kind=value.sample_kind,
                     description=value.description,
@@ -283,7 +282,6 @@ def _get_model_outputs(
             systems,
             {
                 key: ModelOutput(
-                    quantity=value.quantity,
                     unit=value.unit,
                     sample_kind=value.sample_kind,
                     description=value.description,

--- a/src/metatrain/utils/logging.py
+++ b/src/metatrain/utils/logging.py
@@ -398,8 +398,20 @@ def setup_logging(
         formatter = logging.Formatter(format, datefmt="%Y-%m-%d %H:%M:%S", style="{")
         handlers: List[Union[logging.StreamHandler, logging.FileHandler]] = []
 
+        class HideWarnings(logging.Filter):
+            messages_to_hide = [
+                "is multi-threaded, use of fork() may lead to deadlocks in the child",
+            ]
+
+            def filter(self, record: logging.LogRecord) -> bool:
+                for message in self.messages_to_hide:
+                    if message in record.getMessage():
+                        return False
+                return True
+
         stream_handler = logging.StreamHandler(sys.stdout)
         stream_handler.setFormatter(formatter)
+        stream_handler.addFilter(HideWarnings())
         handlers.append(stream_handler)
 
         if log_file and is_main_process():

--- a/src/metatrain/utils/logging.py
+++ b/src/metatrain/utils/logging.py
@@ -409,15 +409,18 @@ def setup_logging(
                         return False
                 return True
 
+        warnings_filter = HideWarnings()
+
         stream_handler = logging.StreamHandler(sys.stdout)
         stream_handler.setFormatter(formatter)
-        stream_handler.addFilter(HideWarnings())
+        stream_handler.addFilter(warnings_filter)
         handlers.append(stream_handler)
 
         if log_file and is_main_process():
             log_file = check_file_extension(filename=log_file, extension=".log")
             file_handler = logging.FileHandler(filename=str(log_file), encoding="utf-8")
             file_handler.setFormatter(formatter)
+            file_handler.addFilter(warnings_filter)
             handlers.append(file_handler)
 
             csv_file = Path(log_file).with_suffix(".csv")

--- a/src/metatrain/utils/testing/output.py
+++ b/src/metatrain/utils/testing/output.py
@@ -645,7 +645,6 @@ class OutputTests(ArchitectureTests):
         )
 
         features_output_options = ModelOutput(
-            quantity="",
             unit="",
             sample_kind=sample_kind,
         )
@@ -730,7 +729,6 @@ class OutputTests(ArchitectureTests):
 
         # last-layer features per atom:
         ll_output_options = ModelOutput(
-            quantity="",
             unit="",
             sample_kind=sample_kind,
         )

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -22,11 +22,13 @@ from omegaconf import OmegaConf
 
 import metatrain.soap_bpnn
 from metatrain import RANDOM_SEED
-from metatrain.cli.train import _process_restart_from, train_model
+from metatrain.cli.train import _process_restart_from
+from metatrain.cli.train import train_model as raw_train_model
 from metatrain.utils.data import build_train_dataloaders, build_val_dataloaders
 from metatrain.utils.data.readers.ase import read
 from metatrain.utils.data.writers import DiskDatasetWriter
 from metatrain.utils.errors import ArchitectureError
+from metatrain.utils.logging import ROOT_LOGGER, setup_logging
 from metatrain.utils.neighbor_lists import get_system_with_neighbor_lists
 from metatrain.utils.pydantic import MetatrainValidationError
 from metatrain.utils.testing._utils import WANDB_AVAILABLE
@@ -65,6 +67,11 @@ def options_extra():
 @pytest.fixture(scope="function")
 def options_spherical():
     return OmegaConf.load(OPTIONS_SPHERICAL_PATH)
+
+
+def train_model(*args, **kwargs):
+    with setup_logging(ROOT_LOGGER, log_file=None, level=logging.INFO):
+        return raw_train_model(*args, **kwargs)
 
 
 @pytest.mark.parametrize("output", [None, "mymodel.pt"])


### PR DESCRIPTION
Before the next release, we:

- Hide the multiprocessing warnings (see change in `metatrain.utils.logging`). These just warn about a problem that has been there since forever, it's not like the new release will be less robust than the previous ones in this regard.
- Remove all uses of `ModelOutput(quantity="X")` to avoid getting metatomic's warning. These were useless anyway, so in principle it shouldn't be a problem. The only architecture that seems to use `output.quantity` is LLPR, so there I didn't change anything. But it could be that having removed it in PET will create problems. Could you see if things can be done without output.quantity @ppegolo ?
- Add `unit="eV"` to the `ModelOutput` that is initialized in `metatrain.utils.data.dataset` to avoid getting an "empty unit" warning.


<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1248.org.readthedocs.build/en/1248/

<!-- readthedocs-preview metatrain end -->