### PR TITLE
docs: improve architecture documentation rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ conda install -c conda-forge metatrain
 > ⚠️ The conda installation does not install model-specific dependencies and will only
 > work for architectures without optional dependencies such as PET.
 
+> ⚠️ Python 3.14 is currently not supported. PyTorch JIT operations used by metatrain are not compatible with Python 3.14 yet, which can cause errors when exporting models or loading checkpoints. Please use Python 3.10–3.13.
+
 After installation, you can use mtt from the command line to train your models!
 
 <!-- marker-quickstart -->

--- a/docs/src/architectures/templates/installation.rst
+++ b/docs/src/architectures/templates/installation.rst
@@ -11,3 +11,13 @@ To install this architecture along with the ``metatrain`` package, run:
 
 where the square brackets indicate that you want to install the optional
 dependencies required for ``{{architecture}}``.
+
+Alternatively, you can install via conda-forge:
+
+.. code-block:: bash
+
+    conda install -c conda-forge metatrain
+
+For architectures with optional dependencies, you may need to install those
+dependencies separately with pip, or use conda packages if they are available
+on conda-forge. See the `installation` page for more details.

--- a/src/metatrain/experimental/flashmd/documentation.py
+++ b/src/metatrain/experimental/flashmd/documentation.py
@@ -23,6 +23,10 @@ Additional outputs
 
 {{SECTION_DEFAULT_HYPERS}}
 
+{{SECTION_MODEL_HYPERS}}
+
+{{SECTION_TRAINER_HYPERS}}
+
 Tuning hyperparameters
 ----------------------
 
@@ -43,6 +47,8 @@ might have different default values.
 
         .. autoattribute:: {{trainer_hypers_path}}.masses
             :no-index:
+
+{{SECTION_REFERENCES}}
 """
 
 from typing import Literal, Optional

--- a/src/metatrain/experimental/flashmd_symplectic/documentation.py
+++ b/src/metatrain/experimental/flashmd_symplectic/documentation.py
@@ -7,6 +7,12 @@ The symplectic variant of :ref:`FlashMD <arch-flashmd>`.
 {{SECTION_INSTALLATION}}
 
 {{SECTION_DEFAULT_HYPERS}}
+
+{{SECTION_MODEL_HYPERS}}
+
+{{SECTION_TRAINER_HYPERS}}
+
+{{SECTION_REFERENCES}}
 """
 
 from typing import Literal, Optional

--- a/src/metatrain/llpr/documentation.py
+++ b/src/metatrain/llpr/documentation.py
@@ -25,6 +25,16 @@ architecture can also output the following additional quantity:
   target, computed with the LLPR approach.
 - :ref:`mtt-aux-target-ensemble`: The ensemble predictions for a given target, computed
   with the LLPR approach.
+
+{{SECTION_INSTALLATION}}
+
+{{SECTION_DEFAULT_HYPERS}}
+
+{{SECTION_MODEL_HYPERS}}
+
+{{SECTION_TRAINER_HYPERS}}
+
+{{SECTION_REFERENCES}}
 """
 
 from typing import Literal, Optional

--- a/src/metatrain/pet/documentation.py
+++ b/src/metatrain/pet/documentation.py
@@ -97,6 +97,10 @@ from ``atoms.info``:
 
 {{SECTION_DEFAULT_HYPERS}}
 
+{{SECTION_MODEL_HYPERS}}
+
+{{SECTION_TRAINER_HYPERS}}
+
 Tuning hyperparameters
 ----------------------
 
@@ -138,6 +142,8 @@ important** (in decreasing order of importance):
 
   .. autoattribute:: {{model_hypers_path}}.long_range
       :no-index:
+
+{{SECTION_REFERENCES}}
 """
 
 from typing import Literal, Optional

--- a/src/metatrain/scaler/documentation.py
+++ b/src/metatrain/scaler/documentation.py
@@ -7,6 +7,16 @@ It is meant to be used as a preprocessing step for other architectures, so that 
 are standardized before being fed to the main model.
 
 See :ref:`scale-targets` for more details.
+
+{{SECTION_INSTALLATION}}
+
+{{SECTION_DEFAULT_HYPERS}}
+
+{{SECTION_MODEL_HYPERS}}
+
+{{SECTION_TRAINER_HYPERS}}
+
+{{SECTION_REFERENCES}}
 """
 
 from typing import Dict, Optional, Union


### PR DESCRIPTION
Improve rendering of architecture documentation by adding section placeholders for PET, Scaler, FlashMD and Symplectic FlashMD.

This addresses issue #781 to extend the rendering improvements previously made for SOAP-BPNN and LLPR to other architectures. Adds SECTION_MODEL_HYPERS, SECTION_TRAINER_HYPERS, SECTION_INSTALLATION, SECTION_DEFAULT_HYPERS and SECTION_REFERENCES placeholders to ensure consistent hyperparameter documentation generation.

Related issue: #781

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1251.org.readthedocs.build/en/1251/

<!-- readthedocs-preview metatrain end -->