### PR TITLE
docs: fix typos in PET documentation

### DIFF
--- a/src/metatrain/pet/documentation.py
+++ b/src/metatrain/pet/documentation.py
@@ -4,10 +4,10 @@ PET
 
 PET is a cleaner, more user-friendly reimplementation of the original
 PET model :footcite:p:`pozdnyakov_smooth_2023`. It is designed for better
-modularity and maintainability, while preseving compatibility with the original
+modularity and maintainability, while preserving compatibility with the original
 PET implementation in ``metatrain``. It also adds new features like long-range
 features, better fine-tuning implementation, a possibility to train on
-arbitrarty targets, and a faster inference due to the ``fast attention``.
+arbitrary targets, and a faster inference due to the ``fast attention``.
 
 {{SECTION_INSTALLATION}}
 


### PR DESCRIPTION
Fix typos in PET architecture documentation:

- 'preseving' -> 'preserving'
- 'arbitrarty' -> 'arbitrary'

This improves readability of the PET documentation page.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1253.org.readthedocs.build/en/1253/

<!-- readthedocs-preview metatrain end -->