### PR TITLE
docs: note Python 3.14 incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ conda install -c conda-forge metatrain
 > ⚠️ The conda installation does not install model-specific dependencies and will only
 > work for architectures without optional dependencies such as PET.
 
+> ⚠️ Python 3.14 is currently not supported. PyTorch JIT operations used by metatrain are not compatible with Python 3.14 yet, which can cause errors when exporting models or loading checkpoints. Please use Python 3.10–3.13.
+
 After installation, you can use mtt from the command line to train your models!
 
 <!-- marker-quickstart -->


### PR DESCRIPTION
Add a note in README installation section that Python 3.14 is currently not supported due to PyTorch JIT incompatibility.

Closes #1024

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1249.org.readthedocs.build/en/1249/

<!-- readthedocs-preview metatrain end -->