### PR TITLE
docs: add conda installation instructions to architecture pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ conda install -c conda-forge metatrain
 > ⚠️ The conda installation does not install model-specific dependencies and will only
 > work for architectures without optional dependencies such as PET.
 
+> ⚠️ Python 3.14 is currently not supported. PyTorch JIT operations used by metatrain are not compatible with Python 3.14 yet, which can cause errors when exporting models or loading checkpoints. Please use Python 3.10–3.13.
+
 After installation, you can use mtt from the command line to train your models!
 
 <!-- marker-quickstart -->

--- a/docs/src/architectures/templates/installation.rst
+++ b/docs/src/architectures/templates/installation.rst
@@ -11,3 +11,13 @@ To install this architecture along with the ``metatrain`` package, run:
 
 where the square brackets indicate that you want to install the optional
 dependencies required for ``{{architecture}}``.
+
+Alternatively, you can install via conda-forge:
+
+.. code-block:: bash
+
+    conda install -c conda-forge metatrain
+
+For architectures with optional dependencies, you may need to install those
+dependencies separately with pip, or use conda packages if they are available
+on conda-forge. See the `installation` page for more details.

--- a/src/metatrain/llpr/documentation.py
+++ b/src/metatrain/llpr/documentation.py
@@ -25,6 +25,16 @@ architecture can also output the following additional quantity:
   target, computed with the LLPR approach.
 - :ref:`mtt-aux-target-ensemble`: The ensemble predictions for a given target, computed
   with the LLPR approach.
+
+{{SECTION_INSTALLATION}}
+
+{{SECTION_DEFAULT_HYPERS}}
+
+{{SECTION_MODEL_HYPERS}}
+
+{{SECTION_TRAINER_HYPERS}}
+
+{{SECTION_REFERENCES}}
 """
 
 from typing import Literal, Optional


### PR DESCRIPTION
Addresses issue #901. Adds conda installation instructions to the architecture installation template, providing clarity for conda users.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1250.org.readthedocs.build/en/1250/

<!-- readthedocs-preview metatrain end -->