### PR TITLE
docs: add conda installation reference to architecture pages

### DIFF
--- a/docs/src/architectures/templates/installation.rst
+++ b/docs/src/architectures/templates/installation.rst
@@ -11,3 +11,6 @@ To install this architecture along with the ``metatrain`` package, run:
 
 where the square brackets indicate that you want to install the optional
 dependencies required for ``{{architecture}}``.
+
+For conda installation instructions, see the :ref:`label_installation` page. Note
+that conda may not provide all optional architecture-specific dependencies.


### PR DESCRIPTION
Add a note to architecture installation sections pointing users to the main installation page for conda instructions, with a note about optional dependencies.

Closes #901

<!-- readthedocs-preview metatrain start -->
----
📚 Documentation preview 📚: https://metatrain--1261.org.readthedocs.build/en/1261/

<!-- readthedocs-preview metatrain end -->