### PR TITLE
utils/io: suggest upgrade when trainer checkpoint version is too new

### DIFF
--- a/src/metatrain/utils/io.py
+++ b/src/metatrain/utils/io.py
@@ -295,7 +295,18 @@ def trainer_from_checkpoint(
         trainer_ckpt_version = 1
         checkpoint["trainer_ckpt_version"] = trainer_ckpt_version
 
-    if trainer_ckpt_version != architecture.__trainer__.__checkpoint_version__:
+    current_trainer_version = architecture.__trainer__.__checkpoint_version__
+    if trainer_ckpt_version > current_trainer_version:
+        raise RuntimeError(
+            f"Unable to load the trainer checkpoint for the '{architecture_name}' "
+            f"architecture: the checkpoint uses checkpoint format version "
+            f"{trainer_ckpt_version}, but the installed '{architecture_name}' "
+            f"architecture only supports up to version "
+            f"{current_trainer_version}. You are using "
+            f"metatrain version {__version__}, which is too old to read this "
+            "checkpoint. Please upgrade metatrain to a newer version."
+        )
+    elif trainer_ckpt_version != current_trainer_version:
         try:
             if ckpt_before_versioning:
                 warnings.warn(
@@ -310,7 +321,7 @@ def trainer_from_checkpoint(
                 f"Unable to load the trainer checkpoint for "
                 f"the '{architecture_name}' architecture: the checkpoint is using "
                 f"version {trainer_ckpt_version}, while the current version is "
-                f"{architecture.__trainer__.__checkpoint_version__}; and trying to "
+                f"{current_trainer_version}; and trying to "
                 "upgrade the checkpoint failed."
             ) from e
 

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -125,9 +125,12 @@ def test_load_model_checkpoint_older_version_upgrade_fails(
         model_from_checkpoint(checkpoint, context="restart")
 
 
-def test_load_trainer_checkpoint_wrong_version(
+def test_load_trainer_checkpoint_newer_version(
     monkeypatch, tmp_path, MODEL_PATH_64_BIT
 ):
+    """A checkpoint version newer than the installed architecture should tell the
+    user to upgrade metatrain, instead of trying (and failing) to upgrade the
+    checkpoint."""
     monkeypatch.chdir(tmp_path)
     path = MODEL_PATH_64_BIT.with_suffix(".ckpt")
     model = torch.load(path, weights_only=False, map_location="cpu")
@@ -138,8 +141,10 @@ def test_load_trainer_checkpoint_wrong_version(
 
     message = (
         "Unable to load the trainer checkpoint for the 'soap_bpnn' architecture: the "
-        r"checkpoint is using version 5000000, while the current version is \d+; "
-        "and trying to upgrade the checkpoint failed."
+        r"checkpoint uses checkpoint format version 5000000, but the installed "
+        r"'soap_bpnn' architecture only supports up to version \d+\. You are using "
+        r"metatrain version .*, which is too old to read this checkpoint\. Please "
+        "upgrade metatrain to a newer version."
     )
 
     with pytest.raises(RuntimeError, match=message):


### PR DESCRIPTION
Fix issue #857: when loading a trainer checkpoint with a newer checkpoint version than the installed metatrain, the error message now suggests upgrading metatrain, similar to the model loading path.

This improves error messages for users encountering version mismatches.

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1254.org.readthedocs.build/en/1254/

<!-- readthedocs-preview metatrain end -->